### PR TITLE
[#29] Build and upload GameDAO documentation on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,10 +63,11 @@ steps:
   - label: contract doc development
     if: build.branch != "autodoc/master" && build.branch != "master"
     commands:
-      - nix-build ci.nix -A contracts-doc --arg release false
-      - ln -s ./result/BaseDAO.md BaseDAO.md
+    - nix-build ci.nix -A contracts-doc --arg release false
+    - ln -s ./result/*.md .
     artifact_paths:
       - BaseDAO.md
+      - GameDAO.md
 
   - label: contract doc release
     if: build.branch == "master"
@@ -74,9 +75,10 @@ steps:
     - nix-build ci.nix -A contracts-doc --arg release true
         --argstr commitSha "$(git rev-parse HEAD)"
         --argstr commitDate "$(git log HEAD -1 --format=%cd)"
-    - ln -s ./result/BaseDAO.md BaseDAO.md
+    - ln -s ./result/*.md .
     artifact_paths:
       - BaseDAO.md
+      - GameDAO.md
 
   - label: xrefcheck generated doc
     if: build.branch != "autodoc/master"
@@ -86,7 +88,7 @@ steps:
       then CONTRACT_DOC_STEP="contract doc release";
       else CONTRACT_DOC_STEP="contract doc development";
       fi
-    - buildkite-agent artifact download BaseDAO.md tmp/
+    - buildkite-agent artifact download "*.md" tmp/
         --step "$$CONTRACT_DOC_STEP"
     - nix run -f ci.nix xrefcheck -c xrefcheck
         --mode local-only --root tmp
@@ -95,6 +97,6 @@ steps:
     if: build.branch == "master"
     commands:
     - mkdir tmp
-    - buildkite-agent artifact download BaseDAO.md tmp/
+    - buildkite-agent artifact download "*.md" tmp/
         --step "contract doc release"
     - ./scripts/ci/upload-autodoc.sh

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ and Haskell programming language.
 
 The [specification](docs/specification.md) document is the specification used as a basis for the smart contract development.
 
-Documentation of the actually implemented smart contract is generated automatically and
-can be found [here](https://github.com/tqtezos/baseDAO/blob/autodoc/master/BaseDAO.md).
+Documentation of the actually implemented smart contract is generated automatically.
+* [BaseDAO](https://github.com/tqtezos/baseDAO/blob/autodoc/master/BaseDAO.md)
+* [GaseDAO](https://github.com/tqtezos/baseDAO/blob/autodoc/master/GameDAO.md)
 
 ## Build Instructions
 

--- a/ci.nix
+++ b/ci.nix
@@ -95,6 +95,7 @@ rec {
       mkdir $out
       cd $out
       baseDAO document --name BaseDAO --output BaseDAO.md
+      baseDAO document --name GameDAO --output GameDAO.md
     '';
 
   # nixpkgs has weeder 2, but we use weeder 1

--- a/scripts/ci/upload-autodoc.sh
+++ b/scripts/ci/upload-autodoc.sh
@@ -18,8 +18,8 @@ sha=$(git rev-parse --short HEAD)
 git checkout origin/$doc_branch
 git checkout -B $doc_branch
 git merge -X theirs origin/$our_branch -m "Merge $our_branch"
-mv tmp/BaseDAO.md BaseDAO.md
-git add BaseDAO.md
+mv tmp/*.md .
+git add BaseDAO.md GameDAO.md
 git commit --allow-empty -m "Documentation update for $sha"
 git push --set-upstream auth-origin $doc_branch
 git checkout @{-2}


### PR DESCRIPTION
## Description

Problem: we recently added `GameDAO` contract with its own
documentation.
However, this documentation is not generated and checked by our CI,
it's hard to access it.

Solution: generate, check and upload it as part of CI, the same way
as we do for `BaseDAO`.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

#29

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
