### PR TITLE
Fix RegistryDAO tests failling during scheduled delphinet tests

### DIFF
--- a/test/Test/RegistryDAO.hs
+++ b/test/Test/RegistryDAO.hs
@@ -27,7 +27,10 @@ test_RegistryDAO :: TestTree
 test_RegistryDAO = testGroup "RegistryDAO Tests"
   [ testGroup "Proposal creator:"
       [ nettestScenario "can propose a valid proposal" validProposal
-      , nettestScenario "can propose a valid configuration proposal" validConfigProposal
+
+      -- TODO [#47]: Disable running in real network due to time-sensitive operations
+      , nettestScenarioOnEmulator "can propose a valid configuration proposal" $
+          \_emulated -> validConfigProposal
       ]
   ]
 


### PR DESCRIPTION
## Description

Problem: `validConfigProposal` test in RegistyDAO contains
time-sensitive operations (`flush`). This currently does not work well
in delphinet tests.

Solution: Only run the test in emulator for now.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
