### PR TITLE
[#36] Add `GameDAO` contract as an example of `BaseDAO`

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -21,6 +21,7 @@ import Util.CLI (mkCLOptionParser)
 import Util.Named
 
 import qualified Lorentz.Contracts.BaseDAO as DAO
+import qualified Lorentz.Contracts.GameDAO as GameDAO
 
 programInfo :: DGitRevision -> Opt.ParserInfo CmdLnArgs
 programInfo gitRev = Opt.info (Opt.helper <*> versionOption <*> argParser contracts gitRev) $
@@ -50,16 +51,23 @@ contracts = ContractRegistry $ Map.fromList
   [ "BaseDAO" ?:: ContractInfo
     { ciContract = DAO.baseDaoContract DAO.defaultConfig
     , ciIsDocumented = True
-    , ciStorageParser = Just baseDaoStorageParser
+    , ciStorageParser = Just $ baseDaoStorageParser @()
+    , ciStorageNotes = Nothing
+    }
+  , "GameDAO" ?:: ContractInfo
+    { ciContract = GameDAO.gameDaoContract
+    , ciIsDocumented = True
+    , ciStorageParser = Just $
+        baseDaoStorageParser @GameDAO.GameDaoProposalMetadata
     , ciStorageNotes = Nothing
     }
   ]
 
-baseDaoStorageParser :: Opt.Parser (DAO.Storage ())
+baseDaoStorageParser :: forall m. Opt.Parser (DAO.Storage m)
 baseDaoStorageParser = do
   adminAddress <-
     addressOption Nothing (#name .! "admin")
-    (#help .! "Administrator of the BaseDAO contract")
+    (#help .! "Administrator of the DAO contract")
   votingPeriod <-
     mkCLOptionParser (Just $ 60 * 60 * 24 * 7) (#name .! "voting-period")
     (#help .! "Period after which proposals can be finished")

--- a/src/Lorentz/Contracts/BaseDAO/Types.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Types.hs
@@ -41,6 +41,8 @@ module Lorentz.Contracts.BaseDAO.Types
 
   , unfrozenTokenId
   , frozenTokenId
+
+  , baseDaoAnnOptions
   ) where
 
 import Universum hiding (drop, (>>))

--- a/src/Lorentz/Contracts/GameDAO.hs
+++ b/src/Lorentz/Contracts/GameDAO.hs
@@ -1,0 +1,196 @@
+-- SPDX-FileCopyrightText: 2020 TQ Tezos
+-- SPDX-License-Identifier: LicenseRef-MIT-TQ
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | A simple DAO for a Moba-like game.
+module Lorentz.Contracts.GameDAO
+  ( GameDaoProposalMetadata (..)
+  , Storage
+  , Parameter
+  , ProposalType (..)
+  , BalanceChange (..)
+  , ItemChange (..)
+  , HeroChange (..)
+  , NewContents
+  , NewContent (..)
+
+  , gameDaoContract
+  , config
+  ) where
+
+import Universum hiding ((>>), drop, swap)
+import Lorentz
+import qualified Lorentz.Contracts.BaseDAO as DAO
+import qualified Lorentz.Contracts.BaseDAO.Types as DAO
+import Util.Markdown
+
+data GameDaoProposalMetadata = GameDaoProposalMetadata
+  { pmProposalType :: ProposalType
+  , pmProposalDescription :: MText
+  , pmConsumerAddr :: Address
+  }
+  deriving stock (Generic)
+  deriving anyclass IsoValue
+
+instance HasAnnotation GameDaoProposalMetadata where
+  annOptions = DAO.baseDaoAnnOptions
+
+data ProposalType = BalanceType BalanceChange | NewType NewContents
+  deriving stock (Generic)
+  deriving anyclass (IsoValue)
+
+instance HasAnnotation ProposalType where
+  annOptions = defaultAnnOptions { fieldAnnModifier = toSnake }
+
+instance TypeHasDoc ProposalType where
+  typeDocMdDescription = "There are 2 types of proposal that Game DAO supports. \
+    \'balance_type' is for small update to existing mechanic, items and heroes. \
+    \'new_type' is for proposing new contents all together."
+
+data BalanceChange = BalanceChange
+  { bcItemChanges :: [ItemChange]
+  , bcHeroChanges :: [HeroChange]
+  }
+  deriving stock (Generic)
+  deriving anyclass (IsoValue)
+
+instance HasAnnotation BalanceChange where
+  annOptions = DAO.baseDaoAnnOptions
+
+instance TypeHasDoc BalanceChange where
+  typeDocMdDescription = "Describe the update of all items and heroes in the proposal."
+
+data ItemChange = ItemChange
+  { icItemName :: MText
+  , icChangelogs :: [MText]
+  }
+  deriving stock (Generic)
+  deriving anyclass (IsoValue)
+
+instance TypeHasDoc ItemChange where
+  typeDocMdDescription = "Describe the update of a specific item."
+
+instance HasAnnotation ItemChange where
+  annOptions = DAO.baseDaoAnnOptions
+
+data HeroChange = HeroChange
+  { hcHeroName :: MText
+  , hcChangelogs :: [MText]
+  }
+  deriving stock (Generic)
+  deriving anyclass (IsoValue)
+
+instance TypeHasDoc HeroChange where
+  typeDocMdDescription = "Describe the update of a specific hero."
+
+instance HasAnnotation HeroChange where
+  annOptions = DAO.baseDaoAnnOptions
+
+type NewContents = [NewContent]
+
+data NewContent = NewContent
+  { ncContentName :: MText
+  , ncContentDescription :: [MText]
+  }
+  deriving stock (Generic)
+  deriving anyclass (IsoValue)
+
+instance TypeHasDoc NewContent where
+  typeDocMdDescription = "Describe a new content. The content should have a \
+    \name and detail description."
+
+instance HasAnnotation NewContent where
+  annOptions = DAO.baseDaoAnnOptions
+
+instance TypeHasDoc GameDaoProposalMetadata where
+  typeDocMdDescription = "GameDAO's metadata. This fields affect how proposal \
+    \got accepted and how many tokens will be frozen"
+
+----------------------------------------------------------------------------
+
+type instance ErrorArg "fAIL_DECISION_LAMBDA" = ()
+
+instance CustomErrorHasDoc "fAIL_DECISION_LAMBDA" where
+  customErrClass = ErrClassActionException
+  customErrDocMdCause = "Trying to execute decision lambda but result in errors."
+
+----------------------------------------------------------------------------
+
+type Parameter = DAO.Parameter GameDaoProposalMetadata
+type Storage = DAO.Storage GameDaoProposalMetadata
+
+-- | For "balance change", the proposer needs to freeze 10 tokens
+-- For "new content", the proposal needs to freeze 50 tokens
+gameDaoProposalCheck
+  :: forall s. (DAO.ProposeParams GameDaoProposalMetadata) : s
+  :-> Bool : s
+gameDaoProposalCheck = do
+  getFieldNamed #ppFrozenToken; swap
+  toField #ppProposalMetadata
+  toField #pmProposalType
+  stackType @(ProposalType : "ppFrozenToken" :! Natural : s)
+  caseT
+    ( #cBalanceType /-> do drop; push (10 :: Natural)
+    , #cNewType /-> do drop; push (50 :: Natural)
+    )
+  toNamed #requireValue
+
+  if #requireValue <=. #ppFrozenToken then
+    push True
+  else
+    push False
+
+-- | In case of a proposal got rejected, the proposer loses half of the tokens.
+gameDaoRejectedProposalReturnValue
+  :: forall s. (DAO.Proposal GameDaoProposalMetadata) : s
+  :-> ("slash_amount" :! Natural) : s
+gameDaoRejectedProposalReturnValue = do
+  toField #pProposerFrozenToken
+  push (2 :: Natural)
+  swap
+  ediv
+  ifSome car $
+    push (0 :: Natural)
+  toNamed #slash_amount
+
+-- | When a proposal got accepted, call a consumer contract with the proposal
+-- description. It would be more useful to send the whole proposal itself but
+-- using just the description is simpler to test.
+decisionLambda
+  ::  forall s store. (DAO.StorageC store GameDaoProposalMetadata)
+  =>  (DAO.Proposal GameDaoProposalMetadata) : store : s
+  :-> (List Operation, store) : s
+decisionLambda = do
+  toField #pMetadata
+  getField #pmProposalDescription
+
+  dip $ do
+    toField #pmConsumerAddr
+    contractCallingUnsafe @MText DefEpName
+    ifSome nop $ do
+      failCustom_ #fAIL_DECISION_LAMBDA
+    push zeroMutez
+  transferTokens
+  nil; swap; cons
+  pair
+
+config :: DAO.Config GameDaoProposalMetadata
+config = DAO.defaultConfig
+  { DAO.cDaoName = "Game DAO"
+  , DAO.cDaoDescription = [md|A simple DAO for a Moba-like game.|]
+  , DAO.cProposalCheck = gameDaoProposalCheck
+  , DAO.cRejectedProposalReturnValue = gameDaoRejectedProposalReturnValue
+  , DAO.cDecisionLambda = decisionLambda
+
+  , DAO.cMaxVotingPeriod = 60 * 60 * 24 * 30 -- 1 months
+  , DAO.cMinVotingPeriod = 1 -- value between 1 second - 1 month
+
+  , DAO.cMaxQuorumThreshold = 1000
+  , DAO.cMinQuorumThreshold = 1
+
+  , DAO.cMaxVotes = 1000
+  , DAO.cMaxProposals = 500
+  }
+
+gameDaoContract :: Contract Parameter Storage
+gameDaoContract = DAO.baseDaoContract config

--- a/test/Test/BaseDAO/Proposal.hs
+++ b/test/Test/BaseDAO/Proposal.hs
@@ -11,7 +11,6 @@ import Lorentz
 import Morley.Nettest
 import Morley.Nettest.Tasty
 import Test.Tasty (TestTree, testGroup)
-import Tezos.Crypto (blake2b)
 import Time (sec)
 
 import qualified Lorentz.Contracts.BaseDAO.Types as DAO
@@ -73,7 +72,7 @@ test_BaseDAO_Proposal = testGroup "BaseDAO propose/vote entrypoints tests:"
 
 validProposal :: (Monad m) => NettestImpl m -> m ()
 validProposal = uncapsNettest $ do
-  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig config
+  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig @Integer config
   let params = DAO.ProposeParams
         { ppFrozenToken = 10
         , ppProposalMetadata = 1
@@ -89,7 +88,7 @@ validProposal = uncapsNettest $ do
 
 rejectProposal :: (Monad m) => NettestImpl m -> m ()
 rejectProposal = uncapsNettest $ do
-  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig config
+  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig @Integer config
   let params = DAO.ProposeParams
         { ppFrozenToken = 9
         , ppProposalMetadata = 1
@@ -100,7 +99,7 @@ rejectProposal = uncapsNettest $ do
 
 insufficientTokenProposal :: (Monad m) => NettestImpl m -> m ()
 insufficientTokenProposal = uncapsNettest $ do
-  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig config
+  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig @Integer config
   let params = DAO.ProposeParams
         { ppFrozenToken = 101
         , ppProposalMetadata = 1
@@ -111,14 +110,14 @@ insufficientTokenProposal = uncapsNettest $ do
 
 nonUniqueProposal :: (Monad m) => NettestImpl m -> m ()
 nonUniqueProposal = uncapsNettest $ do
-  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig config
+  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig @Integer config
   _ <- createSampleProposal 1 owner1 dao
   createSampleProposal 1 owner1 dao
     & expectCustomError_ #pROPOSAL_NOT_UNIQUE
 
 voteValidProposal :: (Monad m) => NettestImpl m -> m ()
 voteValidProposal = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig config
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer config
 
   -- | Create sample proposal (first proposal has id = 0)
   key1 <- createSampleProposal 1 owner1 dao
@@ -135,7 +134,7 @@ voteValidProposal = uncapsNettest $ do
 
 voteNonExistingProposal :: (Monad m) => NettestImpl m -> m ()
 voteNonExistingProposal = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig config
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer config
 
   -- | Create sample proposal
   _ <- createSampleProposal 1 owner1 dao
@@ -150,7 +149,7 @@ voteNonExistingProposal = uncapsNettest $ do
 
 voteMultiProposals :: (Monad m) => NettestImpl m -> m ()
 voteMultiProposals = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig config
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer config
 
   -- | Create sample proposal
   key1 <- createSampleProposal 1 owner1 dao
@@ -175,7 +174,7 @@ voteMultiProposals = uncapsNettest $ do
 
 insufficientTokenVote :: (Monad m) => NettestImpl m -> m ()
 insufficientTokenVote = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig config
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer config
 
   -- | Create sample proposal
   key1 <- createSampleProposal 1 owner1 dao
@@ -197,7 +196,7 @@ insufficientTokenVote = uncapsNettest $ do
 
 voteOutdatedProposal :: (Monad m) => NettestImpl m -> m ()
 voteOutdatedProposal = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, admin) <- originateBaseDaoWithConfig config
+  ((owner1, _), (owner2, _), dao, admin) <- originateBaseDaoWithConfig @Integer config
 
   -- | Create sample proposal
   key1 <- createSampleProposal 1 owner1 dao
@@ -218,7 +217,7 @@ voteOutdatedProposal = uncapsNettest $ do
 
 setVotingPeriod :: (Monad m) => NettestImpl m -> m ()
 setVotingPeriod = uncapsNettest $ do
-  ((owner1, _), _, dao, admin) <- originateBaseDaoWithConfig config
+  ((owner1, _), _, dao, admin) <- originateBaseDaoWithConfig @Integer config
 
   let param = 60 * 60 -- 1 hour
 
@@ -230,7 +229,7 @@ setVotingPeriod = uncapsNettest $ do
 
 setQuorumThreshold :: (Monad m) => NettestImpl m -> m ()
 setQuorumThreshold = uncapsNettest $ do
-  ((owner1, _), _, dao, admin) <- originateBaseDaoWithConfig config
+  ((owner1, _), _, dao, admin) <- originateBaseDaoWithConfig @Integer config
 
   let param = 100
 
@@ -242,7 +241,7 @@ setQuorumThreshold = uncapsNettest $ do
 
 flushNotAffectOngoingProposals :: (Monad m) => NettestImpl m -> m ()
 flushNotAffectOngoingProposals = uncapsNettest $ do
-  ((owner1, _), _, dao, admin) <- originateBaseDaoWithConfig config
+  ((owner1, _), _, dao, admin) <- originateBaseDaoWithConfig @Integer config
 
   -- Note: Cannot set to few seconds, since in real network, each
   -- calls takes some times to run. 20 seconds seem to be the ideal.
@@ -262,7 +261,7 @@ flushNotAffectOngoingProposals = uncapsNettest $ do
 
 flushAcceptedProposals :: (Monad m) => NettestImpl m -> m ()
 flushAcceptedProposals = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, admin) <- originateBaseDaoWithConfig config
+  ((owner1, _), (owner2, _), dao, admin) <- originateBaseDaoWithConfig @Integer config
 
   -- Use 60s for voting period, since in real network by the time we call
   -- vote entrypoint 30s is already passed.
@@ -306,7 +305,7 @@ flushRejectProposalQuorum :: (Monad m) => NettestImpl m -> m ()
 flushRejectProposalQuorum =
   uncapsNettest $ do
   ((owner1, _), (owner2, _), dao, admin)
-    <- originateBaseDaoWithConfig configWithRejectedProposal
+    <- originateBaseDaoWithConfig @Integer configWithRejectedProposal
 
   callFrom (AddressResolved admin) dao (Call @"Set_voting_period") 60
   callFrom (AddressResolved admin) dao (Call @"Set_quorum_threshold") 3
@@ -343,7 +342,7 @@ flushRejectProposalQuorum =
 flushRejectProposalNegativeVotes :: (Monad m) => NettestImpl m -> m ()
 flushRejectProposalNegativeVotes = uncapsNettest $ do
   ((owner1, _), (owner2, _), dao, admin)
-    <- originateBaseDaoWithConfig configWithRejectedProposal
+    <- originateBaseDaoWithConfig @Integer configWithRejectedProposal
 
   callFrom (AddressResolved admin) dao (Call @"Set_voting_period") 60
   callFrom (AddressResolved admin) dao (Call @"Set_quorum_threshold") 3
@@ -387,7 +386,7 @@ flushRejectProposalNegativeVotes = uncapsNettest $ do
 
 flushWithBadConfig :: (Monad m) => NettestImpl m -> m ()
 flushWithBadConfig = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, admin) <- originateBaseDaoWithConfig badRejectedValueConfig
+  ((owner1, _), (owner2, _), dao, admin) <- originateBaseDaoWithConfig @Integer badRejectedValueConfig
 
   callFrom (AddressResolved admin) dao (Call @"Set_voting_period") 60
   callFrom (AddressResolved admin) dao (Call @"Set_quorum_threshold") 2
@@ -416,7 +415,7 @@ flushWithBadConfig = uncapsNettest $ do
 
 flushDecisionLambda :: (Monad m) => NettestImpl m -> m ()
 flushDecisionLambda = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, admin) <- originateBaseDaoWithConfig decisionLambdaConfig
+  ((owner1, _), (owner2, _), dao, admin) <- originateBaseDaoWithConfig @Integer decisionLambdaConfig
 
   callFrom (AddressResolved admin) dao (Call @"Set_voting_period") 60
   callFrom (AddressResolved admin) dao (Call @"Set_quorum_threshold") 1
@@ -439,7 +438,7 @@ flushDecisionLambda = uncapsNettest $ do
 
 proposalBoundedValue :: (Monad m) => NettestImpl m -> m ()
 proposalBoundedValue = uncapsNettest $ do
-  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig (config { DAO.cMaxProposals = 1})
+  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig @Integer (config { DAO.cMaxProposals = 1})
 
   let params = DAO.ProposeParams
         { ppFrozenToken = 10
@@ -452,7 +451,7 @@ proposalBoundedValue = uncapsNettest $ do
 
 votesBoundedValue :: (Monad m) => NettestImpl m -> m ()
 votesBoundedValue = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig (config { DAO.cMaxVotes = 1})
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer (config { DAO.cMaxVotes = 1})
 
   key1 <- createSampleProposal 1 owner2 dao
   let upvote = DAO.VoteParam
@@ -472,7 +471,7 @@ votesBoundedValue = uncapsNettest $ do
 
 quorumThresholdBound :: (Monad m) => NettestImpl m -> m ()
 quorumThresholdBound = uncapsNettest $ do
-  (_, _, dao, admin) <- originateBaseDaoWithConfig
+  (_, _, dao, admin) <- originateBaseDaoWithConfig @Integer
                                           (config { DAO.cMinQuorumThreshold = 1
                                                   , DAO.cMaxQuorumThreshold = 2
                                                   })
@@ -485,7 +484,7 @@ quorumThresholdBound = uncapsNettest $ do
 
 votingPeriodBound :: (Monad m) => NettestImpl m -> m ()
 votingPeriodBound = uncapsNettest $ do
-  (_, _, dao, admin) <- originateBaseDaoWithConfig
+  (_, _, dao, admin) <- originateBaseDaoWithConfig @Integer
                                           (config { DAO.cMinVotingPeriod = 1
                                                   , DAO.cMaxVotingPeriod = 2
                                                   })
@@ -502,7 +501,7 @@ votingPeriodBound = uncapsNettest $ do
 
 createSampleProposal
   :: MonadNettest caps base m
-  => Integer -> Address -> TAddress (DAO.Parameter TestProposalMetadata) -> m ByteString
+  => Integer -> Address -> TAddress (DAO.Parameter Integer) -> m ByteString
 createSampleProposal counter owner1 dao = do
   let params = DAO.ProposeParams
         { ppFrozenToken = 10
@@ -521,9 +520,6 @@ createSampleProposal counter owner1 dao = do
 --   consumer <- originateSimple "consumer" [] contractConsumer
 --   -- | If the proposal exists, there should be no error
 --   callFrom (AddressResolved owner) dao (Call @"Proposal_metadata") (mkView proposalKey consumer)
-
-makeProposalKey :: DAO.ProposeParams Integer -> Address -> ByteString
-makeProposalKey params owner = blake2b $ lPackValue (params, owner)
 
 -- TODO [#31]: See this ISSUES: https://gitlab.com/morley-framework/morley/-/issues/415#note_435327096
 -- Check if certain field in storage

--- a/test/Test/BaseDAO/Token.hs
+++ b/test/Test/BaseDAO/Token.hs
@@ -35,7 +35,7 @@ test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
 adminBurnScenario :: (Monad m) => NettestImpl m -> m ()
 adminBurnScenario = uncapsNettest $ do
   ((owner1, _), _, dao, admin)
-    <- originateBaseDaoWithBalance DAO.defaultConfig
+    <- originateBaseDaoWithBalance @() DAO.defaultConfig
           (\o1 _ ->
               [ ((o1, 0), 10)
               , ((o1, 1), 10)
@@ -55,7 +55,7 @@ adminBurnScenario = uncapsNettest $ do
 adminMintScenario :: (Monad m) => NettestImpl m -> m ()
 adminMintScenario = uncapsNettest $ do
   ((owner1, _), _, dao, admin)
-    <- originateBaseDaoWithBalance DAO.defaultConfig
+    <- originateBaseDaoWithBalance @() DAO.defaultConfig
           (\o1 _ ->
               [ ((o1, 0), 0)
               , ((o1, 1), 0)
@@ -69,8 +69,8 @@ adminMintScenario = uncapsNettest $ do
 
 transferContractTokensScenario :: (Monad m) => NettestImpl m -> m ()
 transferContractTokensScenario = uncapsNettest $ do
-  (_, _, dao, admin) <- originateBaseDao
-  ((owner1, _), (owner2, _), fa2Contract, _) <- originateBaseDao
+  (_, _, dao, admin) <- originateBaseDao @()
+  ((owner1, _), (owner2, _), fa2Contract, _) <- originateBaseDao @()
   let addParams = FA2.OperatorParam
         { opOwner = owner1
         , opOperator = toAddress dao
@@ -97,7 +97,7 @@ transferContractTokensScenario = uncapsNettest $ do
 
 tokenAddressScenario :: (Monad m) => NettestImpl m -> m ()
 tokenAddressScenario = uncapsNettest $ do
-  ((owner1, _), _, dao, _) <- originateBaseDao
+  ((owner1, _), _, dao, _) <- originateBaseDao @()
   consumer <- originateSimple "consumer" [] contractConsumer
   callFrom (AddressResolved owner1) dao (Call @"Token_address") (toContractRef consumer)
 

--- a/test/Test/BaseDAO/Token/FA2.hs
+++ b/test/Test/BaseDAO/Token/FA2.hs
@@ -76,7 +76,7 @@ test_BaseDAO_FA2 = testGroup "BaseDAO FA2 tests:"
 zeroTransferScenario :: (Monad m) => NettestImpl m -> m ()
 zeroTransferScenario = uncapsNettest $ do
   nonexistent :: Address <- newAddress "nonexistent"
-  ((owner1, _), _, dao, _) <- originateBaseDao
+  ((owner1, _), _, dao, _) <- originateBaseDao @()
   let params = [ FA2.TransferItem
         { tiFrom = nonexistent
         , tiTxs = [ FA2.TransferDestination
@@ -90,7 +90,7 @@ zeroTransferScenario = uncapsNettest $ do
 
 validTransferScenario :: (Monad m) => NettestImpl m -> m ()
 validTransferScenario = uncapsNettest $ do
-  ((owner1, op1), (owner2, _), dao, _) <- originateBaseDao
+  ((owner1, op1), (owner2, _), dao, _) <- originateBaseDao @()
   let params = [ FA2.TransferItem
         { tiFrom = owner1
         , tiTxs = [ FA2.TransferDestination
@@ -115,7 +115,7 @@ validTransferScenario = uncapsNettest $ do
 
 validTransferOwnerScenario :: (Monad m) => NettestImpl m -> m ()
 validTransferOwnerScenario = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao @()
   let params = [ FA2.TransferItem
         { tiFrom = owner1
         , tiTxs = [ FA2.TransferDestination
@@ -140,7 +140,7 @@ validTransferOwnerScenario = uncapsNettest $ do
 
 updatingOperatorAfterMigrationScenario :: (Monad m) => NettestImpl m -> m ()
 updatingOperatorAfterMigrationScenario = uncapsNettest $ do
-  ((owner1, _), (owner2, newAddress1), dao, admin) <- originateBaseDao
+  ((owner1, _), (owner2, newAddress1), dao, admin) <- originateBaseDao @()
   let params = FA2.OperatorParam
         { opOwner = owner1
         , opOperator = owner2
@@ -154,7 +154,7 @@ updatingOperatorAfterMigrationScenario = uncapsNettest $ do
 
 updatingOperatorScenario :: (Monad m) => NettestImpl m -> m ()
 updatingOperatorScenario = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao @()
   let params = FA2.OperatorParam
         { opOwner = owner1
         , opOperator = owner2
@@ -189,7 +189,7 @@ updatingOperatorScenario = uncapsNettest $ do
 
 lowBalanceScenario :: (Monad m) => NettestImpl m -> m ()
 lowBalanceScenario = uncapsNettest $ do
-  ((owner1, op1), (owner2, _), dao, _) <- originateBaseDao
+  ((owner1, op1), (owner2, _), dao, _) <- originateBaseDao @()
 
   let params = [ FA2.TransferItem
         { tiFrom = owner1
@@ -204,7 +204,7 @@ lowBalanceScenario = uncapsNettest $ do
 
 lowBalanceOwnerScenario :: (Monad m) => NettestImpl m -> m ()
 lowBalanceOwnerScenario = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao @()
 
   let params = [ FA2.TransferItem
         { tiFrom = owner1
@@ -220,7 +220,7 @@ lowBalanceOwnerScenario = uncapsNettest $ do
 noSourceAccountScenario :: (Monad m) => NettestImpl m -> m ()
 noSourceAccountScenario = uncapsNettest $ do
   nonexistent :: Address <- newAddress "nonexistent"
-  ((owner1, _), _, dao, _) <- originateBaseDao
+  ((owner1, _), _, dao, _) <- originateBaseDao @()
 
   let params = [ FA2.TransferItem
         { tiFrom = nonexistent
@@ -239,7 +239,7 @@ noSourceAccountScenario = uncapsNettest $ do
 badOperatorScenario :: (Monad m) => NettestImpl m -> m ()
 badOperatorScenario = uncapsNettest $ do
   op3  :: Address <- newAddress "operator3"
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao @()
 
   let params = [ FA2.TransferItem
         { tiFrom = owner2
@@ -254,12 +254,12 @@ badOperatorScenario = uncapsNettest $ do
 
 emptyTransferListScenario :: (Monad m) => NettestImpl m -> m ()
 emptyTransferListScenario = uncapsNettest $ do
-  ((_, op1), _, dao, _) <- originateBaseDao
+  ((_, op1), _, dao, _) <- originateBaseDao @()
   callFrom (AddressResolved op1) dao (Call @"Transfer") []
 
 validateTokenScenario :: (Monad m) => NettestImpl m -> m ()
 validateTokenScenario = uncapsNettest $ do
-  ((owner1, op1), (owner2, _), dao, _) <- originateBaseDao
+  ((owner1, op1), (owner2, _), dao, _) <- originateBaseDao @()
 
   let params tokenId = [ FA2.TransferItem
         { tiFrom = owner1
@@ -279,7 +279,7 @@ validateTokenScenario = uncapsNettest $ do
 
 validateTokenOwnerScenario :: (Monad m) => NettestImpl m -> m ()
 validateTokenOwnerScenario = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao @()
 
   let params tokenId = [ FA2.TransferItem
         { tiFrom = owner1
@@ -299,7 +299,7 @@ validateTokenOwnerScenario = uncapsNettest $ do
 
 noForeignMoneyScenario :: (Monad m) => NettestImpl m -> m ()
 noForeignMoneyScenario = uncapsNettest $ do
-  ((owner1, op1), (owner2, _), dao, _) <- originateBaseDao
+  ((owner1, op1), (owner2, _), dao, _) <- originateBaseDao @()
 
   let params = [ FA2.TransferItem
         { tiFrom = owner2
@@ -314,7 +314,7 @@ noForeignMoneyScenario = uncapsNettest $ do
 
 noForeignMoneyOwnerScenario :: (Monad m) => NettestImpl m -> m ()
 noForeignMoneyOwnerScenario = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDao @()
 
   let params = [ FA2.TransferItem
         { tiFrom = owner2
@@ -329,7 +329,7 @@ noForeignMoneyOwnerScenario = uncapsNettest $ do
 
 balanceOfOwnerScenario :: (Monad m) => NettestImpl m -> m ()
 balanceOfOwnerScenario = uncapsNettest $ do
-  ((owner1, _), _, dao, _) <- originateBaseDao
+  ((owner1, _), _, dao, _) <- originateBaseDao @()
   consumer <- originateSimple "consumer" [] contractConsumer
   let
     params requestItems = mkFA2View requestItems consumer
@@ -343,7 +343,7 @@ balanceOfOwnerScenario = uncapsNettest $ do
 
 adminTransferScenario :: (Monad m) => NettestImpl m -> m ()
 adminTransferScenario = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, admin) <- originateBaseDao
+  ((owner1, _), (owner2, _), dao, admin) <- originateBaseDao @()
 
   let params = [ FA2.TransferItem
         { tiFrom = owner2
@@ -359,7 +359,7 @@ adminTransferScenario = uncapsNettest $ do
 adminTransferFrozenScenario :: (Monad m) => NettestImpl m -> m ()
 adminTransferFrozenScenario = uncapsNettest $ do
   ((owner1, _), (owner2, _), dao, admin)
-    <- originateBaseDaoWithBalance DAO.defaultConfig
+    <- originateBaseDaoWithBalance @() DAO.defaultConfig
         (\owner1 owner2 ->
             [ ((owner1, 1), 100)
             , ((owner2, 1), 100)
@@ -378,7 +378,7 @@ adminTransferFrozenScenario = uncapsNettest $ do
 
 transferAfterMigrationScenario :: (Monad m) => NettestImpl m -> m ()
 transferAfterMigrationScenario = uncapsNettest $ do
-  ((owner1, op1), (owner2, newAddress1), dao, admin) <- originateBaseDao
+  ((owner1, op1), (owner2, newAddress1), dao, admin) <- originateBaseDao @()
 
   let params = [ FA2.TransferItem
         { tiFrom = owner2
@@ -396,7 +396,7 @@ transferAfterMigrationScenario = uncapsNettest $ do
 
 balanceOfRequestAfterMigrationScenario :: (Monad m) => NettestImpl m -> m ()
 balanceOfRequestAfterMigrationScenario = uncapsNettest $ do
-  ((owner1, newAddress1), _, dao, admin) <- originateBaseDao
+  ((owner1, newAddress1), _, dao, admin) <- originateBaseDao @()
   consumer <- originateSimple "consumer" [] contractConsumer
   let
     params requestItems = mkFA2View requestItems consumer
@@ -410,7 +410,7 @@ balanceOfRequestAfterMigrationScenario = uncapsNettest $ do
 
 tokenMetadataRegistryRequestAfterMigrationScenario :: (Monad m) => NettestImpl m -> m ()
 tokenMetadataRegistryRequestAfterMigrationScenario = uncapsNettest $ do
-  ((owner1, newAddress1), _, dao, admin) <- originateBaseDao
+  ((owner1, newAddress1), _, dao, admin) <- originateBaseDao @()
   consumer <- originateSimple "consumer" [] (contractConsumer @Address)
 
   callFrom (AddressResolved admin) dao (Call @"Migrate") (#newAddress .! newAddress1)

--- a/test/Test/GameDAO.hs
+++ b/test/Test/GameDAO.hs
@@ -1,0 +1,137 @@
+-- SPDX-FileCopyrightText: 2020 TQ Tezos
+-- SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+module Test.GameDAO
+  ( test_GameDAO
+  ) where
+
+import Universum hiding (compare, drop, (>>))
+
+import Lorentz
+import Lorentz.Test (contractConsumer)
+import Morley.Nettest
+import Morley.Nettest.Tasty
+import Test.Tasty (TestTree, testGroup)
+import Time (sec)
+
+import qualified Lorentz.Contracts.BaseDAO.Types as DAO
+import Lorentz.Contracts.GameDAO
+import Test.Common
+
+{-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
+
+test_GameDAO :: TestTree
+test_GameDAO = testGroup "GameDAO Tests"
+  [ testGroup "Proposal creator:"
+      [ nettestScenario "can propose a valid proposal" validProposal
+      ]
+  , testGroup "Admin"
+      [ nettestScenarioOnEmulator "can flush proposals that got accepted" $
+          \_emulated -> flushAcceptedProposals
+      ]
+  ]
+
+validProposal :: (Monad m) => NettestImpl m -> m ()
+validProposal = uncapsNettest $ do
+  (consumer :: TAddress MText) <- originateSimple "consumer" [] contractConsumer
+  ((owner1, _), _, dao, _) <- originateBaseDaoWithConfig config
+
+  -- Fail due to proposing new content require 50 token.
+  callFrom (AddressResolved owner1) dao (Call @"Propose") (DAO.ProposeParams
+    { ppFrozenToken = 20
+    , ppProposalMetadata = sampleMetadataContent $ toAddress consumer
+    }) & expectCustomError_ #fAIL_PROPOSAL_CHECK
+
+  callFrom (AddressResolved owner1) dao (Call @"Propose") (DAO.ProposeParams
+    { ppFrozenToken = 15
+    , ppProposalMetadata = sampleMetadataBalance $ toAddress consumer
+    })
+
+  checkTokenBalance (DAO.frozenTokenId) dao owner1 15
+  checkTokenBalance (DAO.unfrozenTokenId) dao owner1 85
+
+flushAcceptedProposals :: (Monad m) => NettestImpl m -> m ()
+flushAcceptedProposals = uncapsNettest $ do
+  (consumer :: TAddress MText) <- originateSimple "consumer" [] contractConsumer
+  ((owner1, _), (owner2, _), dao, admin)
+    <- originateBaseDaoWithConfig config
+
+  callFrom (AddressResolved admin) dao (Call @"Set_voting_period") 20
+  callFrom (AddressResolved admin) dao (Call @"Set_quorum_threshold") 1
+
+  -- | Accepted Proposals
+  key1 <- createSampleProposal (sampleMetadataBalance $ toAddress consumer) owner1 dao
+  checkTokenBalance (DAO.frozenTokenId) dao owner1 10
+
+  let upvote = DAO.VoteParam
+        { vVoteType = True
+        , vVoteAmount = 2
+        , vProposalKey = key1
+        }
+      downvote = DAO.VoteParam
+        { vVoteType = False
+        , vVoteAmount = 1
+        , vProposalKey = key1
+        }
+  callFrom (AddressResolved owner2) dao (Call @"Vote") [upvote, downvote]
+  checkTokenBalance (DAO.frozenTokenId) dao owner2 3
+  checkTokenBalance (DAO.unfrozenTokenId) dao owner2 97
+
+  advanceTime (sec 21)
+  callFrom (AddressResolved admin) dao (Call @"Flush") ()
+
+  checkTokenBalance (DAO.frozenTokenId) dao owner1 0
+  checkTokenBalance (DAO.unfrozenTokenId) dao owner1 100 -- proposer
+
+  checkTokenBalance (DAO.frozenTokenId) dao owner2 0
+  checkTokenBalance (DAO.unfrozenTokenId) dao owner2 100 -- voter
+
+  -- Consumer contract is used in decision lambda and should contain accepted proposal
+  -- description.
+  checkStorage (AddressResolved $ toAddress consumer)
+    (toVal [([mt|Balance Item|] :: MText)])
+
+-------------------------------------------------------------------------------
+-- Helper
+-------------------------------------------------------------------------------
+sampleMetadataBalance :: Address -> GameDaoProposalMetadata
+sampleMetadataBalance consumerAddr = GameDaoProposalMetadata
+  { pmProposalType = BalanceType BalanceChange
+      { bcItemChanges = [ ItemChange
+          { icItemName = [mt|Ganto|]
+          , icChangelogs =
+              [ [mt|Ganto now has 10 charges.|]
+              , [mt|Ganto can now target enemey to reduce health regen.|]
+              ]
+          }]
+      , bcHeroChanges = []
+      }
+  , pmProposalDescription = [mt|Balance Item|]
+  , pmConsumerAddr = consumerAddr
+  }
+
+sampleMetadataContent :: Address -> GameDaoProposalMetadata
+sampleMetadataContent consumerAddr = GameDaoProposalMetadata
+  { pmProposalType = NewType [ NewContent
+      { ncContentName = [mt|TireDide|]
+      , ncContentDescription =
+          [ [mt|New Halloween event called TireDide.|]
+          , [mt|Each players play in a team of 5 fighting each other to gain the most candies.|]
+          ]
+      } ]
+  , pmProposalDescription = [mt|New Content Update|]
+  , pmConsumerAddr = consumerAddr
+  }
+
+createSampleProposal
+  :: MonadNettest caps base m
+  => GameDaoProposalMetadata -> Address -> TAddress Parameter -> m ByteString
+createSampleProposal pm owner1 dao = do
+  let params = DAO.ProposeParams
+        { ppFrozenToken = 10
+        , ppProposalMetadata = pm
+        }
+
+  callFrom (AddressResolved owner1) dao (Call @"Propose") params
+  pure $ (makeProposalKey params owner1)
+


### PR DESCRIPTION

## Description
Problem: Our `baseDAO` executable can print one simple DAO contract.
This contract is parameterized with `defaultConfig` which is the
simplest possible config. It doesn't check anything about proposals,
its decision lambda does nothing, it doesn't slash returned amount.
I think we need to provide a better example that could be practically useful.
The initial document we received contains 4 DAOs: Registry DAO, BakerDAO,
DEXDAO, GameDAO. We can implement one of them or come up with something else (inspired by these 4).

Solution: Use `GameDAO` from the google doc specification as example.
Add proper `proposalMetadata`, `proposalCheck`, and
`rejectedProposalValue` that makes sense for `GameDAO`.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #36 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
