### PR TITLE
[#129] Make management entrypoint tests shared

### DIFF
--- a/baseDAO.cabal
+++ b/baseDAO.cabal
@@ -25,6 +25,7 @@ library
       BaseDAO.CLI
       BaseDAO.ShareTest.Common
       BaseDAO.ShareTest.FA2
+      BaseDAO.ShareTest.Management
       BaseDAO.ShareTest.OffChainViews
       BaseDAO.ShareTest.Proposal
       BaseDAO.ShareTest.Proposal.Bounds

--- a/ligo/haskell/test/Test/Ligo/BaseDAO/Management.hs
+++ b/ligo/haskell/test/Test/Ligo/BaseDAO/Management.hs
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: LicenseRef-MIT-TQ
 --
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
--- For all the incomplete list pattern matches in the calls to with
--- withOriginated func
+-- For all the incomplete list pattern matches in the calls to the
+-- `withOriginated` function
 module Test.Ligo.BaseDAO.Management
   ( test_BaseDAO_Management
   ) where
@@ -20,9 +20,10 @@ import Michelson.Untyped.Entrypoints (unsafeBuildEpName)
 import Morley.Nettest
 import Morley.Nettest.Tasty (nettestScenarioCaps)
 import Tezos.Core (unsafeMkMutez)
-
-import Ligo.BaseDAO.Contract
 import Util.Named
+
+import BaseDAO.ShareTest.Management
+import Ligo.BaseDAO.Contract
 import Ligo.BaseDAO.Types
 
 -- | Function that originates the contract and also make a bunch of
@@ -62,170 +63,68 @@ test_BaseDAO_Management =
           & expectForbiddenXTZ
 
     , nettestScenarioCaps "transfer ownership entrypoint authenticates sender" $
-        withOriginated 2 (\(owner:_) -> initialStorage owner) $ \[_, wallet1] baseDao ->
-          callFrom (AddressResolved wallet1) baseDao (Call @"Transfer_ownership") (#newOwner .! wallet1)
-            & expectNotAdmin
+        transferOwnership withOriginated initialStorage
 
     , nettestScenarioCaps "sets pending owner" $
-        withOriginated 2 (\(owner:_) -> initialStorage owner) $
-          \[owner, wallet1] baseDao -> do
-              callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                (#newOwner .! wallet1)
-              callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+        transferOwnership withOriginated initialStorage
 
     , nettestScenarioCaps "does not set administrator" $
-        withOriginated 2 (\(owner:_) -> initialStorage owner) $
-          \[owner, wallet1] baseDao -> do
-            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-              (#newOwner .! wallet1)
-            -- Make the call once again to make sure the admin still retains admin
-            -- privileges
-            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-              (#newOwner .! wallet1)
+        notSetAdmin withOriginated initialStorage
 
     , nettestScenarioCaps "rewrite existing pending owner" $
-        withOriginated 3 (\(owner:_) -> initialStorage owner) $
-          \[owner, wallet1, wallet2] baseDao -> do
-            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-              (#newOwner .! wallet1)
-            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-              (#newOwner .! wallet2)
-            -- Make the accept ownership call from wallet1 and see that it fails
-            callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
-              & expectNotPendingOwner
-            -- Make the accept ownership call from wallet1 and see that it works
-            callFrom (AddressResolved wallet2) baseDao (Call @"Accept_ownership") ()
+        rewritePendingOwner withOriginated initialStorage
 
     , nettestScenarioCaps "invalidates pending owner if new owner is current admin" $
-        withOriginated 2 (\(owner:_) -> initialStorage owner) $
-          \[owner, wallet1] baseDao -> do
-            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-              (#newOwner .! wallet1)
-            callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-              (#newOwner .! owner)
-            -- Make the accept ownership call from wallet1 and see that it fails
-            -- with 'not pending owner' error
-            callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
-              & expectNotPendingOwner
+        invalidatePendingOwner withOriginated initialStorage
 
-      , nettestScenarioCaps "Respects migration state" $
-          withOriginated 3 (\(owner:_) -> initialStorage owner) $
-            \[owner, newAddress1, newOwner] baseDao -> do
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-              -- We test this by calling `confirmMigration` and seeing that it does not fail
-              callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
-              callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                (#newOwner .! newOwner)
-                & expectMigrated newAddress1
+    , nettestScenarioCaps "Respects migration state" $
+        respectMigratedState withOriginated initialStorage
     ]
   , testGroup "Accept Ownership"
       [ nettestScenarioCaps "authenticates the sender" $
-          withOriginated 3 (\(owner:_) -> initialStorage owner) $
-            \[owner, wallet1, wallet2] baseDao -> do
-              callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                (#newOwner .! wallet1)
-              callFrom (AddressResolved wallet2) baseDao (Call @"Accept_ownership") ()
-                & expectNotPendingOwner
+          authenticateSender withOriginated initialStorage
 
        , nettestScenarioCaps "changes the administrator to pending owner" $
-           withOriginated 2 (\(owner:_) -> initialStorage owner) $
-             \[owner, wallet1] baseDao -> do
-               callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                 (#newOwner .! wallet1)
-               callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+          changeToPendingAdmin withOriginated initialStorage
 
        , nettestScenarioCaps "throws error when there is no pending owner" $
-           withOriginated 2 (\(owner:_) -> initialStorage owner) $
-             \[_, wallet1] baseDao -> do
-               callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
-                & expectNotPendingOwner
+          noPendingAdmin withOriginated initialStorage
 
        , nettestScenarioCaps "throws error when called by current admin, when pending owner is not the same" $
-           withOriginated 2 (\(owner:_) -> initialStorage owner) $
-             \[owner, wallet1] baseDao -> do
-               callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
-                 (#newOwner .! wallet1)
-               callFrom (AddressResolved owner) baseDao (Call @"Accept_ownership") ()
-                & expectNotPendingOwner
+          pendingOwnerNotTheSame withOriginated initialStorage
 
       , nettestScenarioCaps "Respects migration state" $
-          withOriginated 2 (\(owner:_) -> initialStorage owner) $
-            \[owner, newAddress1] baseDao -> do
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-              -- We test this by calling `confirmMigration` and seeing that it does not fail
-              callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
-              callFrom (AddressResolved owner) baseDao (Call @"Accept_ownership") ()
-                & expectMigrated newAddress1
+          acceptOwnerRespectMigration withOriginated initialStorage
       ]
 
   , testGroup "Migration"
       [ nettestScenarioCaps "authenticates the sender" $
-          withOriginated 3 (\(owner:_) -> initialStorage owner) $
-            \[_, newAddress1, randomAddress] baseDao -> do
-              callFrom (AddressResolved randomAddress) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                & expectNotAdmin
+          migrationAuthenticateSender withOriginated initialStorage
 
       , nettestScenarioCaps "successfully sets the pending migration address " $
-          withOriginated 2 (\(owner:_) -> initialStorage owner) $
-            \[owner, newAddress1] baseDao -> do
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-              -- We test this by calling `confirmMigration` and seeing that it does not fail
-              callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+          migrationSetPendingOwner withOriginated initialStorage
 
       , nettestScenarioCaps "overwrites previous migration target" $
-          withOriginated 3 (\(owner:_) -> initialStorage owner) $
-            \[owner, newAddress1, newAddress2] baseDao -> do
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress2)
-              -- We test this by calling `confirmMigration` and seeing that it does not fail
-              callFrom (AddressResolved newAddress2) baseDao (Call @"Confirm_migration") ()
+          migrationOverwritePrevious withOriginated initialStorage
 
       , nettestScenarioCaps "allows calls until confirm migration is called" $
-          withOriginated 3 (\(owner:_) -> initialStorage owner) $
-            \[owner, newAddress1, newAddress2] baseDao -> do
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress2)
+          migrationAllowCallUntilConfirm withOriginated initialStorage
       ]
 
   , testGroup "Confirm Migration"
       [ nettestScenarioCaps "authenticates the sender" $
-          withOriginated 3 (\(owner:_) -> initialStorage owner) $
-            \[owner, newAddress1, randomAddress] baseDao -> do
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-              -- We test this by calling `confirmMigration` and seeing that it does not fail
-              callFrom (AddressResolved randomAddress) baseDao (Call @"Confirm_migration") ()
-                & expectNotMigrationTarget
+          confirmMigAuthenticateSender withOriginated initialStorage
 
       , nettestScenarioCaps "authenticates migration state" $
-          withOriginated 2 (\(owner:_) -> initialStorage owner) $
-            \[_, newAddress1] baseDao -> do
-              callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
-                & expectNotMigrating
+          confirmMigAuthenticateState withOriginated initialStorage
 
       , nettestScenarioCaps "finalizes migration" $
-          withOriginated 2 (\(owner:_) -> initialStorage owner) $
-            \[owner, newAddress1] baseDao -> do
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-              -- We test this by calling `confirmMigration` and seeing that it does not fail
-              callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
-                & expectMigrated newAddress1
+          confirmMigFinalize withOriginated initialStorage
+
      ]
 
-  , testGroup "Custom entrypoints"
-      [ nettestScenarioCaps "can call custom entrypoint" $
-          withOriginated 3 (\(owner:_) -> initialStorage owner) $
-            \[owner, randomAddress, newContractAddress] baseDao -> do
-              -- Using a custom entry point we replace the admin address
-              -- with `randomAddress`
-              callFrom (AddressResolved randomAddress) baseDao (Call @"CallCustom") ([mt|testCustomEp|], lPackValueRaw randomAddress)
-              -- Then we try to call an admin only endpoint as `owner`, expecting it to fail.
-              callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newContractAddress)
-                & expectNotAdmin
-              -- Then we try to call an admin only endpoint as `randomAddress`, expecting it to work.
-              callFrom (AddressResolved randomAddress) baseDao (Call @"Migrate") (#newAddress .! newContractAddress)
-     ]
   ]
+
   where
 
     testCustomEntrypoint :: ('[(ByteString, FullStorage)] :-> '[([Operation], FullStorage)])
@@ -246,33 +145,3 @@ test_BaseDAO_Management =
           [ ([mt|testCustomEp|], lPackValueRaw testCustomEntrypoint)
           ]
       ! defaults
-
-expectNotAdmin
-  :: (MonadNettest caps base m)
-  => m a -> m ()
-expectNotAdmin = expectCustomError_ #nOT_ADMIN
-
-expectNotPendingOwner
-  :: (MonadNettest caps base m)
-  => m a -> m ()
-expectNotPendingOwner = expectCustomError_ #nOT_PENDING_ADMIN
-
-expectNotMigrating
-  :: (MonadNettest caps base m)
-  => m a -> m ()
-expectNotMigrating = expectCustomError_ #nOT_MIGRATING
-
-expectNotMigrationTarget
-  :: (MonadNettest caps base m)
-  => m a -> m ()
-expectNotMigrationTarget = expectCustomError_ #nOT_MIGRATION_TARGET
-
-expectMigrated
-  :: (MonadNettest caps base m)
-  => Address -> m a -> m ()
-expectMigrated addr = expectCustomError #mIGRATED addr
-
-expectForbiddenXTZ
-  :: (MonadNettest caps base m)
-  => m a -> m ()
-expectForbiddenXTZ = expectCustomError_ #fORBIDDEN_XTZ

--- a/src/BaseDAO/ShareTest/FA2.hs
+++ b/src/BaseDAO/ShareTest/FA2.hs
@@ -33,6 +33,7 @@ import Morley.Nettest
 import Util.Named
 
 import BaseDAO.ShareTest.Common
+import BaseDAO.ShareTest.Management (expectMigrated)
 import Lorentz.Contracts.BaseDAO.Types
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 

--- a/src/BaseDAO/ShareTest/Management.hs
+++ b/src/BaseDAO/ShareTest/Management.hs
@@ -1,0 +1,296 @@
+-- SPDX-FileCopyrightText: 2020 TQ Tezos
+-- SPDX-License-Identifier: LicenseRef-MIT-TQ
+--
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+-- For all the incomplete list pattern matches in the calls to the
+-- `withOriginatedFn` function
+
+module BaseDAO.ShareTest.Management
+  ( transferOwnership
+  , setPendingOwner
+  , notSetAdmin
+  , rewritePendingOwner
+  , invalidatePendingOwner
+  , respectMigratedState
+  , authenticateSender
+  , changeToPendingAdmin
+  , noPendingAdmin
+  , pendingOwnerNotTheSame
+  , acceptOwnerRespectMigration
+  , migrationAuthenticateSender
+  , migrationSetPendingOwner
+  , migrationOverwritePrevious
+  , migrationAllowCallUntilConfirm
+  , confirmMigAuthenticateSender
+  , confirmMigAuthenticateState
+  , confirmMigFinalize
+  , expectNotAdmin
+  , expectNotPendingOwner
+  , expectNotMigrating
+  , expectNotMigrationTarget
+  , expectMigrated
+  , expectForbiddenXTZ
+  ) where
+
+import Universum
+
+import Lorentz hiding ((>>))
+import Morley.Nettest
+import Util.Named
+
+import qualified Lorentz.Contracts.BaseDAO.Types as DAO
+
+type WithOriginateFn m param st = Integer
+  -> ([Address] -> st)
+  -> ([Address] -> TAddress param  -> m ())
+  -> m ()
+
+type WithStorage st = Address -> st
+
+transferOwnership
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+transferOwnership withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $ \[_, wallet1] baseDao ->
+    callFrom (AddressResolved wallet1) baseDao (Call @"Transfer_ownership") (#newOwner .! wallet1)
+      & expectNotAdmin
+
+setPendingOwner
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+setPendingOwner withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $
+    \[owner, wallet1] baseDao -> do
+        callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+          (#newOwner .! wallet1)
+        callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+
+notSetAdmin
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+notSetAdmin withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $
+    \[owner, wallet1] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+        (#newOwner .! wallet1)
+      -- Make the call once again to make sure the admin still retains admin
+      -- privileges
+      callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+        (#newOwner .! wallet1)
+
+rewritePendingOwner
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+rewritePendingOwner withOriginatedFn initialStorage =
+  withOriginatedFn 3 (\(owner:_) -> initialStorage owner) $
+    \[owner, wallet1, wallet2] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+        (#newOwner .! wallet1)
+      callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+        (#newOwner .! wallet2)
+      -- Make the accept ownership call from wallet1 and see that it fails
+      callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+        & expectNotPendingOwner
+      -- Make the accept ownership call from wallet1 and see that it works
+      callFrom (AddressResolved wallet2) baseDao (Call @"Accept_ownership") ()
+
+invalidatePendingOwner
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+invalidatePendingOwner withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $
+    \[owner, wallet1] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+        (#newOwner .! wallet1)
+      callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+        (#newOwner .! owner)
+      -- Make the accept ownership call from wallet1 and see that it fails
+      -- with 'not pending owner' error
+      callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+        & expectNotPendingOwner
+
+respectMigratedState
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+respectMigratedState withOriginatedFn initialStorage =
+  withOriginatedFn 3 (\(owner:_) -> initialStorage owner) $
+    \[owner, newAddress1, newOwner] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+      -- We test this by calling `confirmMigration` and seeing that it does not fail
+      callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+      callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+        (#newOwner .! newOwner)
+        & expectMigrated newAddress1
+
+authenticateSender
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+authenticateSender withOriginatedFn initialStorage =
+  withOriginatedFn 3 (\(owner:_) -> initialStorage owner) $
+    \[owner, wallet1, wallet2] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+        (#newOwner .! wallet1)
+      callFrom (AddressResolved wallet2) baseDao (Call @"Accept_ownership") ()
+        & expectNotPendingOwner
+
+changeToPendingAdmin
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+changeToPendingAdmin withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $
+    \[owner, wallet1] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+        (#newOwner .! wallet1)
+      callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+
+noPendingAdmin
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+noPendingAdmin withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $
+    \[_, wallet1] baseDao -> do
+      callFrom (AddressResolved wallet1) baseDao (Call @"Accept_ownership") ()
+      & expectNotPendingOwner
+
+pendingOwnerNotTheSame
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+pendingOwnerNotTheSame withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $
+    \[owner, wallet1] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Transfer_ownership")
+        (#newOwner .! wallet1)
+      callFrom (AddressResolved owner) baseDao (Call @"Accept_ownership") ()
+      & expectNotPendingOwner
+
+acceptOwnerRespectMigration
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+acceptOwnerRespectMigration withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $
+    \[owner, newAddress1] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+      -- We test this by calling `confirmMigration` and seeing that it does not fail
+      callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+      callFrom (AddressResolved owner) baseDao (Call @"Accept_ownership") ()
+        & expectMigrated newAddress1
+
+
+migrationAuthenticateSender
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+migrationAuthenticateSender withOriginatedFn initialStorage =
+  withOriginatedFn 3 (\(owner:_) -> initialStorage owner) $
+    \[_, newAddress1, randomAddress] baseDao -> do
+      callFrom (AddressResolved randomAddress) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+        & expectNotAdmin
+
+migrationSetPendingOwner
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+migrationSetPendingOwner withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $
+    \[owner, newAddress1] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+      -- We test this by calling `confirmMigration` and seeing that it does not fail
+      callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+
+migrationOverwritePrevious
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+migrationOverwritePrevious withOriginatedFn initialStorage =
+  withOriginatedFn 3 (\(owner:_) -> initialStorage owner) $
+    \[owner, newAddress1, newAddress2] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+      callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress2)
+      -- We test this by calling `confirmMigration` and seeing that it does not fail
+      callFrom (AddressResolved newAddress2) baseDao (Call @"Confirm_migration") ()
+
+migrationAllowCallUntilConfirm
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+migrationAllowCallUntilConfirm withOriginatedFn initialStorage =
+  withOriginatedFn 3 (\(owner:_) -> initialStorage owner) $
+    \[owner, newAddress1, newAddress2] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+      callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress2)
+
+confirmMigAuthenticateSender
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+confirmMigAuthenticateSender withOriginatedFn initialStorage =
+  withOriginatedFn 3 (\(owner:_) -> initialStorage owner) $
+    \[owner, newAddress1, randomAddress] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+      -- We test this by calling `confirmMigration` and seeing that it does not fail
+      callFrom (AddressResolved randomAddress) baseDao (Call @"Confirm_migration") ()
+        & expectNotMigrationTarget
+
+confirmMigAuthenticateState
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+confirmMigAuthenticateState withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $
+    \[_, newAddress1] baseDao -> do
+      callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+        & expectNotMigrating
+
+confirmMigFinalize
+  :: forall caps base m param pm st
+  . (MonadNettest caps base m, DAO.ParameterC param pm)
+  => WithOriginateFn m param st -> WithStorage st -> m ()
+confirmMigFinalize withOriginatedFn initialStorage =
+  withOriginatedFn 2 (\(owner:_) -> initialStorage owner) $
+    \[owner, newAddress1] baseDao -> do
+      callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+      -- We test this by calling `confirmMigration` and seeing that it does not fail
+      callFrom (AddressResolved newAddress1) baseDao (Call @"Confirm_migration") ()
+      callFrom (AddressResolved owner) baseDao (Call @"Migrate") (#newAddress .! newAddress1)
+        & expectMigrated newAddress1
+
+expectNotAdmin
+  :: (MonadNettest caps base m)
+  => m a -> m ()
+expectNotAdmin = expectCustomError_ #nOT_ADMIN
+
+expectNotPendingOwner
+  :: (MonadNettest caps base m)
+  => m a -> m ()
+expectNotPendingOwner = expectCustomError_ #nOT_PENDING_ADMIN
+
+expectNotMigrating
+  :: (MonadNettest caps base m)
+  => m a -> m ()
+expectNotMigrating = expectCustomError_ #nOT_MIGRATING
+
+expectNotMigrationTarget
+  :: (MonadNettest caps base m)
+  => m a -> m ()
+expectNotMigrationTarget = expectCustomError_ #nOT_MIGRATION_TARGET
+
+expectMigrated
+  :: (MonadNettest caps base m)
+  => Address -> m a -> m ()
+expectMigrated addr = expectCustomError #mIGRATED addr
+
+expectForbiddenXTZ
+  :: (MonadNettest caps base m)
+  => m a -> m ()
+expectForbiddenXTZ = expectCustomError_ #fORBIDDEN_XTZ

--- a/test/Test/Common.hs
+++ b/test/Test/Common.hs
@@ -5,7 +5,6 @@
 
 module Test.Common
   ( checkTokenBalance
-  , withOriginated
   , originateTrivialDao
   , originateBaseDaoWithConfig
   , originateBaseDaoWithBalance
@@ -28,27 +27,6 @@ import qualified Lorentz.Contracts.BaseDAO as DAO
 import Lorentz.Contracts.BaseDAO.Types
 import qualified Lorentz.Contracts.BaseDAO.Types as DAO
 import qualified Lorentz.Contracts.TrivialDAO as DAO
-
--- | Function that originates the contract and also make a bunch of
--- address (the `addrCount` arg determines the count) for use within
--- the tests. It is not pretty, but IMO it makes the test a bit less
--- verbose.
-withOriginated
-  :: MonadNettest caps base m
-  => Integer
-  -> ([Address] -> (Storage () ()))
-  -> ([Address] -> TAddress (Parameter () Empty) -> m a)
-  -> m a
-withOriginated addrCount storageFn tests = do
-  addresses <- mapM (\x -> newAddress $ "address" <> (show x)) [1 ..addrCount]
-  baseDao <- originate $ OriginateData
-    { odFrom = nettestAddress
-    , odName = "BaseDAO Test Contract"
-    , odBalance = zeroMutez
-    , odStorage = storageFn addresses
-    , odContract = DAO.baseDaoContract DAO.defaultConfig
-    }
-  tests addresses baseDao
 
 -- | Helper functions which originate BaseDAO with a predefined owners, operators and initial storage.
 -- used in FA2 Proposals tests.


### PR DESCRIPTION
## Description

Problem: Management tests between Lorentz and LIGO version are very
similar. We should create shared tests to use between them instead to
reduce duplication.

Solution: Make management tests shared between Lorentz and LIGO.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #129 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
