### PR TITLE
[#30] Use `advanceTime` from `Nettest` to properly test `flush` entrypoint 

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -123,6 +123,7 @@ tests:
     - lorentz
     - morley
     - morley-ledgers
+    - o-clock
     - tasty
     - universum
     - containers

--- a/src/Lorentz/Contracts/BaseDAO/Types.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Types.hs
@@ -81,9 +81,6 @@ data Config proposalMetadata = Config
   , cMinQuorumThreshold :: Natural
   , cMaxVotingPeriod :: Natural -- Maximum of seconds allow to be set
   , cMinVotingPeriod :: Natural
-
-  -- TODO [#30]: remove (Currently needed due to Nettest can track time, use this to force flush)
-  , cForceVotingPeriod :: Bool
   }
 
 defaultConfig :: Config pm
@@ -119,8 +116,6 @@ defaultConfig = Config
 
   , cMaxVotes = 1000
   , cMaxProposals = 500
-
-  , cForceVotingPeriod = False
   }
 ------------------------------------------------------------------------
 -- Operators


### PR DESCRIPTION
## Description

Problem: Previously, it is not possible to do a `wait 3 seconds` in `Nettest`.
We need this to actually check if a voting period of a proposal is over or not.

Solution: Use `advanceTime` to properly test `flush` entrypoint. Remove
the workaround.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #30 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
