### PR TITLE
[#38] Optimize `flush` slightly

### DIFF
--- a/src/Lorentz/Contracts/BaseDAO/Token.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Token.hs
@@ -10,7 +10,7 @@ module Lorentz.Contracts.BaseDAO.Token
   ) where
 
 import Lorentz
-import Lorentz.Contracts.BaseDAO.Doc(burnDoc, mintDoc, transferContractTokensDoc, tokenAddressDoc)
+import Lorentz.Contracts.BaseDAO.Doc (burnDoc, mintDoc, tokenAddressDoc, transferContractTokensDoc)
 import Lorentz.Contracts.BaseDAO.Management (authorizeAdmin, ensureNotMigrated)
 import Lorentz.Contracts.BaseDAO.Token.FA2 (creditTo, debitFrom)
 import Lorentz.Contracts.BaseDAO.Types
@@ -19,7 +19,8 @@ import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
 burn
-  :: forall store ce pm s. (StorageC store ce pm, HasFuncContext s store)
+  :: forall store ce pm s.
+     (StorageC store ce pm, HasFuncContext s store (TransferFuncs store))
   => Entrypoint' BurnParam store s
 burn = do
   doc $ DDescription burnDoc
@@ -38,7 +39,8 @@ burn = do
   nil; pair
 
 mint
-  :: forall store ce pm s. (StorageC store ce pm, HasFuncContext s store)
+  :: forall store ce pm s.
+     (StorageC store ce pm, HasFuncContext s store (TransferFuncs store))
   => Entrypoint' MintParam store s
 mint = do
   doc $ DDescription mintDoc

--- a/src/Lorentz/Contracts/BaseDAO/Token/FA2.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Token/FA2.hs
@@ -27,19 +27,19 @@ defaultPermissionsDescriptor = PermissionsDescriptor
   }
 
 transfer
-  :: forall ce pm s.
-     (IsoValue ce, KnownValue pm, HasFuncContext s (Storage ce pm))
-  => Entrypoint' TransferParams (Storage ce pm) s
+  :: forall store ce pm s.
+     (StorageC store ce pm, HasFuncContext s store (TransferFuncs store))
+  => Entrypoint' TransferParams store s
 transfer = do
   doc $ DDescription transferDoc
   dip ensureNotMigrated
   iter transferItem
   nil; pair
   where
-    transferItem :: (TransferItem : Storage ce pm : s) :-> (Storage ce pm : s)
+    transferItem :: (TransferItem : store : s) :-> (store : s)
     transferItem = do
       swap
-      getField #sAdmin
+      stGetField #sAdmin
       Lorentz.sender
       eq
       dig @2
@@ -52,7 +52,7 @@ transfer = do
       iter transferOne
       dropN @2
 
-    transferOne :: TransferDestination : Bool : "from" :! Address : Storage ce pm : s :-> Bool : "from" :! Address : Storage ce pm : s
+    transferOne :: TransferDestination : Bool : "from" :! Address : store : s :-> Bool : "from" :! Address : store : s
     transferOne = do
       swap
       dup
@@ -98,24 +98,20 @@ transfer = do
       swap
 
     checkSender
-      :: forall f. ("from" :! Address) : Storage ce pm : f
-      :-> ("from" :! Address) : Storage ce pm : f
+      :: forall f. ("from" :! Address) : store : f
+      :-> ("from" :! Address) : store : f
     checkSender = do
       dup; fromNamed #from
       Lorentz.sender
       if IsEq
       then nop
       else do
-        dup
-        dig @2
-        getField #sOperators
-        swap
-        dug @3
-        swap; fromNamed #from; toNamed #owner
+        dupTop2
+        fromNamed #from; toNamed #owner
         Lorentz.sender; toNamed #operator
         swap
         pair
-        mem
+        stMem #sOperators
         if_ nop (failCustom_ #fA2_NOT_OPERATOR)
 
 debitFrom

--- a/src/Lorentz/Contracts/BaseDAO/Token/FA2.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Token/FA2.hs
@@ -120,7 +120,7 @@ transfer = do
 
 debitFrom
   :: forall store ce pm. (StorageC store ce pm, IsoValue store)
-  => CachedFunc "debitFrom" [store, Address, (TokenId, Natural)] '[store]
+  => DebitFromFunc store
 debitFrom = mkCachedFunc $ do
   dig @2
   unpair
@@ -178,7 +178,7 @@ debitFrom = mkCachedFunc $ do
 
 creditTo
   :: forall pm ce store. (StorageC store ce pm, IsoValue store)
-  => CachedFunc "creditTo" [store, Address, (TokenId, Natural)] '[store]
+  => CreditToFunc store
 creditTo = mkCachedFunc $ do
   dig @2
   unpair

--- a/src/Lorentz/Contracts/BaseDAO/Types.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Types.hs
@@ -35,6 +35,9 @@ module Lorentz.Contracts.BaseDAO.Types
   , mkCachedFunc
   , pushCachedFunc
   , callCachedFunc
+
+  , DebitFromFunc
+  , CreditToFunc
   , HasFuncContext
 
   , Entrypoint'
@@ -378,16 +381,26 @@ callCachedFunc (CachedFunc l f :: CachedFunc n i o) = do
   dupL l
   execute @i @o @s
 
+-- Cached functions context of the contract
+------------------------------------------------------------------------
+
+type DebitFromFunc store =
+  CachedFunc "debitFrom" [store, Address, (FA2.TokenId, Natural)] '[store]
+
+type CreditToFunc store =
+  CachedFunc "creditTo" [store, Address, (FA2.TokenId, Natural)] '[store]
+
+type family IncludesFunc f where
+  IncludesFunc (CachedFunc n i o) = n := (i :-> o)
+
 -- | Indicates that we keep some functions on stack in order to include
 -- them only once in the contract.
 type HasFuncContext s store =
   ( IsoValue store
   , VarIsUnnamed store
   , HasNamedVars s
-    [ "creditTo"
-        := '[store, Address, (FA2.TokenId, Natural)] :-> '[store]
-    , "debitFrom"
-        := '[store, Address, (FA2.TokenId, Natural)] :-> '[store]
+    [ IncludesFunc (DebitFromFunc store)
+    , IncludesFunc (CreditToFunc store)
     ]
   )
 

--- a/src/Lorentz/Contracts/BaseDAO/Types.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Types.hs
@@ -32,13 +32,18 @@ module Lorentz.Contracts.BaseDAO.Types
   , mkStorage
 
   , CachedFunc (..)
+  , PushedFunc
   , mkCachedFunc
   , pushCachedFunc
+  , pushCachedFuncSimple
   , callCachedFunc
 
   , DebitFromFunc
   , CreditToFunc
+  , UnfreezeProposerTokenFunc
   , HasFuncContext
+  , TransferFuncs
+  , AllFuncs
 
   , Entrypoint'
 
@@ -68,7 +73,6 @@ import Michelson.Typed.T
 import Michelson.Untyped.Annotation
 import Tezos.Address
 import Util.Markdown
-import Util.Named
 import Util.Type
 import Util.TypeLits
 
@@ -98,7 +102,9 @@ data Config contractExtra proposalMetadata = Config
   -- only 50 tokens will be unfrozen and other 50 tokens will be burnt.
 
   , cDecisionLambda :: forall s store.
-     (StorageC store contractExtra proposalMetadata, HasFuncContext s store)
+     ( StorageC store contractExtra proposalMetadata
+     , HasFuncContext s store (AllFuncs store contractExtra proposalMetadata)
+     )
     => Proposal proposalMetadata : store : s
     :-> List Operation : store : s
   -- ^ The decision lambda is executed based on a successful proposal.
@@ -346,23 +352,55 @@ mkStorage admin votingPeriod quorumThreshold extra =
 --
 -- We also attach a name to the function, so that we don't not need
 -- to remember the names.
-data CachedFunc n i o =
+--
+-- @f@ type argument stands for other cached functions this function
+-- would like to call. If you don't care, use @'[]@.
+data CachedFunc n f i o =
   (Each [KnownList, ZipInstr] [i, o]) =>
-  CachedFunc (Label n) (i :-> o)
+  CachedFunc (Label n) ((i ++ f) :-> (o ++ f))
+
+-- | How function is represented when pushed on stack.
+type family PushedFunc f where
+  PushedFunc (CachedFunc n _ i o) = n :! (i :-> o)
 
 -- | Construct a 'CachedFunc' object.
 mkCachedFunc
   :: (KnownSymbol n, Each [KnownList, ZipInstr] [i, o])
-  => i :-> o -> CachedFunc n i o
+  => (i ++ f) :-> (o ++ f) -> CachedFunc n f i o
 mkCachedFunc = CachedFunc fromLabel
 
 -- | Push 'CachedFunc' on stack so that it is later accessible by
 -- 'callCachedFunc'.
 pushCachedFunc
-  :: (NiceConstant (i :-> o))
-  => CachedFunc n i o
-  -> s :-> n :! (i :-> o) : s
-pushCachedFunc (CachedFunc Label f) = push (fromLabel .! f)
+  :: ( func ~ CachedFunc n f i o
+     , NiceConstant (i :-> o), KnownValue (f ++ i :-> o)
+     )
+  => func
+  -> ((f ++ i) :-> o) : s :-> (i :-> o) : s
+     -- ^ Feed our function with all functions it wants to call.
+     -- This is usually a sequence of 'dupL's and 'applicate's.
+  -> (f ++ i) :-> (i ++ f)
+     -- ^ Drop cached functions to the bottom of the stack.
+     -- Usually this is a sequence of 'dug's.
+  -> (o ++ f :-> o)
+    -- ^ Remove pushed functions in the end.
+    -- Use: dipN @oLen (dropN @fLen)
+  -> s :-> PushedFunc func : s
+pushCachedFunc (CachedFunc Label f) injectFuncs pullFuncsDown cleanupFuncs = do
+  push (pullFuncsDown # f # cleanupFuncs)
+  injectFuncs
+  toNamed fromLabel
+
+-- | 'pushCachedFunc' specialized to case when given function
+-- does not need to call any other function.
+pushCachedFuncSimple
+ :: ( func ~ CachedFunc n f i o, f ~ '[]
+    , NiceConstant (i :-> o)
+    , (i ++ '[]) ~ i, (o ++ '[]) ~ o
+    )
+  => func
+  -> s :-> PushedFunc func : s
+pushCachedFuncSimple f = pushCachedFunc f nop nop nop
 
 -- | Call a function that previously was pushed on stack.
 --
@@ -371,12 +409,14 @@ pushCachedFunc (CachedFunc Label f) = push (fromLabel .! f)
 --
 -- You have to provide the original 'CachedFunc' object here,
 -- this is necessary to inherit the documentation of the function.
+-- Calling cached functions bypassing this method is dangerous as
+-- it documentation related to the called lambda may got lost.
 callCachedFunc
-  :: forall i o n s.
+  :: forall i o f n s.
      (HasNamedVar (i ++ s) n (i :-> o))
-  => CachedFunc n i o
+  => CachedFunc n f i o
   -> (i ++ s) :-> (o ++ s)
-callCachedFunc (CachedFunc l f :: CachedFunc n i o) = do
+callCachedFunc (CachedFunc l f :: CachedFunc n f i o) = do
   cutLorentzNonDoc f
   dupL l
   execute @i @o @s
@@ -385,24 +425,44 @@ callCachedFunc (CachedFunc l f :: CachedFunc n i o) = do
 ------------------------------------------------------------------------
 
 type DebitFromFunc store =
-  CachedFunc "debitFrom" [store, Address, (FA2.TokenId, Natural)] '[store]
+  CachedFunc "debitFrom" '[] [store, Address, (FA2.TokenId, Natural)] '[store]
 
 type CreditToFunc store =
-  CachedFunc "creditTo" [store, Address, (FA2.TokenId, Natural)] '[store]
+  CachedFunc "creditTo" '[] [store, Address, (FA2.TokenId, Natural)] '[store]
+
+type UnfreezeProposerTokenFunc store pm =
+  CachedFunc "unfreezeProposerToken"
+    [PushedFunc (CreditToFunc store), PushedFunc (DebitFromFunc store)]
+    ["isAccepted" :! Bool, Proposal pm, store, ProposalKey pm, [Operation]]
+    [Proposal pm, store, ProposalKey pm, [Operation]]
 
 type family IncludesFunc f where
-  IncludesFunc (CachedFunc n i o) = n := (i :-> o)
+  IncludesFunc (CachedFunc n _ i o) = n := (i :-> o)
+
+type family IncludesFuncs f where
+  IncludesFuncs '[] = '[]
+  IncludesFuncs (f : fs) = IncludesFunc f ': IncludesFuncs fs
 
 -- | Indicates that we keep some functions on stack in order to include
 -- them only once in the contract.
-type HasFuncContext s store =
-  ( IsoValue store
+type HasFuncContext s store funcs =
+  ( KnownValue store
   , VarIsUnnamed store
-  , HasNamedVars s
-    [ IncludesFunc (DebitFromFunc store)
-    , IncludesFunc (CreditToFunc store)
-    ]
+  , HasNamedVars s (IncludesFuncs funcs)
   )
+
+-- | Pass this to 'HasFuncContext' to require transfers-related functions.
+type TransferFuncs store =
+  [ DebitFromFunc store
+  , CreditToFunc store
+  ]
+
+-- | Pass this to 'HasFuncContext' to require all cached functions.
+type AllFuncs store ce pm =
+  [ DebitFromFunc store
+  , CreditToFunc store
+  , UnfreezeProposerTokenFunc store pm
+  ]
 
 ------------------------------------------------------------------------
 -- Misc

--- a/test/Test/BaseDAO/ProposalConfig.hs
+++ b/test/Test/BaseDAO/ProposalConfig.hs
@@ -56,7 +56,9 @@ decisionLambdaConfig = config
   { DAO.cDecisionLambda = decisionLambda
   }
   where
-    decisionLambda :: forall s store. (DAO.StorageC store ce pm, DAO.HasFuncContext s store)
+    decisionLambda
+      :: forall s store.
+         (DAO.StorageC store ce pm, DAO.HasFuncContext s store (DAO.AllFuncs store ce pm))
       => (DAO.Proposal pm) : store : s
       :-> List Operation : store : s
     decisionLambda = do


### PR DESCRIPTION
## Description

Extract `unfreezeProposerTokens` since it is used 3 times and costs ~1300 bytes in overall.

**TODO:** this depends on an [MR in Morley](https://gitlab.com/morley-framework/morley/-/merge_requests/679), I'll measure the contract size once everything works.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves (partially) #38

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
