### PR TITLE
[#131] Remove `FAILWITH` `Pair "string" Unit` from LIGO 

### DIFF
--- a/baseDAO.cabal
+++ b/baseDAO.cabal
@@ -51,6 +51,7 @@ library
       Lorentz.Contracts.TreasuryDAO.Doc
       Lorentz.Contracts.TreasuryDAO.Types
       Lorentz.Contracts.TrivialDAO
+      Lorentz.Helper
   other-modules:
       Paths_baseDAO
   autogen-modules:

--- a/ligo/haskell/test/Test/Ligo/BaseDAO/Management.hs
+++ b/ligo/haskell/test/Test/Ligo/BaseDAO/Management.hs
@@ -60,7 +60,7 @@ test_BaseDAO_Management =
             , tdEntrypoint = unsafeBuildEpName "transfer_ownership"
             , tdParameter = (#newOwner .! wallet1)
             }
-          & expectForbiddenXTZ
+          & expectForbiddenXTZ (toAddress baseDao)
 
     , nettestScenarioCaps "transfer ownership entrypoint authenticates sender" $
         transferOwnership withOriginated initialStorage

--- a/ligo/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/ligo/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -16,7 +16,8 @@ import Morley.Nettest.Tasty
 import Test.Tasty (TestTree, testGroup)
 import Time (sec)
 
-import BaseDAO.ShareTest.Common (OriginateFn, checkTokenBalance, makeProposalKey, sendXtz)
+import BaseDAO.ShareTest.Common
+  (OriginateFn, checkTokenBalance, expectFailed, makeProposalKey, sendXtz)
 import qualified Lorentz.Contracts.BaseDAO.Types as DAO
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.TreasuryDAO.Types
@@ -66,7 +67,7 @@ validProposal = uncapsNettest $ withFrozenCallStack do
     proposalSize = metadataSize proposalMeta
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") (ProposeParams (proposalSize + 1) proposalMeta)
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectFailed (toAddress dao) [mt|FAIL_PROPOSAL_CHECK|]
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") (ProposeParams proposalSize proposalMeta)
 
@@ -149,11 +150,11 @@ flushXtzTransfer = uncapsNettest $ withFrozenCallStack $ do
 
   -- due to smaller than y (min mutez allow)
   callFrom (AddressResolved owner1) dao (Call @"Propose") (proposeParams 1)
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectFailed (toAddress dao) [mt|FAIL_PROPOSAL_CHECK|]
 
   -- due to bigger than z (max mutez allow)
   callFrom (AddressResolved owner1) dao (Call @"Propose") (proposeParams 6)
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectFailed (toAddress dao) [mt|FAIL_PROPOSAL_CHECK|]
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") (proposeParams 3)
   let key1 = makeProposalKey (proposeParams 3) owner1

--- a/ligo/src/base_DAO.mligo
+++ b/ligo/src/base_DAO.mligo
@@ -26,9 +26,7 @@ let base_DAO_contract
             | M_right (fbp) ->
                 let result =
                   if Tezos.amount > 0tez
-                    then
-                      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-                        ("FORBIDDEN_XTZ", ()) : return)
+                    then (failwith("FORBIDDEN_XTZ"): return)
                     else
                       begin
                         match fbp with

--- a/ligo/src/common.mligo
+++ b/ligo/src/common.mligo
@@ -10,8 +10,6 @@
 let authorize_admin (store : storage): storage =
   if sender = store.admin then
     store
-  else
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-        ("NOT_ADMIN", ()) : storage)
+  else (failwith("NOT_ADMIN"): storage)
 
 #endif

--- a/ligo/src/management.mligo
+++ b/ligo/src/management.mligo
@@ -32,9 +32,7 @@ let transfer_ownership
 let accept_ownership(param, store : unit * storage) : return =
   if store.pending_owner = Tezos.sender
     then (([] : operation list), { store with admin = store.pending_owner })
-    else
-      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-        ("NOT_PENDING_ADMIN", ()) : return)
+    else (failwith("NOT_PENDING_ADMIN"): return)
 
 (*
  * Auth check for admin and sets the migration status to 'MigratingTo' using
@@ -51,17 +49,13 @@ let migrate(param, store : migrate_param * storage) : return =
  *)
 let confirm_migration(param, store : unit * storage) : return =
   match store.migration_status with
-    Not_in_migration ->
-      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-        ("NOT_MIGRATING", ()) : return)
+    Not_in_migration -> (failwith("NOT_MIGRATING"): return)
   | MigratingTo (new_addr) -> if new_addr = Tezos.sender
       then (([] : operation list), { store with migration_status = MigratedTo (new_addr) })
-      else
-        ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-          ("NOT_MIGRATION_TARGET", ()) : return)
+      else (failwith("NOT_MIGRATION_TARGET"): return)
   | MigratedTo (new_addr)  ->
-      ([%Michelson ({| { FAILWITH } |} : string * address -> return)]
-        ("MIGRATED", new_addr) : return)
+    ([%Michelson ({| { FAILWITH } |} : string * address -> return)]
+      ("MIGRATED", new_addr) : return)
 
 (*
  * Call a custom entrypoint. Looks up the packed code for entrypoint using the entrypoint
@@ -81,10 +75,6 @@ let call_custom(param, full_storage : custom_ep_param * full_storage) : return_w
       begin
         match ((Bytes.unpack ep_code) : ((bytes * full_storage) -> return_with_full_storage) option) with
           Some lambda -> lambda (packed_param, full_storage)
-        | None ->
-            ([%Michelson ({| { FAILWITH } |} : string * unit -> return_with_full_storage)]
-              ("UNPACKING_FAILED", ()) : return_with_full_storage)
+        | None -> (failwith("UNPACKING_FAILED"): return_with_full_storage)
       end
-  | None ->
-      ([%Michelson ({| { FAILWITH } |} : string * unit -> return_with_full_storage)]
-        ("ENTRYPOINT_NOT_FOUND", ()) : return_with_full_storage)
+  | None -> (failwith("ENTRYPOINT_NOT_FOUND"): return_with_full_storage)

--- a/ligo/src/proposal.mligo
+++ b/ligo/src/proposal.mligo
@@ -20,23 +20,19 @@ let to_proposal_key (propose_params, sender_addr : propose_params * address): pr
 let check_if_proposal_exist (proposal_key, store : proposal_key * storage): proposal =
   match Map.find_opt proposal_key store.proposals with
     Some p -> p
-  | None ->
-      ([%Michelson ({| { FAILWITH } |} : string * unit -> proposal)]
-        ("PROPOSAL_NOT_EXIST", ()))
+  | None -> (failwith("PROPOSAL_NOT_EXIST"): proposal)
 
 [@inline]
 let ensure_voting_period_is_not_over (proposal, store : proposal * storage): storage =
   if Tezos.now >= proposal.start_date + int(store.voting_period)
-    then ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-          ("VOTING_PERIOD_OVER", ()) : storage)
+    then (failwith("VOTING_PERIOD_OVER"): storage)
     else store
 
 [@inline]
 let ensure_proposal_is_unique (propose_params, store : propose_params * storage): proposal_key =
   let proposal_key = to_proposal_key(propose_params, sender) in
   if Map.mem proposal_key store.proposals
-    then ([%Michelson ({| { FAILWITH } |} : string * unit -> proposal_key)]
-        ("PROPOSAL_NOT_UNIQUE", ()) : proposal_key)
+    then (failwith("PROPOSAL_NOT_UNIQUE"): proposal_key)
     else proposal_key
 
 // -----------------------------------------------------------------
@@ -47,8 +43,7 @@ let ensure_proposal_is_unique (propose_params, store : propose_params * storage)
 let check_is_proposal_valid (config, propose_params, store : config * propose_params * storage): storage =
   if config.proposal_check (propose_params, store)
     then store
-    else ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-          ("FAIL_PROPOSAL_CHECK", ()) : storage)
+    else (failwith("FAIL_PROPOSAL_CHECK"): storage)
 
 [@inline]
 let check_proposer_unfrozen_token (propose_params, store : propose_params * storage): storage =
@@ -60,15 +55,13 @@ let check_proposer_unfrozen_token (propose_params, store : propose_params * stor
     | Some v -> v
     in
   if propose_params.frozen_token > current_balance
-    then ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-          ("PROPOSAL_INSUFFICIENT_BALANCE", ()) : storage)
+    then (failwith("PROPOSAL_INSUFFICIENT_BALANCE"): storage)
     else store
 
 [@inline]
 let check_proposal_limit_reached (config, propose_params, store : config * propose_params * storage): storage =
   if config.max_proposals <= List.length store.proposal_key_list_sort_by_date
-    then ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-          ("MAX_PROPOSALS_REACHED", ()) : storage)
+    then (failwith("MAX_PROPOSALS_REACHED"): storage)
     else store
 
 let freeze (tokens, addr, store : nat * address * storage): storage =
@@ -121,13 +114,12 @@ let check_voter_unfrozen_token (vote_param, author, store : vote_param * address
   let current_balance =
     match Map.find_opt (author, unfrozen_token_id) store.ledger with
       None ->
-        ([%Michelson ({| { FAILWITH } |} : string * (nat * nat) -> nat)]
+         ([%Michelson ({| { FAILWITH } |} : string * (nat * nat) -> nat)]
           ("FA2_INSUFFICIENT_BALANCE", (vote_param.vote_amount, 0n)) : nat)
     | Some value -> value
     in
   if vote_param.vote_amount > current_balance
-    then ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-          ("VOTING_INSUFFICIENT_BALANCE", ()) : storage)
+    then (failwith("VOTING_INSUFFICIENT_BALANCE"): storage)
     else store
 
 [@inline]
@@ -154,8 +146,7 @@ let submit_vote (proposal, vote_param, author, store : proposal * vote_param * a
 let check_vote_limit_reached
     (config, proposal, vote_param : config * proposal * vote_param): vote_param =
   if config.max_votes < proposal.upvotes + proposal.downvotes + vote_param.vote_amount
-    then ([%Michelson ({| { FAILWITH } |} : string * unit -> vote_param)]
-          ("MAX_VOTES_REACHED", ()) : vote_param)
+    then (failwith("MAX_VOTES_REACHED"): vote_param)
     else vote_param
 
 let vote(votes, config, store : vote_param_permited list * config * storage): return =
@@ -183,8 +174,7 @@ let set_voting_period(new_period, config, store : voting_period * config * stora
   let store =
     if   config.max_voting_period < new_period
       || config.min_voting_period > new_period
-      then ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-            ("OUT_OF_BOUND_VOTING_PERIOD", ()) : storage)
+      then (failwith("OUT_OF_BOUND_VOTING_PERIOD"): storage)
       else store
     in
   let store = { store with voting_period = new_period } in
@@ -198,8 +188,7 @@ let set_quorum_threshold(new_threshold, config, store : quorum_threshold * confi
   let store =
     if   config.max_quorum_threshold < new_threshold
       || config.min_quorum_threshold > new_threshold
-      then ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-            ("OUT_OF_BOUND_QUORUM_THRESHOLD", ()) : storage)
+      then (failwith("OUT_OF_BOUND_QUORUM_THRESHOLD"): storage)
       else store
     in
   let store = { store with quorum_threshold = new_threshold } in
@@ -212,9 +201,7 @@ let check_balance_less_then_frozen_value
       : nat * address * proposal * proposal_key * storage): nat =
   let actual_frozen_value =
     match Map.find_opt (addr, frozen_token_id) store.ledger with
-      None ->
-        ([%Michelson ({| { FAILWITH } |} : string * unit -> nat)]
-          ("PROPOSER_NOT_EXIST_IN_LEDGER", ()) : nat)
+      None -> (failwith("PROPOSER_NOT_EXIST_IN_LEDGER"): nat)
     | Some value -> value
     in
   if unfreeze_value > actual_frozen_value
@@ -309,9 +296,7 @@ let handle_proposal_is_over
 let flush(n, config, store : nat * config * storage): return =
   let store =
     if n = 0n
-      then
-        ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-          ("BAD_ENTRYPOINT_PARAMETER", ()) : storage)
+      then (failwith("BAD_ENTRYPOINT_PARAMETER"): storage)
       else store
     in
 
@@ -342,9 +327,5 @@ let drop_proposal (proposal_key, config, store : proposal_key * config * storage
       let store = unfreeze_proposer_and_voter_token (config, true, proposal, proposal_key, store) in
       let store = delete_proposal (proposal.start_date, proposal_key, store) in
       (([] : operation list), store)
-    else
-      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-        ("FAIL_DROP_PROPOSAL_NOT_ACCEPTED", ()) : return)
-  else
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-      ("FAIL_DROP_PROPOSAL_NOT_OVER", ()) : return)
+    else (failwith("FAIL_DROP_PROPOSAL_NOT_ACCEPTED"): return)
+  else (failwith("FAIL_DROP_PROPOSAL_NOT_OVER"): return)

--- a/ligo/src/token.mligo
+++ b/ligo/src/token.mligo
@@ -31,7 +31,4 @@ let transfer_contract_tokens
     Some contract ->
       let transfer_operation = Tezos.transaction param.params 0mutez contract
       in (([transfer_operation] : operation list), store)
-  | None ->
-      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-        ("FAIL_TRANSFER_CONTRACT_TOKENS", ()) : return)
-
+  | None -> (failwith("FAIL_TRANSFER_CONTRACT_TOKENS"): return)

--- a/ligo/src/token/fa2.mligo
+++ b/ligo/src/token/fa2.mligo
@@ -22,8 +22,7 @@ let check_sender (from_ , store : address * storage): address =
     if Big_map.mem key store.operators then
       from_
     else
-     ([%Michelson ({| { FAILWITH } |} : string * unit -> address)]
-        ("FA2_NOT_OPERATOR", ()) : address)
+      (failwith("FA2_NOT_OPERATOR"): address)
 
 [@inline]
 let debit_from (amt, from_, token_id, store: nat * address * token_id * storage): storage =
@@ -68,11 +67,9 @@ let transfer_item (store, ti : storage * transfer_item): storage =
         else if tx.token_id = frozen_token_id then (
           if sender = store.admin then tx.token_id
           else
-            ([%Michelson ({| { FAILWITH } |} : string * unit -> token_id)]
-              ("FROZEN_TOKEN_NOT_TRANSFERABLE", ()) : token_id)
+            (failwith("FROZEN_TOKEN_NOT_TRANSFERABLE"): token_id)
         ) else
-            ([%Michelson ({| { FAILWITH } |} : string * unit -> token_id)]
-              ("FA2_TOKEN_UNDEFINED", ()) : token_id)
+            (failwith("FA2_TOKEN_UNDEFINED"): token_id)
       in credit_to
         ( tx.amount, tx.to_, valid_token_id
         , debit_from (tx.amount, valid_from_, valid_token_id, store)
@@ -93,8 +90,7 @@ let transfer (params, store : transfer_params * storage): return =
 let validate_token_type (token_id : token_id): token_id =
   if (token_id = unfrozen_token_id || token_id = frozen_token_id) then
     token_id
-  else ([%Michelson ({| { FAILWITH } |} : string * unit -> token_id)]
-          ("FA2_TOKEN_UNDEFINED", ()) : token_id)
+  else (failwith("FA2_TOKEN_UNDEFINED"): token_id)
 
 let balance_of (params, store : balance_request_params * storage): return =
   let check_one (req : balance_request_item): balance_response_item =
@@ -115,11 +111,9 @@ let validate_operator_token (token_id : token_id): token_id =
   if (token_id = unfrozen_token_id) then
     token_id
   else if (token_id = frozen_token_id) then
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> token_id)]
-      ("OPERATION_PROHIBITED", ()) : token_id)
+    (failwith("OPERATION_PROHIBITED"): token_id)
   else
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> token_id)]
-      ("FA2_TOKEN_UNDEFINED", ()) : token_id)
+    (failwith("FA2_TOKEN_UNDEFINED"): token_id)
 
 let update_one (store, param: storage * update_operator): storage =
   let (operator_update, operator_param) =
@@ -134,9 +128,7 @@ let update_one (store, param: storage * update_operator): storage =
     in  { store with
           operators = updated_operators
         }
-  else
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-      ("NOT_OWNER", ()) : storage)
+  else (failwith("NOT_OWNER"): storage)
 
 let update_operators (params, store : update_operators_param * storage):return =
   let store = List.fold update_one params store in

--- a/ligo/src/treasuryDAO.mligo
+++ b/ligo/src/treasuryDAO.mligo
@@ -94,8 +94,7 @@ let treasury_DAO_decision_lambda (proposal, store : proposal * storage) : return
     (ops, store)
   else
     // TODO: [#87] Improve handling of failed proposals
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-        ("FAIL_DECISION_LAMBDA", ()) : return)
+    (failwith("FAIL_DECISION_LAMBDA"): return)
 
 // A custom entrypoint needed to receive xtz, since most `basedao` entrypoints
 // prohibit non-zero xtz transfer.

--- a/src/BaseDAO/ShareTest/Common.hs
+++ b/src/BaseDAO/ShareTest/Common.hs
@@ -48,10 +48,30 @@ type IsLorentz = Bool
 
 -- | Used for check error from ligo contract
 expectFailed
- :: forall caps base m
-  . (MonadNettest caps base m)
-  => Address -> MText -> m () -> m ()
-expectFailed addr val = flip expectFailure (NettestFailedWith addr val)
+ :: forall caps base m a
+  . (MonadNettest caps base m, HasCallStack)
+  => Address -> MText -> m a -> m ()
+expectFailed addr val = withFrozenCallStack $
+  flip expectFailure (NettestFailedWith addr val)
+
+-- -- | Used for check error from ligo contract
+-- expectFailed
+--  :: forall caps base m
+--   . (MonadNettest caps base m, HasCallStack)
+--   => Address -> MText -> m () -> m ()
+-- expectFailed addr val ma =
+--   expectFailed "FA2_TOKEN_UNDEFINED ma
+--     `catch`
+--       (\_ -> expectFailedText addr val ma)
+  -- let mb = expectFailed "FA2_TOKEN_UNDEFINED ma
+  -- in withFrozenCallStack $
+  --     try @_ @SomeException mb >>= \case
+  --       Right _ -> mb
+  --       Left _ -> expectFailedText addr val ma
+
+-- expectStringError :: _
+-- expectStringError val act =
+
 
 -- | Helper functions which originate BaseDAO with a predefined owners, operators and initial storage.
 -- used in FA2 Proposals tests.

--- a/src/BaseDAO/ShareTest/Proposal/Bounds.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Bounds.hs
@@ -32,7 +32,7 @@ setVotingPeriod _ originateFn = do
   let param = 60 * 60 -- 1 hour
 
   callFrom (AddressResolved owner1) dao (Call @"Set_voting_period") param
-    & expectCustomError_ #nOT_ADMIN
+    & expectFailed (toAddress dao) [mt|NOT_ADMIN|]
 
   callFrom (AddressResolved admin) dao (Call @"Set_voting_period") param
   -- TODO [#31]: checkStorage
@@ -51,7 +51,7 @@ setQuorumThreshold _ originateFn = do
   let param = 100
 
   callFrom (AddressResolved owner1) dao (Call @"Set_quorum_threshold") param
-    & expectCustomError_ #nOT_ADMIN
+    & expectFailed (toAddress dao) [mt|NOT_ADMIN|]
 
   callFrom (AddressResolved admin) dao (Call @"Set_quorum_threshold") param
   -- TODO [#31]: checkStorage
@@ -77,7 +77,7 @@ proposalBoundedValue _ originateFn = do
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") params
   callFrom (AddressResolved owner1) dao (Call @"Propose") params
-    & expectCustomError_ #mAX_PROPOSALS_REACHED
+    & expectFailed (toAddress dao) [mt|MAX_PROPOSALS_REACHED|]
 
 votesBoundedValue
   :: forall pm param config caps base m.
@@ -107,7 +107,7 @@ votesBoundedValue _ originateFn = do
 
   callFrom (AddressResolved owner1) dao (Call @"Vote") [downvote]
   callFrom (AddressResolved owner1) dao (Call @"Vote") [upvote]
-    & expectCustomError_ #mAX_VOTES_REACHED
+    & expectFailed (toAddress dao) [mt|MAX_VOTES_REACHED|]
 
 quorumThresholdBound
   :: forall pm param config caps base m.
@@ -127,9 +127,9 @@ quorumThresholdBound _ originateFn = do
   callFrom (AddressResolved admin) dao (Call @"Set_quorum_threshold") 1
   callFrom (AddressResolved admin) dao (Call @"Set_quorum_threshold") 2
   callFrom (AddressResolved admin) dao (Call @"Set_quorum_threshold") 0
-    & expectCustomError_ #oUT_OF_BOUND_QUORUM_THRESHOLD
+    & expectFailed (toAddress dao) [mt|OUT_OF_BOUND_QUORUM_THRESHOLD|]
   callFrom (AddressResolved admin) dao (Call @"Set_quorum_threshold") 3
-    & expectCustomError_ #oUT_OF_BOUND_QUORUM_THRESHOLD
+    & expectFailed (toAddress dao) [mt|OUT_OF_BOUND_QUORUM_THRESHOLD|]
 
 votingPeriodBound
   :: forall pm param config caps base m.
@@ -149,6 +149,6 @@ votingPeriodBound _ originateFn = do
   callFrom (AddressResolved admin) dao (Call @"Set_voting_period") 1
   callFrom (AddressResolved admin) dao (Call @"Set_voting_period") 2
   callFrom (AddressResolved admin) dao (Call @"Set_voting_period") 0
-    & expectCustomError_ #oUT_OF_BOUND_VOTING_PERIOD
+    & expectFailed (toAddress dao) [mt|OUT_OF_BOUND_VOTING_PERIOD|]
   callFrom (AddressResolved admin) dao (Call @"Set_voting_period") 3
-    & expectCustomError_ #oUT_OF_BOUND_VOTING_PERIOD
+    & expectFailed (toAddress dao) [mt|OUT_OF_BOUND_VOTING_PERIOD|]

--- a/src/BaseDAO/ShareTest/Proposal/Flush.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Flush.hs
@@ -90,7 +90,7 @@ flushAcceptedProposals _ originateFn = do
 
   -- TODO: [#31]
   -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomError_ #pROPOSAL_NOT_EXIST
+  --   & expectFailed (toAddress dao) [mt|PROPOSAL_NOT_EXIST|]
 
   checkTokenBalance (frozenTokenId) dao owner1 0
   checkTokenBalance (unfrozenTokenId) dao owner1 100 -- proposer
@@ -138,13 +138,13 @@ flushAcceptedProposalsWithAnAmount _ originateFn = do
 
   -- Proposals are flushed
   callFrom (AddressResolved owner2) dao (Call @"Vote") [vote key1]
-    & expectCustomError_ #vOTING_PERIOD_OVER
+    & expectFailed (toAddress dao) [mt|VOTING_PERIOD_OVER|]
   callFrom (AddressResolved owner2) dao (Call @"Vote") [vote key2]
-    & expectCustomError_ #vOTING_PERIOD_OVER
+    & expectFailed (toAddress dao) [mt|VOTING_PERIOD_OVER|]
 
   -- Proposal is over but not affected
   callFrom (AddressResolved owner2) dao (Call @"Vote") [vote key3]
-    & expectCustomError_ #vOTING_PERIOD_OVER
+    & expectFailed (toAddress dao) [mt|VOTING_PERIOD_OVER|]
 
   -- Proposal is not yet over
   callFrom (AddressResolved owner2) dao (Call @"Vote") [vote key4]
@@ -189,7 +189,7 @@ flushRejectProposalQuorum _ originateFn = do
 
   -- TODO: [#31]
   -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomError_ #pROPOSAL_NOT_EXIST
+  --   & expectFailed (toAddress dao) [mt|PROPOSAL_NOT_EXIST|]
 
   checkTokenBalance (frozenTokenId) dao owner1 0
   checkTokenBalance (unfrozenTokenId) dao owner1 95 -- proposer: cRejectedValue reduce frozen token by half
@@ -240,7 +240,7 @@ flushRejectProposalNegativeVotes _ originateFn = do
 
   -- TODO: [#31]
   -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomError_ #pROPOSAL_NOT_EXIST
+  --   & expectFailed (toAddress dao) [mt|PROPOSAL_NOT_EXIST|]
 
   checkTokenBalance (frozenTokenId) dao owner1 0
   checkTokenBalance (unfrozenTokenId) dao owner1 95 -- proposer: cRejectedValue reduce frozen token by half
@@ -275,7 +275,7 @@ flushWithBadConfig _ originateFn = do
 
   -- TODO: [#31]
   -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomError_ #pROPOSAL_NOT_EXIST
+  --   & expectFailed (toAddress dao) [mt|PROPOSAL_NOT_EXIST|]
 
   checkTokenBalance (frozenTokenId) dao owner1 0
   checkTokenBalance (unfrozenTokenId) dao owner1 90 -- slash all frozen values
@@ -347,9 +347,9 @@ dropProposal _ originateFn = do
 
   callFrom (AddressResolved admin) dao (Call @"Drop_proposal") key1
   callFrom (AddressResolved admin) dao (Call @"Drop_proposal") key2
-    & expectCustomError_ #fAIL_DROP_PROPOSAL_NOT_ACCEPTED
+    & expectFailed (toAddress dao) [mt|FAIL_DROP_PROPOSAL_NOT_ACCEPTED|]
   callFrom (AddressResolved admin) dao (Call @"Drop_proposal") key3
-    & expectCustomError_ #fAIL_DROP_PROPOSAL_NOT_OVER
+    & expectFailed (toAddress dao) [mt|FAIL_DROP_PROPOSAL_NOT_OVER|]
 
   -- 30 tokens are frozen in total, but 10 tokens are returned after drop_proposal
   checkTokenBalance (frozenTokenId) dao owner1 20

--- a/src/BaseDAO/ShareTest/Proposal/Proposal.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Proposal.hs
@@ -55,7 +55,7 @@ rejectProposal _ originateFn = do
         }
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") params
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectFailed (toAddress dao) [mt|FAIL_PROPOSAL_CHECK|]
 
 insufficientTokenProposal
   :: forall pm param config caps base m.
@@ -72,7 +72,7 @@ insufficientTokenProposal _ originateFn = do
         }
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") params
-    & expectCustomError_ #pROPOSAL_INSUFFICIENT_BALANCE
+    & expectFailed (toAddress dao) [mt|PROPOSAL_INSUFFICIENT_BALANCE|]
 
 nonUniqueProposal
   :: forall pm param config caps base m.
@@ -85,7 +85,7 @@ nonUniqueProposal _ originateFn = do
   ((owner1, _), _, dao, _) <- originateFn testConfig
   _ <- createSampleProposal 1 owner1 dao
   createSampleProposal 1 owner1 dao
-    & expectCustomError_ #pROPOSAL_NOT_UNIQUE
+    & expectFailed (toAddress dao) [mt|PROPOSAL_NOT_UNIQUE|]
 
 voteValidProposal
   :: forall pm param config caps base m.

--- a/src/BaseDAO/ShareTest/Proposal/Vote.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Vote.hs
@@ -38,7 +38,7 @@ voteNonExistingProposal _ originateFn = do
         }
 
   callFrom (AddressResolved owner2) dao (Call @"Vote") [params]
-    & expectCustomError_ #pROPOSAL_NOT_EXIST
+    & expectFailed (toAddress dao) [mt|PROPOSAL_NOT_EXIST|]
 
 voteMultiProposals
   :: forall pm param config caps base m.
@@ -98,7 +98,7 @@ insufficientTokenVote _ originateFn = do
         ]
 
   callFrom (AddressResolved owner2) dao (Call @"Vote") params
-    & expectCustomError_ #vOTING_INSUFFICIENT_BALANCE
+    & expectFailed (toAddress dao) [mt|VOTING_INSUFFICIENT_BALANCE|]
 
 voteOutdatedProposal
   :: forall pm param config caps base m.
@@ -124,7 +124,7 @@ voteOutdatedProposal _ originateFn = do
   callFrom (AddressResolved owner2) dao (Call @"Vote") [params]
   advanceTime (sec 25)
   callFrom (AddressResolved owner2) dao (Call @"Vote") [params]
-    & expectCustomError_ #vOTING_PERIOD_OVER
+    & expectFailed (toAddress dao) [mt|VOTING_PERIOD_OVER|]
 
 voteWithPermit
   :: forall pm param config caps base m.

--- a/src/BaseDAO/ShareTest/Token.hs
+++ b/src/BaseDAO/ShareTest/Token.hs
@@ -28,7 +28,7 @@ burnScenario originateFn = do
   ((owner1, _), _, dao, admin) <- originateFn
 
   callFrom (AddressResolved owner1) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 10)
-    & expectCustomError_ #nOT_ADMIN
+    & expectFailed (toAddress dao) [mt|NOT_ADMIN|]
 
   callFrom (AddressResolved admin) dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 100)
     & expectCustomError #fA2_INSUFFICIENT_BALANCE (#required .! 100, #present .! 10)
@@ -49,7 +49,7 @@ mintScenario originateFn = do
   ((owner1, _), _, dao, admin) <- originateFn
 
   callFrom (AddressResolved owner1) dao (Call @"Mint") (DAO.MintParam owner1 DAO.unfrozenTokenId 10)
-    & expectCustomError_ #nOT_ADMIN
+    & expectFailed (toAddress dao) [mt|NOT_ADMIN|]
 
   callFrom (AddressResolved admin) dao (Call @"Mint") (DAO.MintParam owner1 DAO.unfrozenTokenId 100)
   checkTokenBalance (DAO.unfrozenTokenId) dao owner1 100
@@ -84,7 +84,7 @@ transferContractTokensScenario originateFn = do
         }
 
   callFrom (AddressResolved owner1) dao (Call @"Transfer_contract_tokens") param
-    & expectCustomError_ #nOT_ADMIN
+    & expectFailed (toAddress dao) [mt|NOT_ADMIN|]
 
   callFrom (AddressResolved admin) dao (Call @"Transfer_contract_tokens") param
   checkTokenBalance (DAO.unfrozenTokenId) fa2Contract target_owner1 90

--- a/src/Lorentz/Contracts/BaseDAO.hs
+++ b/src/Lorentz/Contracts/BaseDAO.hs
@@ -114,7 +114,7 @@ fa2Handler = do
 -- ensureZeroTransfer = do
 --   amount
 --   push zeroMutez
---   if IsEq then nop else failCustom_ #fORBIDDEN_XTZ
+--   if IsEq then nop else failAsText #fORBIDDEN_XTZ
 
 pushFuncContext
   :: (KnownValue ce, KnownValue pm)

--- a/src/Lorentz/Contracts/BaseDAO/Management.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Management.hs
@@ -16,6 +16,8 @@ import Lorentz.Contracts.BaseDAO.Doc
 import Lorentz.Contracts.BaseDAO.Types
 import Lorentz.Contracts.ManagedLedger.Doc (DRequireRole(..))
 
+import Lorentz.Helper (failAsText)
+
 -- | Set the value of pending owner in storage
 -- using the address in parameter.
 transferOwnership
@@ -80,11 +82,11 @@ confirmMigration = do
   doc $ DRequireRole "migration target contract"
   stGetField #sMigrationStatus
   caseT @MigrationStatus
-    ( #cNotInMigration /-> failCustom_ #nOT_MIGRATING
+    ( #cNotInMigration /-> failAsText #nOT_MIGRATING
     , #cMigratingTo /-> do
         dup
         sender
-        if IsEq then nop else failCustom_ #nOT_MIGRATION_TARGET
+        if IsEq then nop else failAsText #nOT_MIGRATION_TARGET
         wrap_ @MigrationStatus #cMigratedTo
         stSetField #sMigrationStatus
     , #cMigratedTo /-> failCustom #mIGRATED
@@ -98,7 +100,7 @@ authorizePendingOwner = do
   doc $ DRequireRole "pending owner"
   stGetField #sPendingOwner
   sender
-  if IsEq then nop else failCustom_ #nOT_PENDING_ADMIN
+  if IsEq then nop else failAsText #nOT_PENDING_ADMIN
 
 -- Authorise administrator.
 authorizeAdmin ::
@@ -106,4 +108,4 @@ authorizeAdmin ::
 authorizeAdmin = do
   doc $ DRequireRole "administrator"
   stGetField #sAdmin; sender;
-  if IsEq then nop else failCustom_ #nOT_ADMIN
+  if IsEq then nop else failAsText #nOT_ADMIN

--- a/src/Lorentz/Contracts/BaseDAO/Proposal.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Proposal.hs
@@ -20,6 +20,7 @@ import Lorentz.Contracts.BaseDAO.Permit
 import Lorentz.Contracts.BaseDAO.Token.FA2 (creditTo, debitFrom)
 import Lorentz.Contracts.BaseDAO.Types
 import Lorentz.Contracts.Spec.FA2Interface (TokenId)
+import Lorentz.Helper (failAsText)
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
@@ -39,7 +40,7 @@ checkIfProposalExist
   => (ProposalKey pm : store : s) :-> (Proposal pm : s)
 checkIfProposalExist = do
   stGet #sProposals
-  ifSome nop (failCustom_ #pROPOSAL_NOT_EXIST)
+  ifSome nop (failAsText #pROPOSAL_NOT_EXIST)
 
 ensureVotingPeriodIsNotOver
   :: forall store ce pm s. (KnownValue pm, StorageC store ce pm)
@@ -52,7 +53,7 @@ ensureVotingPeriodIsNotOver = do
   toNamed #expectedEndDate
   now; toNamed #currentDate
   if #currentDate >=. #expectedEndDate then
-    failCustom_ #vOTING_PERIOD_OVER
+    failAsText #vOTING_PERIOD_OVER
   else
     nop
 
@@ -64,7 +65,7 @@ ensureProposalIsUnique = do
   sender; swap; pair; toProposalKey
   stMem #sProposals
   if Holds then
-    failCustom_ #pROPOSAL_NOT_UNIQUE
+    failAsText #pROPOSAL_NOT_UNIQUE
   else nop
 
 ------------------------------------------------------------------------
@@ -80,7 +81,7 @@ checkIsProposalValid Config{..} = do
   if Holds then
     nop
   else
-    failCustom_ #fAIL_PROPOSAL_CHECK
+    failAsText #fAIL_PROPOSAL_CHECK
 
 checkProposerUnfrozenToken
   :: forall store ce pm. (StorageC store ce pm)
@@ -103,7 +104,7 @@ checkProposerUnfrozenToken = do
   duupX @2
   toFieldNamed #ppFrozenToken
   if #ppFrozenToken >. #current_balance then
-    failCustom_ #pROPOSAL_INSUFFICIENT_BALANCE
+    failAsText #pROPOSAL_INSUFFICIENT_BALANCE
   else do
     nop
 
@@ -118,7 +119,7 @@ checkProposalLimitReached Config{..} = do
   toNamed #currentAmount
   push (cMaxProposals); toNamed #maxAmount
   if #maxAmount <=. #currentAmount then
-    failCustom_ #mAX_PROPOSALS_REACHED
+    failAsText #mAX_PROPOSALS_REACHED
   else nop
 
 -- | Freeze the account's unfrozen token associated with the address
@@ -247,7 +248,7 @@ checkVoterUnfrozenToken = do
   duupX @2
   toFieldNamed #vVoteAmount
   if #vVoteAmount >. #currentBalance then
-    failCustom_ #vOTING_INSUFFICIENT_BALANCE
+    failAsText #vOTING_INSUFFICIENT_BALANCE
   else do
     nop
 
@@ -310,7 +311,7 @@ checkVoteLimitReached Config{..} = do
 
   push cMaxVotes; toNamed #maxAmount
   if #maxAmount <. #newAmount then
-    failCustom_ #mAX_VOTES_REACHED
+    failAsText #mAX_VOTES_REACHED
   else nop
 
 -- | Vote
@@ -370,12 +371,12 @@ setVotingPeriod Config{..}= do
   dup
   push cMaxVotingPeriod; toNamed #maxValue
   if #maxValue <. #newValue then
-    failCustom_ #oUT_OF_BOUND_VOTING_PERIOD
+    failAsText #oUT_OF_BOUND_VOTING_PERIOD
   else do
     dup
     push cMinVotingPeriod; toNamed #minValue
     if #minValue >. #newValue then
-      failCustom_ #oUT_OF_BOUND_VOTING_PERIOD
+      failAsText #oUT_OF_BOUND_VOTING_PERIOD
     else do
       fromNamed #newValue
       stSetField #sVotingPeriod
@@ -396,12 +397,12 @@ setQuorumThreshold Config{..} = do
   dup
   push cMaxQuorumThreshold; toNamed #maxValue
   if #maxValue <. #newValue then
-    failCustom_ #oUT_OF_BOUND_QUORUM_THRESHOLD
+    failAsText #oUT_OF_BOUND_QUORUM_THRESHOLD
   else do
     dup
     push cMinQuorumThreshold; toNamed #minValue
     if #minValue >. #newValue then
-      failCustom_ #oUT_OF_BOUND_QUORUM_THRESHOLD
+      failAsText #oUT_OF_BOUND_QUORUM_THRESHOLD
     else do
       fromNamed #newValue
       stSetField #sQuorumThreshold
@@ -423,7 +424,7 @@ checkBalanceLessThanFrozenValue = do
   push frozenTokenId; swap; pair
 
   stGet #sLedger; ifSome nop $ do
-    failCustom_ #pROPOSER_NOT_EXIST_IN_LEDGER
+    failAsText #pROPOSER_NOT_EXIST_IN_LEDGER
 
   stackType @[Natural, Address, store, "unfreeze_value" :! Natural, Proposal pm, ProposalKey pm, [Operation]]
   toNamed #actual_frozen_value
@@ -716,9 +717,9 @@ dropProposal config = do
       toField #pStartDate; deleteProposal
       swap; pair
     else do
-      failCustom_ #fAIL_DROP_PROPOSAL_NOT_ACCEPTED
+      failAsText #fAIL_DROP_PROPOSAL_NOT_ACCEPTED
   else do
-    failCustom_ #fAIL_DROP_PROPOSAL_NOT_OVER
+    failAsText #fAIL_DROP_PROPOSAL_NOT_OVER
 
 ensureNot :: forall a s.
   ( NiceParameter a, NiceStorage a
@@ -728,6 +729,6 @@ ensureNot input = do
   dup; toNamed #val
   push input; toNamed #input
   if #input ==. #val then
-    failCustom_ #bAD_ENTRYPOINT_PARAMETER
+    failAsText #bAD_ENTRYPOINT_PARAMETER
   else
     nop

--- a/src/Lorentz/Contracts/BaseDAO/TZIP16Metadata.hs
+++ b/src/Lorentz/Contracts/BaseDAO/TZIP16Metadata.hs
@@ -30,6 +30,7 @@ import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 
 import Lorentz.Contracts.BaseDAO.Token.FA2 (convertOperatorParam)
 import Lorentz.Contracts.BaseDAO.Types
+import Lorentz.Helper (failAsText)
 import qualified Paths_baseDAO as Paths
 
 -- | Piece of metadata defined by user.
@@ -184,7 +185,7 @@ tokenMetadataView MetadataSettings{ msConfig = MetadataConfig{..} } = View
               dup
               dip $ do
                 get
-                ifSome nop $ failCustom_ #fA2_TOKEN_UNDEFINED
+                ifSome nop $ failAsText #fA2_TOKEN_UNDEFINED
               pair
       ]
   }

--- a/src/Lorentz/Contracts/BaseDAO/Token.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Token.hs
@@ -14,6 +14,7 @@ import Lorentz.Contracts.BaseDAO.Management (authorizeAdmin, ensureNotMigrated)
 import Lorentz.Contracts.BaseDAO.Token.FA2 (creditTo, debitFrom)
 import Lorentz.Contracts.BaseDAO.Types
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
+import Lorentz.Helper (failAsText)
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
@@ -68,7 +69,7 @@ transferContractTokens = do
     toField #tcContractAddress
     contractCalling @FA2.Parameter (Call @"Transfer")
     ifSome nop $ do
-      failCustom_ #fAIL_TRANSFER_CONTRACT_TOKENS
+      failAsText #fAIL_TRANSFER_CONTRACT_TOKENS
     push zeroMutez
   transferTokens
   nil; swap; cons

--- a/src/Lorentz/Contracts/BaseDAO/Token/FA2.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Token/FA2.hs
@@ -18,6 +18,8 @@ import Lorentz.Contracts.BaseDAO.Doc (balanceOfDoc, transferDoc, updateOperators
 import Lorentz.Contracts.BaseDAO.Management (ensureNotMigrated)
 import Lorentz.Contracts.BaseDAO.Types
 import Lorentz.Contracts.Spec.FA2Interface
+import Lorentz.Helper (failAsText)
+
 
 defaultPermissionsDescriptor :: PermissionsDescriptor
 defaultPermissionsDescriptor = PermissionsDescriptor
@@ -83,8 +85,8 @@ transfer = do
           dig @5
           dup
           if_ (dug @5) $
-            failCustom_ #fROZEN_TOKEN_NOT_TRANSFERABLE
-        else failCustom_ #fA2_TOKEN_UNDEFINED
+            failAsText #fROZEN_TOKEN_NOT_TRANSFERABLE
+        else failAsText #fA2_TOKEN_UNDEFINED
       pair
       dup
       dig @3
@@ -117,7 +119,7 @@ transfer = do
         swap
         pair
         mem
-        if_ nop (failCustom_ #fA2_NOT_OPERATOR)
+        if_ nop (failAsText #fA2_NOT_OPERATOR)
 
 debitFrom
   :: forall store ce pm. (StorageC store ce pm, IsoValue store)
@@ -251,7 +253,7 @@ balanceOf = do
         push frozenTokenId
         if IsEq
         then nop
-        else failCustom_ #fA2_TOKEN_UNDEFINED
+        else failAsText #fA2_TOKEN_UNDEFINED
       swap
       pair
       dig @3
@@ -302,7 +304,7 @@ addOperator = do
   Lorentz.sender
   if IsEq
   then nop
-  else failCustom_ #nOT_OWNER
+  else failAsText #nOT_OWNER
   stackType @("owner" :! Address : "operator" :! Address : Storage ce pm : s)
   pair
   swap
@@ -335,7 +337,7 @@ removeOperator = do
   Lorentz.sender
   if IsEq
   then nop
-  else failCustom_ #nOT_OWNER
+  else failAsText #nOT_OWNER
   stackType @("owner" :! Address : "operator" :! Address : Storage ce pm : s)
   pair
   swap
@@ -380,4 +382,4 @@ validateOperatorToken = do
     push frozenTokenId
     if IsEq
     then failUsing [mt|OPERATION_PROHIBITED|]
-    else failCustom_ #fA2_TOKEN_UNDEFINED
+    else failAsText #fA2_TOKEN_UNDEFINED

--- a/src/Lorentz/Contracts/GameDAO.hs
+++ b/src/Lorentz/Contracts/GameDAO.hs
@@ -22,6 +22,7 @@ import Lorentz
 
 import qualified Lorentz.Contracts.BaseDAO as DAO
 import qualified Lorentz.Contracts.BaseDAO.Types as DAO
+import Lorentz.Helper (failAsText)
 import Universum hiding (drop, swap, (>>))
 import Util.Markdown
 
@@ -215,7 +216,7 @@ decisionLambda = do
     toField #pmConsumerAddr
     contractCallingUnsafe @MText DefEpName
     ifSome nop $ do
-      failCustom_ #fAIL_DECISION_LAMBDA
+      failAsText #fAIL_DECISION_LAMBDA
     push zeroMutez
   transferTokens
   nil; swap; cons

--- a/src/Lorentz/Contracts/TreasuryDAO.hs
+++ b/src/Lorentz/Contracts/TreasuryDAO.hs
@@ -17,6 +17,7 @@ import qualified Lorentz.Contracts.BaseDAO.Types as DAO
 import Lorentz.Contracts.BaseDAO.Management (ensureNotMigrated)
 import Lorentz.Contracts.TreasuryDAO.Doc
 import Lorentz.Contracts.TreasuryDAO.Types
+import Lorentz.Helper (failAsText)
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
@@ -140,7 +141,7 @@ decisionLambda = do
   if Holds then do
     -- drop; nil
     -- TODO: [#87] Improve handling of failed proposals
-    failCustom_ #fAIL_DECISION_LAMBDA
+    failAsText #fAIL_DECISION_LAMBDA
   else
     nop
 

--- a/src/Lorentz/Helper.hs
+++ b/src/Lorentz/Helper.hs
@@ -1,0 +1,13 @@
+-- SPDX-FileCopyrightText: 2020 TQ Tezos
+-- SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+-- | Simplest DAOs on top of BaseDAO.
+module Lorentz.Helper
+  ( failAsText
+  ) where
+
+import Lorentz
+
+failAsText :: Label name -> s :-> t
+failAsText label =
+  failUsing (errorTagToMText label)

--- a/test/Test/Common.hs
+++ b/test/Test/Common.hs
@@ -4,8 +4,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 
 module Test.Common
-  ( checkTokenBalance
-  , originateTrivialDao
+  ( originateTrivialDao
   , originateBaseDaoWithConfig
   , originateBaseDaoWithBalance
   , originateTrivialDaoWithBalance
@@ -18,7 +17,6 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Lorentz
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
-import Lorentz.Test (contractConsumer)
 import Morley.Nettest
 import Named (defaults, (!))
 import Util.Named ((.!))
@@ -103,32 +101,6 @@ originateTrivialDao
   :: (MonadNettest caps base m)
   => m ((Address, Address), (Address, Address), TAddress (DAO.Parameter () Empty), Address)
 originateTrivialDao = originateBaseDao ()
-
--- | Create FA2 View
-mkFA2View
-  :: forall paramFa a r contract. ToContractRef r contract
-  => a
-  -> contract
-  -> FA2.FA2View paramFa a r
-mkFA2View a c = FA2.FA2View (mkView a c)
-
--- | Helper function to check a user balance of a particular token
-checkTokenBalance
-  :: (NiceParameterFull (Parameter pm op), MonadNettest caps base m)
-  => FA2.TokenId -> TAddress (DAO.Parameter pm op)
-  -> Address -> Natural
-  -> m ()
-checkTokenBalance tokenId dao addr expectedValue = do
-  consumer <- originateSimple "consumer" [] contractConsumer
-
-  callFrom (AddressResolved addr) dao (Call @"Balance_of")
-    (mkFA2View [ FA2.BalanceRequestItem
-      { briOwner = addr
-      , briTokenId = tokenId
-      } ] consumer)
-
-  checkStorage (AddressResolved $ toAddress consumer)
-    (toVal [[((addr, tokenId), expectedValue)]] )
 
 makeProposalKey :: NicePackedValue pm => DAO.ProposeParams pm -> Address -> ProposalKey pm
 makeProposalKey params owner = toHashHs $ lPackValue (params, owner)

--- a/test/Test/GameDAO.hs
+++ b/test/Test/GameDAO.hs
@@ -16,7 +16,8 @@ import Time (sec)
 
 import qualified Lorentz.Contracts.BaseDAO.Types as DAO
 import Lorentz.Contracts.GameDAO
-import Test.Common
+import BaseDAO.ShareTest.Common (checkTokenBalance, expectFailed)
+import Test.Common (makeProposalKey, originateBaseDaoWithConfig)
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
@@ -43,7 +44,7 @@ validProposal = uncapsNettest $ do
   callFrom (AddressResolved owner1) dao (Call @"Propose") (DAO.ProposeParams
     { ppFrozenToken = 20
     , ppProposalMetadata = sampleMetadataContent $ toAddress consumer
-    }) & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    }) & expectFailed (toAddress dao) [mt|FAIL_PROPOSAL_CHECK|]
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") (DAO.ProposeParams
     { ppFrozenToken = 15

--- a/test/Test/RegistryDAO.hs
+++ b/test/Test/RegistryDAO.hs
@@ -13,11 +13,11 @@ import Morley.Nettest.Tasty
 import Test.Tasty (TestTree, testGroup)
 import Time (sec)
 
-import BaseDAO.ShareTest.Common (sendXtz)
+import BaseDAO.ShareTest.Common (checkTokenBalance, expectFailed, sendXtz)
 import qualified Lorentz.Contracts.BaseDAO.Types as DAO
 import Lorentz.Contracts.RegistryDAO
 import Lorentz.Contracts.RegistryDAO.Types
-import Test.Common
+import Test.Common (makeProposalKey, originateBaseDaoWithConfig)
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
@@ -53,10 +53,10 @@ validProposal = uncapsNettest $ do
       expectedToken = fromInteger $ toInteger $ length $ lPackValueRaw longNormalProposalMetadata
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") (params $ expectedToken - 1)
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectFailed (toAddress dao) [mt|FAIL_PROPOSAL_CHECK|]
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") (params $ expectedToken + 1)
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectFailed (toAddress dao) [mt|FAIL_PROPOSAL_CHECK|]
 
   -- Expected token is 58 in this case
   _ <- createSampleProposal (getTokensAmount longNormalProposalMetadata) longNormalProposalMetadata owner1 dao
@@ -98,7 +98,7 @@ validConfigProposal = uncapsNettest $ do
 
   -- Fail due too big proposal size
   _ <- createSampleProposal ((getTokensAmount longNormalProposalMetadata) + 5) longNormalProposalMetadata owner1 dao
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectFailed (toAddress dao) [mt|FAIL_PROPOSAL_CHECK|]
 
   -- Expected token is 58 + 5 in this case
   _ <- createSampleProposal ((getTokensAmount normalProposalMetadata) + 5) normalProposalMetadata owner1 dao

--- a/test/Test/TreasuryDAO.hs
+++ b/test/Test/TreasuryDAO.hs
@@ -18,7 +18,10 @@ import qualified Lorentz.Contracts.BaseDAO.Types as DAO
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Lorentz.Contracts.TreasuryDAO
 import Lorentz.Contracts.TreasuryDAO.Types
-import Test.Common
+
+import BaseDAO.ShareTest.Common (checkTokenBalance, expectFailed)
+import Test.Common (makeProposalKey
+  , originateBaseDaoWithConfig, originateBaseDaoWithBalance)
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
@@ -56,10 +59,10 @@ validProposal = uncapsNettest $ do
       expectedToken = fromInteger $ toInteger $ length $ lPackValueRaw proposal
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") (params $ expectedToken - 1)
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectFailed (toAddress dao) [mt|FAIL_PROPOSAL_CHECK|]
 
   callFrom (AddressResolved owner1) dao (Call @"Propose") (params $ expectedToken + 1)
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectFailed (toAddress dao) [mt|FAIL_PROPOSAL_CHECK|]
 
   -- Expected token is 58 in this case
   _ <- createSampleProposal expectedToken proposal owner1 dao


### PR DESCRIPTION
## Description

Problem: In many places we fail with `Pair "string" Unit`.
In case of the Lorentz version, it's standard behavior which
is not really justified and should be changed in Lorentz.

Solution: Use a `failAsText` helper in Lorentz to no longer fail with
`Pair "string" Unit`, refactor LIGO code to use standard `failwith`
where it can, make adjustment to all the tests.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #131 
Depends on #129 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
