### PR TITLE
[#32] Update `cleveland`, run network tests on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,12 @@
 # SPDX-FileCopyrightText: 2020 TQ Tezos
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
+env:
+  TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER: "Y"
+  # this key is defined in local-chain bootstrap accounts list in
+  # https://github.com/serokell/serokell-profiles/blob/master/profiles/servers/jupiter/default.nix
+  TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk3nAQ3uCP7vc2ccLhhWNNncgFfWQ5HgTyPawepQ8DURRRfzVQzB"
+
 steps:
   - label: hlint
     commands:
@@ -37,7 +43,10 @@ steps:
   - label: test
     commands:
     - nix-build ci.nix -A packages.baseDAO.tests.baseDAO-test
-    - ./result/bin/baseDAO-test
+    # Emulator + local chain for Delphi protocol
+    - nix run -f ci.nix tezos-client -c
+      ./result/bin/baseDAO-test --nettest-run-network
+      -A localhost -P 8734
 
   - label: weeder
     commands:

--- a/ci.nix
+++ b/ci.nix
@@ -14,6 +14,7 @@ rec {
   };
   pkgs = import sources.nixpkgs haskell-nix.nixpkgsArgs;
   weeder-hacks = import sources.haskell-nix-weeder { inherit pkgs; };
+  tezos-client = (import "${sources.tezos-packaging}/nix/build/pkgs.nix" {}).ocamlPackages.tezos-client;
 
   # all local packages and their subdirectories
   # we need to know subdirectories to make weeder stuff work

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "f4f3611ed3ff56ae3acdf3cec60945146daf6779",
-        "sha256": "0r55wxda7ndgsis4r74wh79hx195jzc76cc9dq59jk258zcgaji3",
+        "rev": "60138d26f772a66e4851abac6f4933522716a51c",
+        "sha256": "088vfv0yjfhis17x1p1w4nws55m15xs7xxik8ls4sk9ixircyspp",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/f4f3611ed3ff56ae3acdf3cec60945146daf6779.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/60138d26f772a66e4851abac6f4933522716a51c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-nix-weeder": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -59,6 +59,18 @@
         "url": "https://github.com/input-output-hk/stackage.nix/archive/ea1b7a50d8b401fcc4479c296f1058388e139208.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "tezos-packaging": {
+        "branch": "v7.4-1",
+        "description": "Various form of distribution for tezos-related executables",
+        "homepage": "",
+        "owner": "serokell",
+        "repo": "tezos-packaging",
+        "rev": "e583224fcc5dea18a58cba3acb56f8ee5d8067e5",
+        "sha256": "0z74wggzw3p9dcxlyivymnfq4z19d5dmpxxd5zchvqhr3mfsnxsh",
+        "type": "tarball",
+        "url": "https://github.com/serokell/tezos-packaging/archive/e583224fcc5dea18a58cba3acb56f8ee5d8067e5.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "xrefcheck": {
         "branch": "v0.1.2",
         "description": "Check cross-references in repository documents",

--- a/package.yaml
+++ b/package.yaml
@@ -124,6 +124,5 @@ tests:
     - morley
     - morley-ledgers
     - tasty
-    - tasty-hunit-compat
     - universum
     - containers

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,9 +7,9 @@ packages:
   - .
 
 extra-deps:
-  - morley-1.7.1
-  - lorentz-0.6.2
-  - indigo-0.3.0
+  - morley-1.8.1
+  - lorentz-0.7.0
+  - indigo-0.3.1
   - base58-bytestring-0.1.0
   - hex-text-0.1.0.0
   - show-type-0.1.1
@@ -21,13 +21,13 @@ extra-deps:
   - git:
       https://gitlab.com/morley-framework/morley.git # CI can't use SSH
     commit:
-      17f54b2ef528e201bffca22073055525f4b3de56 # master
+      3984b81a72a639c25dc86cf5d18cc699b1aafc3f # master
     subdirs:
       - code/cleveland
       - code/morley-client
   - git: https://github.com/int-index/caps.git
     commit: c5d61837eb358989b581ed82b1e79158c4823b1b
   - git: https://gitlab.com/morley-framework/morley-ledgers.git
-    commit: ee1fdc1c4880e265ad5509be2d57376662e93918 # master
+    commit: 552774ec4fe8a9da6afc77bbae31c30483402b9a # master
     subdirs:
       - code/morley-ledgers

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,26 +5,26 @@
 
 packages:
 - completed:
-    hackage: morley-1.7.1@sha256:5f859ee96730ba4bfe5405014f4491a05b20ffd0800a24d538d1af63f335990a,7686
+    hackage: morley-1.8.1@sha256:5ca14c1ecfcb37a71a27e123d4ef5aa87db9f74b73df8089c4f4b3c5dd9e82b6,7700
     pantry-tree:
-      size: 8656
-      sha256: 6e4c186eb5ccad81c7d3e295b79adf066c7dfe658b6d5a7f865d0d432856fe4e
+      size: 8807
+      sha256: 4980abc47c80ce2fab9dfcf292d812c8a3494a116cb11325d674d2a3f30af6ba
   original:
-    hackage: morley-1.7.1
+    hackage: morley-1.8.1
 - completed:
-    hackage: lorentz-0.6.2@sha256:ec5b0862eef3f6a17384dd4f0abc4d0df0371bd4a8dd50f979b819e27a0fce33,4101
+    hackage: lorentz-0.7.0@sha256:fcabab37a65d7a2f1c76cf63ddd3e5f894640f99e368c937b5227f54f6fc0115,3609
     pantry-tree:
-      size: 4028
-      sha256: 6d15e31bfdd3f652103b434290f446a70ed4f1b451199c16f34597f5c3b3dbfa
+      size: 2957
+      sha256: d08d1e203b14cba93abed4c5b5a09882bbcff8337543a1c9404a97cd1204fadd
   original:
-    hackage: lorentz-0.6.2
+    hackage: lorentz-0.7.0
 - completed:
-    hackage: indigo-0.3.0@sha256:266aaecbc3a93cce7a9ea9c88fe7ccdfd5e5d4d5414d8126b1c27017e4cebca7,6564
+    hackage: indigo-0.3.1@sha256:e090fdba2749591a2f3e0037659a581267a33e9ed4372fa5d90484061b6fdcc8,6564
     pantry-tree:
       size: 3622
-      sha256: 5b70db853780eff2f7ad196f77af85323a96cdb2b645ef9d4d5902914d488774
+      sha256: 15b4d6f0f3f9686a4fd4d80258d70f2d5ee4bfc3d1d4b677d08d518ae6373a2f
   original:
-    hackage: indigo-0.3.0
+    hackage: indigo-0.3.1
 - completed:
     hackage: base58-bytestring-0.1.0@sha256:a1da72ee89d5450bac1c792d9fcbe95ed7154ab7246f2172b57bd4fd9b5eab79,1913
     pantry-tree:
@@ -87,26 +87,26 @@ packages:
     version: 0.1.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 10876
-      sha256: 1c06ae7f70d9270e791086b34148845786cf86a84610a24d69581144645105ee
-    commit: 17f54b2ef528e201bffca22073055525f4b3de56
+      size: 10456
+      sha256: 8698de58e0a7ecd4f561b88f959bb5f41350c7dfd6cece70756fb162404a9988
+    commit: 3984b81a72a639c25dc86cf5d18cc699b1aafc3f
   original:
     subdir: code/cleveland
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 17f54b2ef528e201bffca22073055525f4b3de56
+    commit: 3984b81a72a639c25dc86cf5d18cc699b1aafc3f
 - completed:
     subdir: code/morley-client
     name: morley-client
     version: 0.1.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 2817
-      sha256: 7c21cb61e91c527b1286f9a601c800ebd81b425195a4b58b03ca967d0f1203fd
-    commit: 17f54b2ef528e201bffca22073055525f4b3de56
+      size: 2818
+      sha256: 8cb4fbe3f480be8256b0631485f19b3d9733987329f0294868dfbcf3e42bcc30
+    commit: 3984b81a72a639c25dc86cf5d18cc699b1aafc3f
   original:
     subdir: code/morley-client
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 17f54b2ef528e201bffca22073055525f4b3de56
+    commit: 3984b81a72a639c25dc86cf5d18cc699b1aafc3f
 - completed:
     name: caps
     version: '0'
@@ -125,12 +125,12 @@ packages:
     git: https://gitlab.com/morley-framework/morley-ledgers.git
     pantry-tree:
       size: 1422
-      sha256: 5df26d135409e4eb69361a4e1d9e67a62966c613b045d3eea8ca11f563fce341
-    commit: ee1fdc1c4880e265ad5509be2d57376662e93918
+      sha256: 4055db68b10b2f8c0fd2332f38ace6bc0c0dd1f84513f2a523acc3388b052d4f
+    commit: 552774ec4fe8a9da6afc77bbae31c30483402b9a
   original:
     subdir: code/morley-ledgers
     git: https://gitlab.com/morley-framework/morley-ledgers.git
-    commit: ee1fdc1c4880e265ad5509be2d57376662e93918
+    commit: 552774ec4fe8a9da6afc77bbae31c30483402b9a
 snapshots:
 - completed:
     size: 531707

--- a/test/Test/BaseDAO/FA2.hs
+++ b/test/Test/BaseDAO/FA2.hs
@@ -10,12 +10,12 @@ import Universum
 import Lorentz
 import Lorentz.Test
 import Morley.Nettest
+import Morley.Nettest.Tasty (nettestScenario)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase)
 import Util.Named
 
-import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import qualified Lorentz.Contracts.BaseDAO.Types as DAO
+import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Test.BaseDAO.Management (expectMigrated)
 import Test.Common
 
@@ -24,52 +24,52 @@ import Test.Common
 test_BaseDAO_FA2 :: TestTree
 test_BaseDAO_FA2 = testGroup "BaseDAO FA2 tests:"
   [ testGroup "Operator:"
-      [ testCase "allows zero transfer from non-existent operator" $
-          nettestTestExpectation zeroTransferScenario
-      , testCase "allows valid transfer and check balance" $
-          nettestTestExpectation validTransferScenario
-      , testCase "validates token id" $
-          nettestTestExpectation validateTokenScenario
-      , testCase "accepts an empty list of transfers" $
-          nettestTestExpectation emptyTransferListScenario
-      , testCase "aborts if there is a failure (due to low balance)" $
-          nettestTestExpectation lowBalanceScenario
-      , testCase "aborts if there is a failure (due to non existent source account)" $
-          nettestTestExpectation noSourceAccountScenario
-      , testCase "aborts if there is a failure (due to bad operator)" $
-          nettestTestExpectation badOperatorScenario
-      , testCase "cannot transfer foreign money" $
-          nettestTestExpectation noForeignMoneyScenario
+      [ nettestScenario "allows zero transfer from non-existent operator"
+          zeroTransferScenario
+      , nettestScenario "allows valid transfer and check balance"
+          validTransferScenario
+      , nettestScenario "validates token id"
+          validateTokenScenario
+      , nettestScenario "accepts an empty list of transfers"
+          emptyTransferListScenario
+      , nettestScenario "aborts if there is a failure (due to low balance)"
+          lowBalanceScenario
+      , nettestScenario "aborts if there is a failure (due to non existent source account)"
+          noSourceAccountScenario
+      , nettestScenario "aborts if there is a failure (due to bad operator)"
+          badOperatorScenario
+      , nettestScenario "cannot transfer foreign money"
+          noForeignMoneyScenario
       ]
   , testGroup "Owner:"
-      [ testCase "allows valid transfer and check balance" $
-          nettestTestExpectation validTransferOwnerScenario
-      , testCase "allows updating operator " $
-          nettestTestExpectation updatingOperatorScenario
-      , testCase "allows balanceOf request" $
-          nettestTestExpectation balanceOfOwnerScenario
-      , testCase "validates token id" $
-          nettestTestExpectation validateTokenOwnerScenario
-      , testCase "aborts if there is a failure (due to low balance)" $
-          nettestTestExpectation lowBalanceOwnerScenario
-      , testCase "cannot transfer foreign money" $
-          nettestTestExpectation noForeignMoneyOwnerScenario
+      [ nettestScenario "allows valid transfer and check balance"
+          validTransferOwnerScenario
+      , nettestScenario "allows updating operator "
+          updatingOperatorScenario
+      , nettestScenario "allows balanceOf request"
+          balanceOfOwnerScenario
+      , nettestScenario "validates token id"
+          validateTokenOwnerScenario
+      , nettestScenario "aborts if there is a failure (due to low balance)"
+          lowBalanceOwnerScenario
+      , nettestScenario "cannot transfer foreign money"
+          noForeignMoneyOwnerScenario
       ]
   , testGroup "Admin:"
-    [ testCase "transfer tokens from any address to any address" $
-        nettestTestExpectation adminTransferScenario
-    , testCase "transfer frozen tokens" $
-        nettestTestExpectation adminTransferFrozenScenario
+    [ nettestScenario "transfer tokens from any address to any address"
+        adminTransferScenario
+    , nettestScenario "transfer frozen tokens"
+        adminTransferFrozenScenario
     ]
   , testGroup "Entrypoints respect migration status"
-      [ testCase "transfer respects migration status" $
-          nettestTestExpectation transferAfterMigrationScenario
-      , testCase "update operator respects migration status " $
-          nettestTestExpectation updatingOperatorAfterMigrationScenario
-      , testCase "balanceOf request respects migration status" $
-          nettestTestExpectation balanceOfRequestAfterMigrationScenario
-      , testCase "tokenMetadataRegistry request respects migration status" $
-          nettestTestExpectation tokenMetadataRegistryRequestAfterMigrationScenario
+      [ nettestScenario "transfer respects migration status"
+          transferAfterMigrationScenario
+      , nettestScenario "update operator respects migration status "
+          updatingOperatorAfterMigrationScenario
+      , nettestScenario "balanceOf request respects migration status"
+          balanceOfRequestAfterMigrationScenario
+      , nettestScenario "tokenMetadataRegistry request respects migration status"
+          tokenMetadataRegistryRequestAfterMigrationScenario
       ]
   ]
 

--- a/test/Test/BaseDAO/Management.hs
+++ b/test/Test/BaseDAO/Management.hs
@@ -13,12 +13,12 @@ module Test.BaseDAO.Management
 import Universum
 
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase)
 
 import Lorentz
 import Lorentz.Contracts.BaseDAO (mkStorage)
-import Morley.Nettest
 import Michelson.Untyped.Entrypoints (unsafeBuildEpName)
+import Morley.Nettest
+import Morley.Nettest.Tasty (nettestScenarioCaps)
 import Test.Common
 import Tezos.Core (unsafeMkMutez)
 import Util.Named
@@ -26,190 +26,171 @@ import Util.Named
 -- | We test non-token entrypoints of the BaseDAO contract here
 test_BaseDAO_Management :: [TestTree]
 test_BaseDAO_Management =
-  [ testCase "Contract forbids XTZ transfer" $
-      nettestTestExpectation $ uncapsNettest $ do
-        withOriginated 2 (\(owner:_) -> initialStorage owner) $ \[_, wallet1] baseDao ->
-          transfer TransferData
-            { tdFrom = AddressResolved wallet1
-            , tdTo = AddressResolved $ unTAddress baseDao
-            , tdAmount = unsafeMkMutez 1
-            , tdEntrypoint = unsafeBuildEpName "transfer_ownership"
-            , tdParameter = (#newOwner .! wallet1)
-            }
-          & expectForbiddenXTZ
+  [ nettestScenarioCaps "Contract forbids XTZ transfer" $
+      withOriginated 2 (\(owner:_) -> initialStorage owner) $ \[_, wallet1] baseDao ->
+        transfer TransferData
+          { tdFrom = AddressResolved wallet1
+          , tdTo = AddressResolved $ unTAddress baseDao
+          , tdAmount = unsafeMkMutez 1
+          , tdEntrypoint = unsafeBuildEpName "transfer_ownership"
+          , tdParameter = (#newOwner .! wallet1)
+          }
+        & expectForbiddenXTZ
 
   , testGroup "Ownership transfer"
-    [ testCase "transfer ownership entrypoint authenticates sender" $
-        nettestTestExpectation $ uncapsNettest $ do
-          withOriginated 2 (\(owner:_) -> initialStorage owner) $ \[_, wallet1] baseDao ->
-            callFrom (AddressResolved wallet1) baseDao (Call @"Transfer_ownership") (#newOwner .! wallet1)
-              & expectNotAdmin
+    [ nettestScenarioCaps "transfer ownership entrypoint authenticates sender" $
+        withOriginated 2 (\(owner:_) -> initialStorage owner) $ \[_, wallet1] baseDao ->
+          callFrom (AddressResolved wallet1) baseDao (Call @"Transfer_ownership") (#newOwner .! wallet1)
+            & expectNotAdmin
 
-    , testCase "sets pending owner" $
-        nettestTestExpectation $ uncapsNettest $ do
-          withOriginated 2 (\(owner:_) -> initialStorage owner) $
-            \[owner, wallet1] baseDao -> do
-                callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                  (#newOwner .! wallet1)
-                callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
-
-    , testCase "does not set administrator" $
-        nettestTestExpectation $ uncapsNettest $ do
-          withOriginated 2 (\(owner:_) -> initialStorage owner) $
-            \[owner, wallet1] baseDao -> do
+    , nettestScenarioCaps "sets pending owner" $
+        withOriginated 2 (\(owner:_) -> initialStorage owner) $
+          \[owner, wallet1] baseDao -> do
               callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
                 (#newOwner .! wallet1)
-              -- Make the call once again to make sure the admin still retains admin
-              -- privileges
-              callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                (#newOwner .! wallet1)
+              callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
 
-    , testCase "rewrite existing pending owner" $
-        nettestTestExpectation $ uncapsNettest $ do
+    , nettestScenarioCaps "does not set administrator" $
+        withOriginated 2 (\(owner:_) -> initialStorage owner) $
+          \[owner, wallet1] baseDao -> do
+            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+              (#newOwner .! wallet1)
+            -- Make the call once again to make sure the admin still retains admin
+            -- privileges
+            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+              (#newOwner .! wallet1)
+
+    , nettestScenarioCaps "rewrite existing pending owner" $
+        withOriginated 3 (\(owner:_) -> initialStorage owner) $
+          \[owner, wallet1, wallet2] baseDao -> do
+            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+              (#newOwner .! wallet1)
+            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+              (#newOwner .! wallet2)
+            -- Make the accept ownership call from wallet1 and see that it fails
+            callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+              & expectNotPendingOwner
+            -- Make the accept ownership call from wallet1 and see that it works
+            callFrom (AddressResolved wallet2) baseDao (Call @"Accept_ownership") ()
+
+    , nettestScenarioCaps "invalidates pending owner if new owner is current admin" $
+        withOriginated 2 (\(owner:_) -> initialStorage owner) $
+          \[owner, wallet1] baseDao -> do
+            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+              (#newOwner .! wallet1)
+            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+              (#newOwner .! owner)
+            -- Make the accept ownership call from wallet1 and see that it fails
+            -- with 'no pending owner set' error
+            callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+              & expectNoPendingOwnerSet
+
+      , nettestScenarioCaps "Respects migration state" $
+          withOriginated 3 (\(owner:_) -> initialStorage owner) $
+            \[owner, newAddress1, newOwner] baseDao -> do
+              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+              -- We test this by calling `confirmMigration` and seeing that it does not fail
+              callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+              callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+                (#newOwner .! newOwner)
+                & expectMigrated newAddress1
+    ]
+  , testGroup "Accept Ownership"
+      [ nettestScenarioCaps "authenticates the sender" $
           withOriginated 3 (\(owner:_) -> initialStorage owner) $
             \[owner, wallet1, wallet2] baseDao -> do
               callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
                 (#newOwner .! wallet1)
-              callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                (#newOwner .! wallet2)
-              -- Make the accept ownership call from wallet1 and see that it fails
-              callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
-                & expectNotPendingOwner
-              -- Make the accept ownership call from wallet1 and see that it works
               callFrom (AddressResolved wallet2) baseDao (Call @"Accept_ownership") ()
+                & expectNotPendingOwner
 
-    , testCase "invalidates pending owner if new owner is current admin" $
-        nettestTestExpectation $ uncapsNettest $ do
-          withOriginated 2 (\(owner:_) -> initialStorage owner) $
-            \[owner, wallet1] baseDao -> do
-              callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                (#newOwner .! wallet1)
-              callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                (#newOwner .! owner)
-              -- Make the accept ownership call from wallet1 and see that it fails
-              -- with 'no pending owner set' error
-              callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+       , nettestScenarioCaps "changes the administrator to pending owner and resets pending owner" $
+           withOriginated 2 (\(owner:_) -> initialStorage owner) $
+             \[owner, wallet1] baseDao -> do
+               callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+                 (#newOwner .! wallet1)
+               callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+               -- Make a second call and see that it fails with 'no pending owner set' error
+               callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
                 & expectNoPendingOwnerSet
 
-      , testCase "Respects migration state" $
-          nettestTestExpectation $ uncapsNettest $ do
-            withOriginated 3 (\(owner:_) -> initialStorage owner) $
-              \[owner, newAddress1, newOwner] baseDao -> do
-                callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                -- We test this by calling `confirmMigration` and seeing that it does not fail
-                callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
-                callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                  (#newOwner .! newOwner)
-                  & expectMigrated newAddress1
-    ]
-  , testGroup "Accept Ownership"
-      [ testCase "authenticates the sender" $
-          nettestTestExpectation $ uncapsNettest $ do
-            withOriginated 3 (\(owner:_) -> initialStorage owner) $
-              \[owner, wallet1, wallet2] baseDao -> do
-                callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                  (#newOwner .! wallet1)
-                callFrom (AddressResolved wallet2) baseDao (Call @"Accept_ownership") ()
-                  & expectNotPendingOwner
+       , nettestScenarioCaps "throws error when there is no pending owner" $
+           withOriginated 2 (\(owner:_) -> initialStorage owner) $
+             \[_, wallet1] baseDao -> do
+               callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+                & expectNoPendingOwnerSet
 
-       , testCase "changes the administrator to pending owner and resets pending owner" $
-           nettestTestExpectation $ uncapsNettest $ do
-             withOriginated 2 (\(owner:_) -> initialStorage owner) $
-               \[owner, wallet1] baseDao -> do
-                 callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                   (#newOwner .! wallet1)
-                 callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
-                 -- Make a second call and see that it fails with 'no pending owner set' error
-                 callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
-                  & expectNoPendingOwnerSet
+       , nettestScenarioCaps "throws error when called by current admin, when pending owner is not the same" $
+           withOriginated 2 (\(owner:_) -> initialStorage owner) $
+             \[owner, wallet1] baseDao -> do
+               callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+                 (#newOwner .! wallet1)
+               callFrom (AddressResolved owner) baseDao (Call @"Accept_ownership") ()
+                & expectNotPendingOwner
 
-       , testCase "throws error when there is no pending owner" $
-           nettestTestExpectation $ uncapsNettest $ do
-             withOriginated 2 (\(owner:_) -> initialStorage owner) $
-               \[_, wallet1] baseDao -> do
-                 callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
-                  & expectNoPendingOwnerSet
-
-       , testCase "throws error when called by current admin, when pending owner is not the same" $
-           nettestTestExpectation $ uncapsNettest $ do
-             withOriginated 2 (\(owner:_) -> initialStorage owner) $
-               \[owner, wallet1] baseDao -> do
-                 callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                   (#newOwner .! wallet1)
-                 callFrom (AddressResolved owner) baseDao (Call @"Accept_ownership") ()
-                  & expectNotPendingOwner
-
-      , testCase "Respects migration state" $
-          nettestTestExpectation $ uncapsNettest $ do
-            withOriginated 2 (\(owner:_) -> initialStorage owner) $
-              \[owner, newAddress1] baseDao -> do
-                callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                -- We test this by calling `confirmMigration` and seeing that it does not fail
-                callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
-                callFrom (AddressResolved owner) baseDao (Call @"Accept_ownership") ()
-                  & expectMigrated newAddress1
+      , nettestScenarioCaps "Respects migration state" $
+          withOriginated 2 (\(owner:_) -> initialStorage owner) $
+            \[owner, newAddress1] baseDao -> do
+              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+              -- We test this by calling `confirmMigration` and seeing that it does not fail
+              callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+              callFrom (AddressResolved owner) baseDao (Call @"Accept_ownership") ()
+                & expectMigrated newAddress1
       ]
 
   , testGroup "Migration"
-      [ testCase "authenticates the sender" $
-          nettestTestExpectation $ uncapsNettest $ do
-            withOriginated 3 (\(owner:_) -> initialStorage owner) $
-              \[_, newAddress1, randomAddress] baseDao -> do
-                callFrom (AddressResolved randomAddress) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                  & expectNotAdmin
+      [ nettestScenarioCaps "authenticates the sender" $
+          withOriginated 3 (\(owner:_) -> initialStorage owner) $
+            \[_, newAddress1, randomAddress] baseDao -> do
+              callFrom (AddressResolved randomAddress) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+                & expectNotAdmin
 
-      , testCase "successfully sets the pending migration address " $
-          nettestTestExpectation $ uncapsNettest $ do
-            withOriginated 2 (\(owner:_) -> initialStorage owner) $
-              \[owner, newAddress1] baseDao -> do
-                callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                -- We test this by calling `confirmMigration` and seeing that it does not fail
-                callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+      , nettestScenarioCaps "successfully sets the pending migration address " $
+          withOriginated 2 (\(owner:_) -> initialStorage owner) $
+            \[owner, newAddress1] baseDao -> do
+              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+              -- We test this by calling `confirmMigration` and seeing that it does not fail
+              callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
 
-      , testCase "overwrites previous migration target" $
-          nettestTestExpectation $ uncapsNettest $ do
-            withOriginated 3 (\(owner:_) -> initialStorage owner) $
-              \[owner, newAddress1, newAddress2] baseDao -> do
-                callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress2)
-                -- We test this by calling `confirmMigration` and seeing that it does not fail
-                callFrom (AddressResolved newAddress2) baseDao (Call @"Confirm_migration") ()
+      , nettestScenarioCaps "overwrites previous migration target" $
+          withOriginated 3 (\(owner:_) -> initialStorage owner) $
+            \[owner, newAddress1, newAddress2] baseDao -> do
+              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress2)
+              -- We test this by calling `confirmMigration` and seeing that it does not fail
+              callFrom (AddressResolved newAddress2) baseDao (Call @"Confirm_migration") ()
 
-      , testCase "allows calls until confirm migration is called" $
-          nettestTestExpectation $ uncapsNettest $ do
-            withOriginated 3 (\(owner:_) -> initialStorage owner) $
-              \[owner, newAddress1, newAddress2] baseDao -> do
-                callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress2)
+      , nettestScenarioCaps "allows calls until confirm migration is called" $
+          withOriginated 3 (\(owner:_) -> initialStorage owner) $
+            \[owner, newAddress1, newAddress2] baseDao -> do
+              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress2)
       ]
 
   , testGroup "Confirm Migration"
-      [ testCase "authenticates the sender" $
-          nettestTestExpectation $ uncapsNettest $ do
-            withOriginated 3 (\(owner:_) -> initialStorage owner) $
-              \[owner, newAddress1, randomAddress] baseDao -> do
-                callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                -- We test this by calling `confirmMigration` and seeing that it does not fail
-                callFrom (AddressResolved randomAddress) baseDao (Call @"Confirm_migration") ()
-                  & expectNotMigrationTarget
+      [ nettestScenarioCaps "authenticates the sender" $
+          withOriginated 3 (\(owner:_) -> initialStorage owner) $
+            \[owner, newAddress1, randomAddress] baseDao -> do
+              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+              -- We test this by calling `confirmMigration` and seeing that it does not fail
+              callFrom (AddressResolved randomAddress) baseDao (Call @"Confirm_migration") ()
+                & expectNotMigrationTarget
 
-      , testCase "authenticates migration state" $
-          nettestTestExpectation $ uncapsNettest $ do
-            withOriginated 2 (\(owner:_) -> initialStorage owner) $
-              \[_, newAddress1] baseDao -> do
-                callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
-                  & expectNotMigrating
+      , nettestScenarioCaps "authenticates migration state" $
+          withOriginated 2 (\(owner:_) -> initialStorage owner) $
+            \[_, newAddress1] baseDao -> do
+              callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+                & expectNotMigrating
 
-      , testCase "finalizes migration" $
-          nettestTestExpectation $ uncapsNettest $ do
-            withOriginated 2 (\(owner:_) -> initialStorage owner) $
-              \[owner, newAddress1] baseDao -> do
-                callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                -- We test this by calling `confirmMigration` and seeing that it does not fail
-                callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
-                callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                  & expectMigrated newAddress1
-      ]
+      , nettestScenarioCaps "finalizes migration" $
+          withOriginated 2 (\(owner:_) -> initialStorage owner) $
+            \[owner, newAddress1] baseDao -> do
+              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+              -- We test this by calling `confirmMigration` and seeing that it does not fail
+              callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+                & expectMigrated newAddress1
+     ]
   ]
   where
     initialStorage admin = mkStorage admin mempty mempty

--- a/test/Test/BaseDAO/Proposal.hs
+++ b/test/Test/BaseDAO/Proposal.hs
@@ -46,12 +46,13 @@ test_BaseDAO_Proposal = testGroup "BaseDAO propose/vote entrypoints tests:"
   , testGroup "Admin:"
       [ nettestScenario "can set voting period" setVotingPeriod
       , nettestScenario "can set quorum threshold" setQuorumThreshold
-      , nettestScenario "can flush proposals that got accepted"
-          flushAcceptedProposals
-      , nettestScenario "can flush proposals that got rejected due to not meeting quorum_threshold"
-          flushRejectProposalQuorum
-      , nettestScenario "can flush proposals that got rejected due to negative votes"
-          flushRejectProposalNegativeVotes
+      -- TODO [#30]: make sure these tests pass not only in emulator
+      , nettestScenarioOnEmulator "can flush proposals that got accepted" $
+          \_emulated -> flushAcceptedProposals
+      , nettestScenarioOnEmulator "can flush proposals that got rejected due to not meeting quorum_threshold" $
+          \_emulated -> flushRejectProposalQuorum
+      , nettestScenarioOnEmulator "can flush proposals that got rejected due to negative votes" $
+          \_emulated -> flushRejectProposalNegativeVotes
       , nettestScenario "flush should not affecting ongoing proposals"
           flushNotAffectOngoingProposals
       , nettestScenario "flush with bad 'cRejectedProposalReturnValue'"

--- a/test/Test/BaseDAO/Proposal.hs
+++ b/test/Test/BaseDAO/Proposal.hs
@@ -5,79 +5,69 @@ module Test.BaseDAO.Proposal
   ( test_BaseDAO_Proposal
   ) where
 
-import Universum hiding ((>>), drop, compare)
+import Universum hiding (compare, drop, (>>))
 
 import Lorentz
 import Lorentz.Test (contractConsumer)
 import Morley.Nettest
+import Morley.Nettest.Tasty
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase)
 import Tezos.Crypto (blake2b)
 
 import qualified Lorentz.Contracts.BaseDAO.Types as DAO
-import Test.Common
 import Test.BaseDAO.ProposalConfig
+import Test.Common
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
 test_BaseDAO_Proposal :: TestTree
 test_BaseDAO_Proposal = testGroup "BaseDAO propose/vote entrypoints tests:"
   [ testGroup "Proposal creator:"
-      [ testCase "can propose a valid proposal" $
-          nettestTestExpectation validProposal
-      , testCase "cannot propose an invalid proposal (rejected)" $
-          nettestTestExpectation rejectProposal
-      , testCase "cannot propose with insufficient tokens" $
-          nettestTestExpectation insufficientTokenProposal
-      , testCase "cannot propose a non-unique proposal" $
-          nettestTestExpectation nonUniqueProposal
+      [ nettestScenario "can propose a valid proposal" validProposal
+      , nettestScenario "cannot propose an invalid proposal (rejected)"
+          rejectProposal
+      , nettestScenario "cannot propose with insufficient tokens"
+          insufficientTokenProposal
+      , nettestScenario "cannot propose a non-unique proposal" nonUniqueProposal
       ]
   , testGroup "Voter:"
-      [ testCase "can vote on a valid proposal" $
-          nettestTestExpectation voteValidProposal
-      , testCase "cannot vote non-existing proposal" $
-          nettestTestExpectation voteNonExistingProposal
-      , testCase "can vote on multiple proposals" $
-          nettestTestExpectation voteMultiProposals
-      , testCase "cannot vote if the vote amounts exceeds token balance" $
-          nettestTestExpectation insufficientTokenVote
+      [ nettestScenario "can vote on a valid proposal"
+          voteValidProposal
+      , nettestScenario "cannot vote non-existing proposal"
+          voteNonExistingProposal
+      , nettestScenario "can vote on multiple proposals"
+          voteMultiProposals
+      , nettestScenario "cannot vote if the vote amounts exceeds token balance"
+          insufficientTokenVote
       -- TODO [#30]: Can be tested until delay time is implemented for nettest
-      -- , testCase "cannot vote on outdated proposal" $
+      -- , nettestScenario "cannot vote on outdated proposal" $
       --     nettestTestExpectation
       ]
   , testGroup "Admin:"
-      [ testCase "can set voting period" $
-          nettestTestExpectation setVotingPeriod
-      , testCase "can set quorum threshold" $
-          nettestTestExpectation setQuorumThreshold
-      , testCase "can flush proposals that got accepted" $
-          nettestTestExpectation flushAcceptedProposals
-      , testCase "can flush proposals that got rejected due to not meeting quorum_threshold" $
-          nettestTestExpectation flushRejectProposalQuorum
-      , testCase "can flush proposals that got rejected due to negative votes" $
-          nettestTestExpectation flushRejectProposalNegativeVotes
-      , testCase "flush should not affecting ongoing proposals" $
-          nettestTestExpectation flushNotAffectOngoingProposals
-      , testCase "flush with bad 'cRejectedProposalReturnValue'" $
-          nettestTestExpectation flushWithBadConfig
+      [ nettestScenario "can set voting period" setVotingPeriod
+      , nettestScenario "can set quorum threshold" setQuorumThreshold
+      , nettestScenario "can flush proposals that got accepted"
+          flushAcceptedProposals
+      , nettestScenario "can flush proposals that got rejected due to not meeting quorum_threshold"
+          flushRejectProposalQuorum
+      , nettestScenario "can flush proposals that got rejected due to negative votes"
+          flushRejectProposalNegativeVotes
+      , nettestScenario "flush should not affecting ongoing proposals"
+          flushNotAffectOngoingProposals
+      , nettestScenario "flush with bad 'cRejectedProposalReturnValue'"
+          flushWithBadConfig
       -- TODO [#15]: admin burn proposer token and test "flush"
 
-      , testCase "flush and run decision lambda" $
-          nettestTestExpectation flushDecisionLambda
+      , nettestScenario "flush and run decision lambda" flushDecisionLambda
       ]
   , testGroup "Other:"
-      [ testCase "can call proposalMetadata" $
-          nettestTestExpectation proposalMetadata
+      [ nettestScenario "can call proposalMetadata" proposalMetadata
       ]
   , testGroup "Bounded Value"
-      [ testCase "bounded value on proposals" $
-          nettestTestExpectation proposalBoundedValue
-      , testCase "bounded value on votes" $
-          nettestTestExpectation votesBoundedValue
-      , testCase "bounded range on quorum_threshold" $
-          nettestTestExpectation quorumThresholdBound
-      , testCase "bounded range on voting_period" $
-          nettestTestExpectation votingPeriodBound
+      [ nettestScenario "bounded value on proposals" proposalBoundedValue
+      , nettestScenario "bounded value on votes" votesBoundedValue
+      , nettestScenario "bounded range on quorum_threshold" quorumThresholdBound
+      , nettestScenario "bounded range on voting_period" votingPeriodBound
       ]
   ]
 
@@ -507,4 +497,3 @@ makeProposalKey params owner = blake2b $ lPackValue (params, owner)
 -- Check if certain field in storage
 -- checkPropertyOfProposal :: _
 -- checkPropertyOfProposal = error "undefined"
-


### PR DESCRIPTION
## Description


Problem: we want to use a newer version of the `cleveland` package
because it has `tasty` integration and some new functionality
that we intend to use in tests.
We also want to run network tests on CI.

Solution: update versions of packages from Morley framework.
Tests have been updated to use new functions from `Morley.Nettest.Tasty`
instead of functions like `nettestTestExpectation` that are no longer
available.
Now CI runs network tests as well. In this PR it runs them only in local chain, but we'll add running in Delphinet as well (not in this PR).

Relevant upstream MR: https://gitlab.com/morley-framework/morley/-/merge_requests/613



<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #32

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
