### PR TITLE
Fix delphinet failing due to short voting period

### DIFF
--- a/test/Test/BaseDAO/Proposal.hs
+++ b/test/Test/BaseDAO/Proposal.hs
@@ -129,7 +129,7 @@ nonUniqueProposal = uncapsNettest $ do
 
 voteValidProposal :: (Monad m) => NettestImpl m -> m ()
 voteValidProposal = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () config
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () voteConfig
 
   -- | Create sample proposal (first proposal has id = 0)
   key1 <- createSampleProposal 1 owner1 dao
@@ -161,7 +161,7 @@ voteNonExistingProposal = uncapsNettest $ do
 
 voteMultiProposals :: (Monad m) => NettestImpl m -> m ()
 voteMultiProposals = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () config
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () voteConfig
 
   -- | Create sample proposal
   key1 <- createSampleProposal 1 owner1 dao
@@ -186,7 +186,7 @@ voteMultiProposals = uncapsNettest $ do
 
 insufficientTokenVote :: (Monad m) => NettestImpl m -> m ()
 insufficientTokenVote = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () config
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () voteConfig
 
   -- | Create sample proposal
   key1 <- createSampleProposal 1 owner1 dao
@@ -228,7 +228,7 @@ voteOutdatedProposal = uncapsNettest $ do
 
 voteWithPermit :: (Monad m) => NettestImpl m -> m ()
 voteWithPermit = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () config
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () voteConfig
 
   -- | Create sample proposal
   key1 <- createSampleProposal 1 owner1 dao
@@ -245,7 +245,7 @@ voteWithPermit = uncapsNettest $ do
 
 voteWithPermitNonce :: (Monad m) => NettestImpl m -> m ()
 voteWithPermitNonce = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () config
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () voteConfig
 
   -- | Create sample proposal
   key1 <- createSampleProposal 1 owner1 dao
@@ -561,7 +561,7 @@ proposalBoundedValue = uncapsNettest $ do
 
 votesBoundedValue :: (Monad m) => NettestImpl m -> m ()
 votesBoundedValue = uncapsNettest $ do
-  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () (config { DAO.cMaxVotes = 1})
+  ((owner1, _), (owner2, _), dao, _) <- originateBaseDaoWithConfig @Integer @Empty () (voteConfig { DAO.cMaxVotes = 1})
 
   key1 <- createSampleProposal 1 owner2 dao
   let upvote = DAO.NoPermit DAO.VoteParam

--- a/test/Test/BaseDAO/ProposalConfig.hs
+++ b/test/Test/BaseDAO/ProposalConfig.hs
@@ -9,6 +9,7 @@ module Test.BaseDAO.ProposalConfig
   , configWithRejectedProposal
   , badRejectedValueConfig
   , decisionLambdaConfig
+  , voteConfig
   ) where
 
 import Lorentz
@@ -30,6 +31,16 @@ config = DAO.defaultConfig
         push True
       else
         push False
+  , DAO.cMinVotingPeriod = 20
+  , DAO.cMinQuorumThreshold = 1
+  }
+
+-- | Config with longer voting period and bigger quorum threshold
+-- Needed for vote related tests that do not call `flush`
+voteConfig :: forall ce pm op. (IsoValue pm) => DAO.Config ce pm op
+voteConfig = config
+  { DAO.cMinVotingPeriod = 120
+  , DAO.cMinQuorumThreshold = 4
   }
 
 configWithRejectedProposal :: forall ce pm op. (IsoValue pm) => DAO.Config ce pm op

--- a/test/Test/Common.hs
+++ b/test/Test/Common.hs
@@ -68,6 +68,7 @@ originateBaseDaoWithConfig contractExtra config = do
         ]
     )
 
+-- TODO: [#96] Add a way to customize storage
 originateBaseDaoWithBalance
   :: forall pm op ce caps base m.
      (DAO.DaoC ce pm op, MonadNettest caps base m)
@@ -98,8 +99,8 @@ originateBaseDaoWithBalance contractExtra config balFunc = do
           ( mkStorage
           ! #admin admin
           ! #extra contractExtra
-          ! #votingPeriod 20
-          ! #quorumThreshold 1
+          ! #votingPeriod (cMinVotingPeriod config)
+          ! #quorumThreshold (cMinQuorumThreshold config)
           ! #metadata mempty
           ! defaults
           ) { sLedger = BigMap bal


### PR DESCRIPTION
## Description

Problem: The recent change makes the default storage having short voting
period. This results in a few tests failing due to time sensitive operation.

Solution: Set a longer voting period for those tests.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

None

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
