### PR TITLE
[#97] Remove metadata type annotation

### DIFF
--- a/src/Lorentz/Contracts/BaseDAO/Types.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Types.hs
@@ -228,7 +228,7 @@ data Storage (contractExtra :: Kind.Type) (proposalMetadata :: Kind.Type) = Stor
 
   , sPermitsCounter :: Nonce
 
-  , sMetadata :: "metadata" :! TZIP16.MetadataMap BigMap
+  , sMetadata :: TZIP16.MetadataMap BigMap
   }
   deriving stock (Generic, Show)
 
@@ -343,7 +343,7 @@ mkStorage admin votingPeriod quorumThreshold extra metadata =
   , sProposalKeyListSortByDate = mempty
   , sPermitsCounter = Nonce 0
 
-  , sMetadata = metadata
+  , sMetadata = arg #metadata metadata
   }
   where
     votingPeriodDef = 60 * 60 * 24 * 7  -- 7 days


### PR DESCRIPTION
## Description

This removes the redundant `:metadata` type annotation from the TZIP-16 metadata big_map.

Note: this resolves the issue because the `s` prefix problem has already been handled by 23189df87e4aa02d15b0bf3e727d452622a8c93d

## Related issue(s)

Resolves #97

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
