### PR TITLE
Update cleveland and morley-client revision

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ extra-deps:
   - git:
       https://gitlab.com/morley-framework/morley.git # CI can't use SSH
     commit:
-      3de9a9467d6cc160e690bc58a58ee48e98729d27 # master
+      13b57e14390c9bf77182b23fd97d8bdbc15f6a8a # master
     subdirs:
       - code/cleveland
       - code/morley-client

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -87,13 +87,13 @@ packages:
     version: 0.1.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 10541
-      sha256: 7d8d8ddc1504b4a4ac99ef0935e88ad8280efc8113a532fea22b2ddd873df11f
-    commit: 3de9a9467d6cc160e690bc58a58ee48e98729d27
+      size: 10694
+      sha256: 2207d58305e20f66c36e579bfad1e1c67e7562f7427d2150388b154c4acccfe2
+    commit: 13b57e14390c9bf77182b23fd97d8bdbc15f6a8a
   original:
     subdir: code/cleveland
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 3de9a9467d6cc160e690bc58a58ee48e98729d27
+    commit: 13b57e14390c9bf77182b23fd97d8bdbc15f6a8a
 - completed:
     subdir: code/morley-client
     name: morley-client
@@ -101,12 +101,12 @@ packages:
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
       size: 2818
-      sha256: f3c235bd36a37a9d7ab7d3a178cccbec56ab7632241d472ff8c08e796bc5432f
-    commit: 3de9a9467d6cc160e690bc58a58ee48e98729d27
+      sha256: 0f8be7c7d90f415caba2aa0358600605b8bd03d92e2b6c134955ff048333ab80
+    commit: 13b57e14390c9bf77182b23fd97d8bdbc15f6a8a
   original:
     subdir: code/morley-client
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 3de9a9467d6cc160e690bc58a58ee48e98729d27
+    commit: 13b57e14390c9bf77182b23fd97d8bdbc15f6a8a
 - completed:
     name: caps
     version: '0'


### PR DESCRIPTION
## Description

Problem: our tests are quite slow, but recently one speed-up was
merged to cleveland, see
https://gitlab.com/morley-framework/morley/-/merge_requests/631
We would like to use it here to potentially speed-up existing tests.

Solution: update git commit of the `morley` repo.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

None

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
