### PR TITLE
[#72] Cleanup Config

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -63,8 +63,10 @@ Compile-time value parameters are captured by the `Config` type (parameterized b
 data Config contractExtra proposalMetadata = Config
   { daoName :: Text
   -- ^ Name of the DAO.
+  -- Only used in documentation generator and does not get stored in @Storage@.
   , daoDescription :: Text
   -- ^ Description of the DAO.
+  -- Only used in documentation generator and does not get stored in @Storage@.
   , proposalCheck :: Lambda
       (ProposeParams proposalMetadata, Storage contractExtra proposalMetadata) Bool
   -- ^ A lambda used to verify whether a proposal can be submitted.

--- a/src/Lorentz/Contracts/BaseDAO/Types.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Types.hs
@@ -106,7 +106,11 @@ instance HasAnnotation FA2.Parameter
 
 data Config contractExtra proposalMetadata otherParam = Config
   { cDaoName :: Text
+  -- ^ Name of the DAO.
+  -- Only used in documentation generator and does not get stored in @Storage@.
   , cDaoDescription :: Markdown
+  -- ^ Description of the DAO.
+  -- Only used in documentation generator and does not get stored in @Storage@.
 
   , cProposalCheck :: forall s store.
         StorageC store contractExtra proposalMetadata
@@ -598,8 +602,8 @@ instance a `CanCastTo` SomeType
 
 type ProposalKey pm = Hash Blake2b $ Packed (ProposeParams pm, Address)
 
--- | Proposal type which will be stored in 'Storage' `sProposals`
--- `pVoters` is needed due to we need to keep track of voters to be able to
+-- | Proposal type which will be stored in 'Storage' @sProposals@
+-- @pVoters@ is needed due to we need to keep track of voters to be able to
 -- unfreeze their tokens.
 data Proposal proposalMetadata = Proposal
   { pUpvotes             :: Natural
@@ -737,7 +741,7 @@ allTokenIds = [unfrozenTokenId, frozenTokenId]
 -- Helper
 ------------------------------------------------------------------------
 
--- Useful type when `iter` with a counter
+-- | Useful type when @iter@ with a counter
 type Counter = (("currentCount" :! Natural), Natural)
 
 baseDaoAnnOptions :: AnnOptions


### PR DESCRIPTION
## Description

Problem: Currently, `daoName` and `daoDescription` are  used only
for documentation and are not part of `Storage`. We should make it more
clear about that.

Solution: Make it clearer that these values are used only for documentation,
and not part of `Storage`.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #72 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
