### PR TITLE
[#69] Allow `flush` to accepts an amout of proposals, add `dropProposals` entrypoint

### DIFF
--- a/src/Lorentz/Contracts/BaseDAO.hs
+++ b/src/Lorentz/Contracts/BaseDAO.hs
@@ -71,6 +71,7 @@ baseDaoContract config@Config{..} = defaultContract $ contractName cDaoName $ do
       , #cGetVotePermitCounter /-> view_ $ do
           doc $ DDescription getVotePermitCounterDoc
           drop @(); stToField #sPermitsCounter
+      , #cDrop_proposal /-> dropProposal config
       )
 
 fa2Handler

--- a/src/Lorentz/Contracts/BaseDAO/Doc.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Doc.hs
@@ -21,6 +21,7 @@ module Lorentz.Contracts.BaseDAO.Doc
    , setVotingPeriodDoc
    , setQuorumThresholdDoc
    , flushDoc
+   , dropProposalDoc
 
    , burnDoc
    , mintDoc
@@ -145,6 +146,15 @@ flushDoc = [md|
   There is a possibility of some tokens being lost due to administrator perform
   of burn or transfer operation.
   If the proposal is accepted, the decision lambda is called.
+  |]
+
+dropProposalDoc :: Markdown
+dropProposalDoc = [md|
+  Delete a finished and accepted proposal that is not flushed. Tokens frozen for this
+  proposal are returned to the proposer and voters in full. The decision lambda is skipped.
+
+  This entrypoint should only be used when there is a proposal that is stuck due to having a
+  failing decision lambda.
   |]
 
 burnDoc :: Markdown

--- a/test/Test/GameDAO.hs
+++ b/test/Test/GameDAO.hs
@@ -78,7 +78,7 @@ flushAcceptedProposals = uncapsNettest $ do
   checkTokenBalance (DAO.unfrozenTokenId) dao owner2 97
 
   advanceTime (sec 21)
-  callFrom (AddressResolved admin) dao (Call @"Flush") ()
+  callFrom (AddressResolved admin) dao (Call @"Flush") Nothing
 
   checkTokenBalance (DAO.frozenTokenId) dao owner1 0
   checkTokenBalance (DAO.unfrozenTokenId) dao owner1 100 -- proposer


### PR DESCRIPTION
## Description
Problem: When calling `flush`, `decisionLambda` or `rejectedValue` lambda may fail due to unexpected error. We should have a way to drop some proposals and a way to not flush proposals all at one.

Solution: 
- Refactor `sProposalKeyListSortByDate` to be a map with `(Timestamp, ProposalKey proposalMetadata)` as the key, and `()` as the value (Since value here is not important).
- Add `dropProposals` entrypoint
- Update `flush` entrypoint to accept a (Maybe Natural)
- Add tests for these new features

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #69

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
