### PR TITLE
[#106] Update LIGO `failwith` to be the same as Lorentz version

### DIFF
--- a/docs/specification-ligo.md
+++ b/docs/specification-ligo.md
@@ -183,7 +183,7 @@ and the balance of the `to_` addresses is increased according to the transferred
 
 # Errors
 
-In error scenarios the baseDAO contract fails with a string.
+In error scenarios the baseDAO contract fails with a string or a pair where the first item is a string.
 Here is a summary of all the strings used as error messages.
 We start with standard FA2 errors which are part of the FA2 specification.
 

--- a/ligo/src/base_DAO.mligo
+++ b/ligo/src/base_DAO.mligo
@@ -26,7 +26,9 @@ let base_DAO_contract
             | M_right (fbp) ->
                 let result =
                   if Tezos.amount > 0tez
-                    then (failwith "FORBIDDEN_XTZ" : return)
+                    then
+                      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
+                        ("FORBIDDEN_XTZ", ()) : return)
                     else
                       begin
                         match fbp with

--- a/ligo/src/common.mligo
+++ b/ligo/src/common.mligo
@@ -10,6 +10,7 @@ let authorize_admin (store : storage): storage =
   if sender = store.admin then
     store
   else
-    (failwith("NOT_ADMIN"): storage)
+    ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
+        ("NOT_ADMIN", ()) : storage)
 
 #endif

--- a/ligo/src/management.mligo
+++ b/ligo/src/management.mligo
@@ -11,7 +11,9 @@ let ensure_not_migrated (storage : storage): storage =
   match storage.migration_status with
       Not_in_migration -> storage
     | MigratingTo (p) -> storage
-    | MigratedTo (p) -> (failwith ("MIGRATED") : storage)
+    | MigratedTo (new_addr) ->
+        ([%Michelson ({| { FAILWITH } |} : string * address -> storage)]
+          ("MIGRATED", new_addr) : storage)
 
 (*
  * Auth checks for admin and store the address in parameter to the
@@ -30,7 +32,9 @@ let transfer_ownership
 let accept_ownership(param, store : unit * storage) : return =
   if store.pending_owner = Tezos.sender
     then (([] : operation list), { store with admin = store.pending_owner })
-    else (failwith("NOT_PENDING_ADMIN") : return)
+    else
+      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
+        ("NOT_PENDING_ADMIN", ()) : return)
 
 (*
  * Auth check for admin and sets the migration status to 'MigratingTo' using
@@ -47,11 +51,17 @@ let migrate(param, store : migrate_param * storage) : return =
  *)
 let confirm_migration(param, store : unit * storage) : return =
   match store.migration_status with
-    Not_in_migration -> (failwith("NOT_MIGRATING") : return)
+    Not_in_migration ->
+      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
+        ("NOT_MIGRATING", ()) : return)
   | MigratingTo (new_addr) -> if new_addr = Tezos.sender
       then (([] : operation list), { store with migration_status = MigratedTo (new_addr) })
-      else (failwith("NOT_MIGRATION_TARGET") : return)
-  | MigratedTo (new_addr)  -> (failwith("MIGRATED") : return)
+      else
+        ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
+          ("NOT_MIGRATION_TARGET", ()) : return)
+  | MigratedTo (new_addr)  ->
+      ([%Michelson ({| { FAILWITH } |} : string * address -> return)]
+        ("MIGRATED", new_addr) : return)
 
 (*
  * Call a custom entrypoint. Looks up the packed code for entrypoint using the entrypoint
@@ -71,6 +81,10 @@ let call_custom(param, full_storage : custom_ep_param * full_storage) : return_w
       begin
         match ((Bytes.unpack ep_code) : ((bytes * full_storage) -> return_with_full_storage) option) with
           Some lambda -> lambda (packed_param, full_storage)
-        | None -> (failwith("UNPACKING_FAILED") : return_with_full_storage)
+        | None ->
+            ([%Michelson ({| { FAILWITH } |} : string * unit -> return_with_full_storage)]
+              ("UNPACKING_FAILED", ()) : return_with_full_storage)
       end
-  | None -> (failwith("ENTRYPOINT_NOT_FOUND") : return_with_full_storage)
+  | None ->
+      ([%Michelson ({| { FAILWITH } |} : string * unit -> return_with_full_storage)]
+        ("ENTRYPOINT_NOT_FOUND", ()) : return_with_full_storage)

--- a/ligo/src/token.mligo
+++ b/ligo/src/token.mligo
@@ -33,5 +33,6 @@ let transfer_contract_tokens
       let transfer_operation = Tezos.transaction param.params 0mutez contract
       in (([transfer_operation] : operation list), store)
   | None ->
-      (failwith("FAIL_TRANSFER_CONTRACT_TOKENS"): return)
+      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
+        ("FAIL_TRANSFER_CONTRACT_TOKENS", ()) : return)
 

--- a/ligo/test/Test/Ligo/BaseDAO/Management.hs
+++ b/ligo/test/Test/Ligo/BaseDAO/Management.hs
@@ -115,7 +115,7 @@ test_BaseDAO_Management =
               callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
               callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
                 (#newOwner .! newOwner)
-                & expectMigrated
+                & expectMigrated newAddress1
     ]
   , testGroup "Accept Ownership"
       [ nettestScenarioCaps "authenticates the sender" $
@@ -154,7 +154,7 @@ test_BaseDAO_Management =
               -- We test this by calling `confirmMigration` and seeing that it does not fail
               callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
               callFrom (AddressResolved owner) baseDao (Call @"Accept_ownership") ()
-                & expectMigrated
+                & expectMigrated newAddress1
       ]
 
   , testGroup "Migration"
@@ -208,7 +208,7 @@ test_BaseDAO_Management =
               -- We test this by calling `confirmMigration` and seeing that it does not fail
               callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
               callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                & expectMigrated
+                & expectMigrated newAddress1
      ]
 
   , testGroup "Custom entrypoints"
@@ -243,29 +243,29 @@ test_BaseDAO_Management =
 expectNotAdmin
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectNotAdmin act = expectFailure act (NettestFailedWithError [mt|NOT_ADMIN|])
+expectNotAdmin = expectCustomError_ #nOT_ADMIN
 
 expectNotPendingOwner
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectNotPendingOwner act = expectFailure act (NettestFailedWithError [mt|NOT_PENDING_ADMIN|])
+expectNotPendingOwner = expectCustomError_ #nOT_PENDING_ADMIN
 
 expectNotMigrating
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectNotMigrating act = expectFailure act (NettestFailedWithError [mt|NOT_MIGRATING|])
+expectNotMigrating = expectCustomError_ #nOT_MIGRATING
 
 expectNotMigrationTarget
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectNotMigrationTarget act = expectFailure act (NettestFailedWithError [mt|NOT_MIGRATION_TARGET|])
+expectNotMigrationTarget = expectCustomError_ #nOT_MIGRATION_TARGET
 
 expectMigrated
   :: (MonadNettest caps base m)
-  => m a -> m ()
-expectMigrated act = expectFailure act (NettestFailedWithError [mt|MIGRATED|])
+  => Address -> m a -> m ()
+expectMigrated addr = expectCustomError #mIGRATED addr
 
 expectForbiddenXTZ
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectForbiddenXTZ act = expectFailure act (NettestFailedWithError [mt|FORBIDDEN_XTZ|])
+expectForbiddenXTZ = expectCustomError_ #fORBIDDEN_XTZ

--- a/ligo/test/Test/Ligo/BaseDAO/Token.hs
+++ b/ligo/test/Test/Ligo/BaseDAO/Token.hs
@@ -20,7 +20,7 @@ import Test.Ligo.BaseDAO.Common
 test_BaseDAO_Token :: TestTree
 test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
   [ nettestScenario "can burn tokens from any accounts"
-      $ uncapsNettest $ Share.burnScenario False
+      $ uncapsNettest $ Share.burnScenario
         $ originateLigoDaoWithBalance
           (\o1 _ ->
               [ ((o1, DAO.unfrozenTokenId), 10)
@@ -28,7 +28,7 @@ test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
               ]
           )
   , nettestScenario "can mint tokens to any accounts"
-      $ uncapsNettest $ Share.mintScenario False
+      $ uncapsNettest $ Share.mintScenario
         $ originateLigoDaoWithBalance
           (\o1 _ ->
               [ ((o1, DAO.unfrozenTokenId), 0)
@@ -36,5 +36,5 @@ test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
               ]
           )
   , nettestScenario "can call transfer tokens entrypoint"
-      $ uncapsNettest $ Share.transferContractTokensScenario False originateLigoDao
+      $ uncapsNettest $ Share.transferContractTokensScenario originateLigoDao
   ]

--- a/ligo/test/Test/Ligo/BaseDAO/Token/FA2.hs
+++ b/ligo/test/Test/Ligo/BaseDAO/Token/FA2.hs
@@ -63,16 +63,15 @@ test_BaseDAO_FA2 = testGroup "BaseDAO FA2 tests:"
                 ]
             )
     ]
-  -- TODO #100: Migration not implemented
-  -- , testGroup "Entrypoints respect migration status"
-  --     [ nettestScenario "transfer respects migration status"
-  --         $ uncapsNettest $ Share.transferAfterMigrationScenario originateLigoDao
-  --     , nettestScenario "update operator respects migration status "
-  --         $ uncapsNettest $ Share.updatingOperatorAfterMigrationScenario originateLigoDao
-  --     , nettestScenario "balanceOf request respects migration status"
-  --         $ uncapsNettest $ Share.balanceOfRequestAfterMigrationScenario originateLigoDao
-  --     , nettestScenario "tokenMetadataRegistry request respects migration status"
-  --         $ uncapsNettest $ Share.tokenMetadataRegistryRequestAfterMigrationScenario originateLigoDao
-  --     ]
+  , testGroup "Entrypoints respect migration status"
+      [ nettestScenario "transfer respects migration status"
+          $ uncapsNettest $ Share.transferAfterMigrationScenario originateLigoDao
+      , nettestScenario "update operator respects migration status "
+          $ uncapsNettest $ Share.updatingOperatorAfterMigrationScenario originateLigoDao
+      , nettestScenario "balanceOf request respects migration status"
+          $ uncapsNettest $ Share.balanceOfRequestAfterMigrationScenario originateLigoDao
+      , nettestScenario "tokenMetadataRegistry request respects migration status"
+          $ uncapsNettest $ Share.tokenMetadataRegistryRequestAfterMigrationScenario originateLigoDao
+      ]
   ]
 

--- a/ligo/test/Test/Ligo/BaseDAO/Token/FA2.hs
+++ b/ligo/test/Test/Ligo/BaseDAO/Token/FA2.hs
@@ -22,41 +22,41 @@ test_BaseDAO_FA2 :: TestTree
 test_BaseDAO_FA2 = testGroup "BaseDAO FA2 tests:"
   [ testGroup "Operator:"
       [ nettestScenario "allows zero transfer from non-existent operator"
-          $ uncapsNettest $ Share.zeroTransferScenario False originateLigoDao
+          $ uncapsNettest $ Share.zeroTransferScenario originateLigoDao
       , nettestScenario "allows valid transfer and check balance"
-          $ uncapsNettest $ Share.validTransferScenario False originateLigoDao
+          $ uncapsNettest $ Share.validTransferScenario originateLigoDao
       , nettestScenario "validates token id"
-          $ uncapsNettest $ Share.validateTokenScenario False originateLigoDao
+          $ uncapsNettest $ Share.validateTokenScenario originateLigoDao
       , nettestScenario "accepts an empty list of transfers"
-          $ uncapsNettest $ Share.emptyTransferListScenario False originateLigoDao
+          $ uncapsNettest $ Share.emptyTransferListScenario originateLigoDao
       , nettestScenario "aborts if there is a failure (due to low balance)"
-          $ uncapsNettest $ Share.lowBalanceScenario False originateLigoDao
+          $ uncapsNettest $ Share.lowBalanceScenario originateLigoDao
       , nettestScenario "aborts if there is a failure (due to non existent source account)"
-          $ uncapsNettest $ Share.noSourceAccountScenario False originateLigoDao
+          $ uncapsNettest $ Share.noSourceAccountScenario originateLigoDao
       , nettestScenario "aborts if there is a failure (due to bad operator)"
-          $ uncapsNettest $ Share.badOperatorScenario False originateLigoDao
+          $ uncapsNettest $ Share.badOperatorScenario originateLigoDao
       , nettestScenario "cannot transfer foreign money"
-          $ uncapsNettest $ Share.noForeignMoneyScenario False originateLigoDao
+          $ uncapsNettest $ Share.noForeignMoneyScenario originateLigoDao
       ]
   , testGroup "Owner:"
       [ nettestScenario "allows valid transfer and check balance"
-          $ uncapsNettest $ Share.validTransferOwnerScenario False originateLigoDao
+          $ uncapsNettest $ Share.validTransferOwnerScenario originateLigoDao
       , nettestScenario "allows updating operator "
-          $ uncapsNettest $ Share.updatingOperatorScenario False originateLigoDao
+          $ uncapsNettest $ Share.updatingOperatorScenario originateLigoDao
       , nettestScenario "allows balanceOf request"
-          $ uncapsNettest $ Share.balanceOfOwnerScenario False originateLigoDao
+          $ uncapsNettest $ Share.balanceOfOwnerScenario originateLigoDao
       , nettestScenario "validates token id"
-          $ uncapsNettest $ Share.validateTokenOwnerScenario False originateLigoDao
+          $ uncapsNettest $ Share.validateTokenOwnerScenario originateLigoDao
       , nettestScenario "aborts if there is a failure (due to low balance)"
-          $ uncapsNettest $ Share.lowBalanceOwnerScenario False originateLigoDao
+          $ uncapsNettest $ Share.lowBalanceOwnerScenario originateLigoDao
       , nettestScenario "cannot transfer foreign money"
-          $ uncapsNettest $ Share.noForeignMoneyOwnerScenario False originateLigoDao
+          $ uncapsNettest $ Share.noForeignMoneyOwnerScenario originateLigoDao
       ]
   , testGroup "Admin:"
     [ nettestScenario "transfer tokens from any address to any address"
-        $ uncapsNettest $ Share.adminTransferScenario False originateLigoDao
+        $ uncapsNettest $ Share.adminTransferScenario originateLigoDao
     , nettestScenario "transfer frozen tokens"
-        $ uncapsNettest $ Share.adminTransferFrozenScenario False $ originateLigoDaoWithBalance
+        $ uncapsNettest $ Share.adminTransferFrozenScenario $ originateLigoDaoWithBalance
             (\owner1 owner2 ->
                 [ ((owner1, frozenTokenId), 100)
                 , ((owner2, frozenTokenId), 100)
@@ -66,13 +66,13 @@ test_BaseDAO_FA2 = testGroup "BaseDAO FA2 tests:"
   -- TODO #100: Migration not implemented
   -- , testGroup "Entrypoints respect migration status"
   --     [ nettestScenario "transfer respects migration status"
-  --         $ uncapsNettest $ Share.transferAfterMigrationScenario False originateLigoDao
+  --         $ uncapsNettest $ Share.transferAfterMigrationScenario originateLigoDao
   --     , nettestScenario "update operator respects migration status "
-  --         $ uncapsNettest $ Share.updatingOperatorAfterMigrationScenario False originateLigoDao
+  --         $ uncapsNettest $ Share.updatingOperatorAfterMigrationScenario originateLigoDao
   --     , nettestScenario "balanceOf request respects migration status"
-  --         $ uncapsNettest $ Share.balanceOfRequestAfterMigrationScenario False originateLigoDao
+  --         $ uncapsNettest $ Share.balanceOfRequestAfterMigrationScenario originateLigoDao
   --     , nettestScenario "tokenMetadataRegistry request respects migration status"
-  --         $ uncapsNettest $ Share.tokenMetadataRegistryRequestAfterMigrationScenario False originateLigoDao
+  --         $ uncapsNettest $ Share.tokenMetadataRegistryRequestAfterMigrationScenario originateLigoDao
   --     ]
   ]
 

--- a/src/BaseDAO/ShareTest/Token.hs
+++ b/src/BaseDAO/ShareTest/Token.hs
@@ -23,30 +23,18 @@ import BaseDAO.ShareTest.Common
 burnScenario
   :: forall caps base m param pm
   . (MonadNettest caps base m, FA2.ParameterC param, DAO.ParameterC param pm)
-  => IsLorentz -> OriginateFn param m -> m ()
-burnScenario isLorentz originateFn = do
+  => OriginateFn param m -> m ()
+burnScenario originateFn = do
   ((owner1, _), _, dao, admin) <- originateFn
 
-  case isLorentz of
-    True -> do
-      callFrom (AddressResolved owner1) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 10)
-        & expectCustomError_ #nOT_ADMIN
+  callFrom (AddressResolved owner1) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 10)
+    & expectCustomError_ #nOT_ADMIN
 
-      callFrom (AddressResolved admin) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 100)
-        & expectCustomError #fA2_INSUFFICIENT_BALANCE (#required .! 100, #present .! 10)
+  callFrom (AddressResolved admin) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 100)
+    & expectCustomError #fA2_INSUFFICIENT_BALANCE (#required .! 100, #present .! 10)
 
-      callFrom (AddressResolved admin) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.frozenTokenId 100)
-        & expectCustomError #fA2_INSUFFICIENT_BALANCE (#required .! 100, #present .! 10)
-
-    False -> do
-      callFrom (AddressResolved owner1) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 10)
-        & expectFailed (toAddress dao) [mt|NOT_ADMIN|]
-
-      callFrom (AddressResolved admin) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 100)
-        & expectFailed (toAddress dao) [mt|FA2_INSUFFICIENT_BALANCE|]
-
-      callFrom (AddressResolved admin) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.frozenTokenId 100)
-        & expectFailed (toAddress dao) [mt|FA2_INSUFFICIENT_BALANCE|]
+  callFrom (AddressResolved admin) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.frozenTokenId 100)
+    & expectCustomError #fA2_INSUFFICIENT_BALANCE (#required .! 100, #present .! 10)
 
   callFrom (AddressResolved admin) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 10)
   checkTokenBalance (DAO.unfrozenTokenId) dao owner1 0
@@ -56,17 +44,12 @@ burnScenario isLorentz originateFn = do
 mintScenario
   :: forall caps base m param pm
   . (MonadNettest caps base m, FA2.ParameterC param, DAO.ParameterC param pm)
-  => IsLorentz -> OriginateFn param m -> m ()
-mintScenario isLorentz originateFn = do
+  => OriginateFn param m -> m ()
+mintScenario originateFn = do
   ((owner1, _), _, dao, admin) <- originateFn
 
-  case isLorentz of
-    True -> do
-      callFrom (AddressResolved owner1) dao (Call @"Mint") (DAO.MintParam owner1 DAO.unfrozenTokenId 10)
-        & expectCustomError_ #nOT_ADMIN
-    False -> do
-      callFrom (AddressResolved owner1) dao (Call @"Mint") (DAO.MintParam owner1 DAO.unfrozenTokenId 10)
-        & expectFailed (toAddress dao) [mt|NOT_ADMIN|]
+  callFrom (AddressResolved owner1) dao (Call @"Mint") (DAO.MintParam owner1 DAO.unfrozenTokenId 10)
+    & expectCustomError_ #nOT_ADMIN
 
   callFrom (AddressResolved admin) dao (Call @"Mint") (DAO.MintParam owner1 DAO.unfrozenTokenId 100)
   checkTokenBalance (DAO.unfrozenTokenId) dao owner1 100
@@ -76,8 +59,8 @@ mintScenario isLorentz originateFn = do
 transferContractTokensScenario
   :: forall caps base m param pm
   . (MonadNettest caps base m, FA2.ParameterC param, DAO.ParameterC param pm)
-  => IsLorentz -> OriginateFn param m -> m ()
-transferContractTokensScenario isLorentz originateFn = do
+  => OriginateFn param m -> m ()
+transferContractTokensScenario originateFn = do
   ((owner1, _), _, dao, admin) <- originateFn
   ((target_owner1, _), (target_owner2, _), fa2Contract, _) <- originateFn
   let addParams = FA2.OperatorParam
@@ -100,13 +83,8 @@ transferContractTokensScenario isLorentz originateFn = do
         , DAO.tcParams = transferParams
         }
 
-  case isLorentz of
-    True -> do
-      callFrom (AddressResolved owner1) dao (Call @"Transfer_contract_tokens") param
-        & expectCustomError_ #nOT_ADMIN
-    False -> do
-      callFrom (AddressResolved owner1) dao (Call @"Transfer_contract_tokens") param
-        & expectFailed (toAddress dao) [mt|NOT_ADMIN|]
+  callFrom (AddressResolved owner1) dao (Call @"Transfer_contract_tokens") param
+    & expectCustomError_ #nOT_ADMIN
 
   callFrom (AddressResolved admin) dao (Call @"Transfer_contract_tokens") param
   checkTokenBalance (DAO.unfrozenTokenId) fa2Contract target_owner1 90

--- a/test/Test/BaseDAO/Token.hs
+++ b/test/Test/BaseDAO/Token.hs
@@ -20,7 +20,7 @@ import Test.Common
 test_BaseDAO_Token :: TestTree
 test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
   [ nettestScenario "can burn tokens from any accounts"
-      $ uncapsNettest $ Share.burnScenario True
+      $ uncapsNettest $ Share.burnScenario
         $ originateTrivialDaoWithBalance
           (\o1 _ ->
               [ ((o1, DAO.unfrozenTokenId), 10)
@@ -28,7 +28,7 @@ test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
               ]
           )
   , nettestScenario "can mint tokens to any accounts"
-      $ uncapsNettest $ Share.mintScenario True
+      $ uncapsNettest $ Share.mintScenario
         $ originateTrivialDaoWithBalance
           (\o1 _ ->
               [ ((o1, DAO.unfrozenTokenId), 0)
@@ -36,5 +36,5 @@ test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
               ]
           )
   , nettestScenario "can call transfer tokens entrypoint"
-      $ uncapsNettest $ Share.transferContractTokensScenario True originateTrivialDao
+      $ uncapsNettest $ Share.transferContractTokensScenario originateTrivialDao
   ]

--- a/test/Test/BaseDAO/Token/FA2.hs
+++ b/test/Test/BaseDAO/Token/FA2.hs
@@ -21,41 +21,41 @@ test_BaseDAO_FA2 :: TestTree
 test_BaseDAO_FA2 = testGroup "BaseDAO FA2 tests:"
   [ testGroup "Operator:"
       [ nettestScenario "allows zero transfer from non-existent operator"
-          $ uncapsNettest $ Share.zeroTransferScenario True originateTrivialDao
+          $ uncapsNettest $ Share.zeroTransferScenario originateTrivialDao
       , nettestScenario "allows valid transfer and check balance"
-          $ uncapsNettest $ Share.validTransferScenario True originateTrivialDao
+          $ uncapsNettest $ Share.validTransferScenario originateTrivialDao
       , nettestScenario "validates token id"
-          $ uncapsNettest $ Share.validateTokenScenario True originateTrivialDao
+          $ uncapsNettest $ Share.validateTokenScenario originateTrivialDao
       , nettestScenario "accepts an empty list of transfers"
-          $ uncapsNettest $ Share.emptyTransferListScenario True originateTrivialDao
+          $ uncapsNettest $ Share.emptyTransferListScenario originateTrivialDao
       , nettestScenario "aborts if there is a failure (due to low balance)"
-          $ uncapsNettest $ Share.lowBalanceScenario True originateTrivialDao
+          $ uncapsNettest $ Share.lowBalanceScenario originateTrivialDao
       , nettestScenario "aborts if there is a failure (due to non existent source account)"
-          $ uncapsNettest $ Share.noSourceAccountScenario True originateTrivialDao
+          $ uncapsNettest $ Share.noSourceAccountScenario originateTrivialDao
       , nettestScenario "aborts if there is a failure (due to bad operator)"
-          $ uncapsNettest $ Share.badOperatorScenario True originateTrivialDao
+          $ uncapsNettest $ Share.badOperatorScenario originateTrivialDao
       , nettestScenario "cannot transfer foreign money"
-          $ uncapsNettest $ Share.noForeignMoneyScenario True originateTrivialDao
+          $ uncapsNettest $ Share.noForeignMoneyScenario originateTrivialDao
       ]
   , testGroup "Owner:"
       [ nettestScenario "allows valid transfer and check balance"
-          $ uncapsNettest $ Share.validTransferOwnerScenario True originateTrivialDao
+          $ uncapsNettest $ Share.validTransferOwnerScenario originateTrivialDao
       , nettestScenario "allows updating operator "
-          $ uncapsNettest $ Share.updatingOperatorScenario True originateTrivialDao
+          $ uncapsNettest $ Share.updatingOperatorScenario originateTrivialDao
       , nettestScenario "allows balanceOf request"
-          $ uncapsNettest $ Share.balanceOfOwnerScenario True originateTrivialDao
+          $ uncapsNettest $ Share.balanceOfOwnerScenario originateTrivialDao
       , nettestScenario "validates token id"
-          $ uncapsNettest $ Share.validateTokenOwnerScenario True originateTrivialDao
+          $ uncapsNettest $ Share.validateTokenOwnerScenario originateTrivialDao
       , nettestScenario "aborts if there is a failure (due to low balance)"
-          $ uncapsNettest $ Share.lowBalanceOwnerScenario True originateTrivialDao
+          $ uncapsNettest $ Share.lowBalanceOwnerScenario originateTrivialDao
       , nettestScenario "cannot transfer foreign money"
-          $ uncapsNettest $ Share.noForeignMoneyOwnerScenario True originateTrivialDao
+          $ uncapsNettest $ Share.noForeignMoneyOwnerScenario originateTrivialDao
       ]
   , testGroup "Admin:"
     [ nettestScenario "transfer tokens from any address to any address"
-        $ uncapsNettest $ Share.adminTransferScenario True originateTrivialDao
+        $ uncapsNettest $ Share.adminTransferScenario originateTrivialDao
     , nettestScenario "transfer frozen tokens"
-        $ uncapsNettest $ Share.adminTransferFrozenScenario True $ originateTrivialDaoWithBalance
+        $ uncapsNettest $ Share.adminTransferFrozenScenario $ originateTrivialDaoWithBalance
             (\owner1 owner2 ->
                 [ ((owner1, frozenTokenId), 100)
                 , ((owner2, frozenTokenId), 100)
@@ -64,12 +64,12 @@ test_BaseDAO_FA2 = testGroup "BaseDAO FA2 tests:"
     ]
   , testGroup "Entrypoints respect migration status"
       [ nettestScenario "transfer respects migration status"
-          $ uncapsNettest $ Share.transferAfterMigrationScenario True originateTrivialDao
+          $ uncapsNettest $ Share.transferAfterMigrationScenario originateTrivialDao
       , nettestScenario "update operator respects migration status "
-          $ uncapsNettest $ Share.updatingOperatorAfterMigrationScenario True originateTrivialDao
+          $ uncapsNettest $ Share.updatingOperatorAfterMigrationScenario originateTrivialDao
       , nettestScenario "balanceOf request respects migration status"
-          $ uncapsNettest $ Share.balanceOfRequestAfterMigrationScenario True originateTrivialDao
+          $ uncapsNettest $ Share.balanceOfRequestAfterMigrationScenario originateTrivialDao
       , nettestScenario "tokenMetadataRegistry request respects migration status"
-          $ uncapsNettest $ Share.tokenMetadataRegistryRequestAfterMigrationScenario True originateTrivialDao
+          $ uncapsNettest $ Share.tokenMetadataRegistryRequestAfterMigrationScenario originateTrivialDao
       ]
   ]


### PR DESCRIPTION
## Description

Problem: Current LIGO only fails with type `string` which is different
from the Lorentz version. Because of this, we require a `isLorentz`
check in the tests to be able to share the tests properly. We can update
the `failwith` in LIGO to be the same as lorentz which would make the
check no longer necessary.

Solution: Update LIGO `failwith` to be the same as Lorentz version,
remove `isLorentz` check in share tests.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #106  

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
