### PR TITLE
[#116] LIGO RegistryDAO contract using BaseDAO

### DIFF
--- a/ligo/README.md
+++ b/ligo/README.md
@@ -28,8 +28,8 @@ which will save the compiled contract in `out/baseDAO.tz`.
 
 ## Generating `Storage`
 
-Currently we don't provide any convenient way to generate the storage, so you'll
-need to do so manually.
+Currently we don't provide any convenient way to generate `BaseDAO` storage,
+but you can use [RegistryDAO Storage generation](#registrydao) as example.
 
 We will work on this in future versions.
 
@@ -49,3 +49,22 @@ You can use the `Makefile` to do so as well:
 make test
 ```
 For more detail about LIGO tests, check out its [README.md](./haskell/test/)
+
+## Example contracts
+
+### RegistryDAO
+
+The storage, including configuration for the RegistryDAO
+[specification](https://github.com/tqtezos/baseDAO/blob/master/docs/registry.md)
+is included in `src/registryDAO.mligo`. You can convert this into a
+Michelson expression during the BaseDAO origination using the `ligo
+compile-storage` command as follows.
+
+```
+
+The `default_registry_DAO_full_storage` is a LIGO function defined in
+`ligo/src/RegistryDAO.mligo`, which returns a LIGO expression for storage,
+which is converted into Michelson using the `compile-storage` command. The
+arguments to this function are the admin address, the token address and the
+configuration parameters described in the Registry spec, which are 'a', 'b',
+'s_max', 'c' and 'd'.

--- a/ligo/src/defaults.mligo
+++ b/ligo/src/defaults.mligo
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2020 TQ Tezos
+// SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+#include "types.mligo"
+
+let default_config : config = {
+    proposal_check = (fun (params, store : propose_params * storage) -> true);
+    rejected_proposal_return_value = (fun (proposal, store : proposal * storage) -> 0n);
+    decision_lambda = (fun (proposal, store : proposal * storage) -> (([] : (operation list)), store));
+
+    max_proposals = 500n;
+    max_votes = 1000n;
+    max_quorum_threshold = 1000n;
+    min_quorum_threshold = 1n;
+    max_voting_period = 2592000n; // 60 * 60 * 24 * 30
+    min_voting_period = 1n;
+    custom_entrypoints = (Map.empty : (string, bytes) map);
+    }
+
+let default_storage (admin , token_address : (address * address)) : storage = {
+    ledger = (Big_map.empty : ledger);
+    operators = (Big_map.empty : operators);
+    token_address = token_address;
+    admin = admin;
+    pending_owner = admin;
+    metadata = (Big_map.empty : (string, bytes) big_map);
+    migration_status = Not_in_migration;
+    voting_period = 11n;
+    quorum_threshold = 33n;
+    extra = (Map.empty : (string, bytes) map);
+    proposals = (Big_map.empty : (proposal_key, proposal) big_map);
+    proposal_key_list_sort_by_date = (Set.empty : (timestamp * proposal_key) set);
+    permits_counter = 0n;
+}
+
+let default_full_storage (admin, token_address : (address * address)) : full_storage =
+  (default_storage (admin, token_address), default_config)

--- a/ligo/src/proposal.mligo
+++ b/ligo/src/proposal.mligo
@@ -348,4 +348,3 @@ let drop_proposal (proposal_key, config, store : proposal_key * config * storage
   else
     ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
       ("FAIL_DROP_PROPOSAL_NOT_OVER", ()) : return)
-

--- a/ligo/src/registryDAO.mligo
+++ b/ligo/src/registryDAO.mligo
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2020 TQ Tezos
+// SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+#include "defaults.mligo"
+#include "types.mligo"
+#include "proposal.mligo"
+#include "registryDAO/types.mligo"
+
+// The following include is required so that we have a function with an
+// entrypoint type to use with `compile-storage` command to make Michelson
+// storage expression.
+#include "base_DAO.mligo"
+
+let require_extra_value (key_name, ce : string * contract_extra) : bytes =
+    match Map.find_opt key_name ce with
+      Some (packed_b) -> packed_b
+    | None -> (failwith "CONFIG_VALUE_NOT_FOUND" : bytes)
+
+let require_unpacked_nat_opt (packed_b: bytes) : nat option =
+  match ((Bytes.unpack packed_b) : ((nat option) option)) with
+    Some (v) -> v
+  | None -> (failwith "UNPACKING_FAILED" : nat option)
+
+let require_unpacked_registry (packed_b: bytes) : registry =
+  match ((Bytes.unpack packed_b) : (registry option)) with
+    Some (v) -> v
+  | None -> (failwith "UNPACKING_FAILED" : registry)
+
+let require_unpacked_registry_affected (packed_b: bytes) : registry_affected =
+  match ((Bytes.unpack packed_b) : (registry_affected option)) with
+    Some (v) -> v
+  | None -> (failwith "UNPACKING_FAILED" : registry_affected)
+
+let lookup_config (key_name, ce : string * contract_extra) : nat option =
+    require_unpacked_nat_opt(require_extra_value(key_name, ce))
+
+let require_config (key_name, ce : string * contract_extra) : nat =
+  match lookup_config (key_name, ce) with
+    Some (v) -> v
+  | None -> (failwith "REQUIRED_CONFIG_NOT_FOUND" : nat)
+
+let apply_diff_registry (diff, registry : registry_diff * registry) : registry =
+  let
+    foldFn (registry, update: registry * (registry_key * registry_value option)) : registry =
+      let registry_key = update.0 in
+      let registry_value = update.1 in
+      Map.update registry_key registry_value registry
+  in List.fold foldFn diff registry
+
+let apply_diff_registry_affected (proposal_key, diff, registry_affected : proposal_key
+        * registry_diff * registry_affected) : registry_affected =
+  let
+    foldFn (registry_affected, update: registry_affected * (registry_key *
+      registry_value option)) : registry_affected =
+      let registry_key = update.0 in
+      Map.update registry_key (Some (proposal_key)) registry_affected
+  in List.fold foldFn diff registry_affected
+
+let apply_diff (diff, ce : registry_diff * contract_extra) : contract_extra =
+  let registry = require_unpacked_registry(require_extra_value("registry", ce)) in
+  let new_registry : registry = apply_diff_registry (diff, registry) in
+  Map.update "registry" (Some (Bytes.pack new_registry)) ce
+
+let apply_diff_affected (proposal_key, diff, ce : proposal_key *
+    registry_diff * contract_extra) : contract_extra =
+  let registry_af = require_unpacked_registry_affected(require_extra_value("registry_affected", ce)) in
+  let new_registry_af : registry_affected = apply_diff_registry_affected (proposal_key, diff, registry_af)
+  in Map.update "registry_affected" (Some (Bytes.pack new_registry_af)) ce
+
+// Configuration Lambdas
+
+(*
+ * Proposal check lambda : returns true if following two checks are true.
+ * 1. if proposer has locked a * s + b where s = size(pack(proposalMetadata))
+ * and a and b are from storage configuration.
+ * 2. proposal size < s_max where s_max is from stored configuration.
+ *)
+let registry_DAO_proposal_check (params, store : propose_params * storage) : bool =
+  let proposal_size = Bytes.size(Bytes.pack(params.proposal_metadata)) in
+  let frozen_scale_value = require_config ("a", store.extra) in
+  let frozen_extra_value = require_config ("b", store.extra) in
+  let max_proposal_size = require_config ("s_max", store.extra) in
+  let requred_token_lock = frozen_scale_value * proposal_size + frozen_extra_value
+  in (params.frozen_token = requred_token_lock) && (proposal_size < max_proposal_size)
+
+(*
+ * Proposal rejection return lambda: returns `c * frozen / d`. where c and d
+ * are specified by the DAO creator in configuration and frozen is the amount
+ * that was frozen by the proposer.
+ *)
+let registry_DAO_rejected_proposal_return_value (params, store : proposal * storage) : nat =
+  let slash_scale_value = require_config ("c", store.extra) in
+  let slash_division_value = require_config ("d", store.extra)
+  in (slash_scale_value * params.proposer_frozen_token) / slash_division_value
+
+(*
+ * Uses the keys in the proposal metadata to differentiate between configuration
+ * proposal and normal proposals. If the map contains `agoraPostID` key, the proposal
+ * is considerd as 'normal'. Or else it is considered as carrying a 'configuration'
+ * proposal.
+ *
+ * For 'normal' proposals, the contract_extra is expected to contain the bigmap
+ * for registry and bigmap for key update tracking under keys 'registry' and
+ * 'registry_affected' keys.
+ *
+ * For 'configuration' proposal, the code expects all the configuration keys
+ * included in the proposal (or it throws an error). The expected keys are "a",
+ * "b", "s_max", "c" and "d".  'None' values are ignored and 'Some' values are
+ * used for updating corresponding configuraton.
+ *)
+let registry_DAO_decision_lambda (proposal, store : proposal * storage) : return =
+  let propose_param : propose_params = {
+    frozen_token = proposal.proposer_frozen_token;
+    proposal_metadata = proposal.metadata
+    } in
+  let proposal_key = to_proposal_key (propose_param, proposal.proposer) in
+  match Map.find_opt "agoraPostID" proposal.metadata with
+    Some (packed_b) ->
+      begin
+        match ((Bytes.unpack packed_b) : (nat option)) with
+          Some (agora_post_id) ->
+            begin
+              match Map.find_opt "updates" proposal.metadata with
+                Some (packed_b) ->
+                  begin
+                    match ((Bytes.unpack packed_b) : (registry_diff option)) with
+                      Some (diff) ->
+                        let ce_after_registry_update = apply_diff(diff, store.extra) in
+                        let ce_after_registry_affected_update =
+                          apply_diff_affected(proposal_key, diff, ce_after_registry_update) in
+                          (([] : operation list), { store with extra = ce_after_registry_affected_update })
+                    | None -> (failwith "UPDATES_UNPACKING_FAILED" : return)
+                  end
+              | None -> (failwith "UPDATES_NOT_FOUND" : return)
+            end
+        | None -> (failwith "UNPACKING FAILED" : return)
+      end
+  | None ->
+      let m_frozen_scale_value = lookup_config ("a", proposal.metadata) in
+      let m_frozen_extra_value = lookup_config ("b", proposal.metadata) in
+      let m_max_proposal_size = lookup_config ("s_max", proposal.metadata) in
+      let m_slash_scale_value = lookup_config ("c", proposal.metadata) in
+      let m_slash_division_value = lookup_config ("d", proposal.metadata) in
+      let new_ce = match m_frozen_scale_value with
+        Some (frozen_scale_value) -> Map.update "a" (Some (Bytes.pack (frozen_scale_value))) store.extra
+        | None -> store.extra in
+
+      let new_ce = match m_frozen_extra_value with
+        Some (frozen_scale_value) -> Map.update "b" (Some (Bytes.pack (frozen_scale_value))) new_ce
+        | None -> new_ce in
+
+      let new_ce = match m_max_proposal_size with
+        Some (max_proposal_size) -> Map.update "s_max" (Some (Bytes.pack (max_proposal_size))) new_ce
+        | None -> new_ce in
+
+      let new_ce = match m_slash_scale_value with
+        Some (slash_scale_value) -> Map.update "c" (Some (Bytes.pack (slash_scale_value))) new_ce
+        | None -> new_ce in
+
+      let new_ce = match m_slash_division_value with
+        Some (slash_division_value) -> Map.update "d" (Some (Bytes.pack (slash_division_value))) new_ce
+        | None -> new_ce
+      in (([] : operation list), { store with extra = new_ce })
+
+let default_registry_DAO_full_storage (admin, token_address, a, b, s_max, c, d
+    : (address * address * nat * nat * nat * nat * nat)) : full_storage = let
+  fs = default_full_storage (admin, token_address) in
+  let new_storage = { fs.0 with
+    extra = Map.literal [
+          ("registry" , Bytes.pack (Map.empty : registry));
+          ("registry_affected" , Bytes.pack (Map.empty : registry_affected));
+          ("a" , Bytes.pack a); // frozen_scale_value
+          ("b" , Bytes.pack b); // frozen_extra_value
+          ("s_max" , Bytes.pack s_max); // max_proposal_size
+          ("c" , Bytes.pack c); // slash_scale_value
+          ("d" , Bytes.pack d); // slash_division_value
+          ];
+  } in
+  let new_config = { fs.1 with
+    proposal_check = registry_DAO_proposal_check;
+    rejected_proposal_return_value = registry_DAO_rejected_proposal_return_value;
+    decision_lambda = registry_DAO_decision_lambda;
+    } in
+  (new_storage, new_config)

--- a/ligo/src/registryDAO/types.mligo
+++ b/ligo/src/registryDAO/types.mligo
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2020 TQ Tezos
+// SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+#include "../types.mligo"
+
+// k, v parameters of the registry contract.
+type registry_key = string
+type registry_value = string
+
+type registry = (registry_key, registry_value) map
+type registry_affected = (registry_key, proposal_key) map
+type registry_diff = (registry_key * registry_value option) list


### PR DESCRIPTION
Problem: As an example, we would like to implement RegistryDAO contract
using ligo version of the BaseDAO contract.

Solution: Implement configuration lambdas for BaseDAO contract which
implements RegistryDAO behavior.

Originally, RegistryDAO contract requires a parameterized contract, but
since it is not clear how to do this in LIGO, the Key/Value types are
just included as a type alias in the source file.

Apart from this, the implementation of decision lambda is a bit hackish
where the two types of proposals are distinguished by looking at the
included keys in the proposal metadata, which is just a `(string, bytes)
map`.

A dummy entrypoint is left in the RegistryDAO source file to facilitate
creation of a Michelson storage expression using the LIGO
compile_storage command.

#### Origination:

During origination of BaseDAO, the configuration for RegistryDAO can be
loaded by making a storage with RegistryDAO lambdas included in
configuration and required map keys in storage. A Michelson expression
for storage can be built during origination using the following LIGO
Command.

```
ligo compile-storage ligo/src/registryDAO.mligo dummy
  'default_registry_DAO_full_storage(("tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" : address), ("tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" : address), 0n, 0n, 0n, 0n, 0n)'
```

Where the arguents to `default_registry_DAO_full_storage` function are
admin address, token_address and values of configuration parameters 'a',
'b', 's_max', 'c' and 'd'.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Addresses part of  #116 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
