### PR TITLE
[#123] Reduce origination size and provide a simple guide for it

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,8 +42,8 @@ steps:
   - label: build-ligo
     if: *not_scheduled
     commands:
-    - nix-build ci.nix -A build-ligo -o baseDAO-non-optimized.tz
-    - nix run -f ci.nix morley -c morley optimize --contract baseDAO-non-optimized.tz --output baseDAO.tz
+    - nix-build ci.nix -A build-ligo -o ./ligo-out/
+    - nix run -f ci.nix morley -c morley optimize --contract ./ligo-out/baseDAO.tz --output baseDAO.tz
     artifact_paths:
       - baseDAO.tz
 

--- a/ci.nix
+++ b/ci.nix
@@ -68,9 +68,7 @@ rec {
         packages.baseDAO-ligo-meta = {
           preBuild = ''
             mkdir -p ./ligo/haskell/test
-            cp ${build-ligo} ./ligo/haskell/test/baseDAO.tz
-            cp ${build-ligo-registryDAO-storage} ./ligo/haskell/test/registryDAO_storage.tz
-            cp ${build-ligo-treasuryDAO-storage} ./ligo/haskell/test/treasuryDAO_storage.tz
+            cp -r ${build-ligo}/* ./ligo/haskell/test
           '';
         };
       }
@@ -120,23 +118,7 @@ rec {
     src = ./ligo;
     nativeBuildInputs = [ ligo ];
     buildPhase = "make";
-    installPhase = "cp out/baseDAO.tz $out";
-  };
-
-  build-ligo-registryDAO-storage = pkgs.stdenv.mkDerivation {
-    name = "baseDAO-ligo";
-    src = ./ligo;
-    nativeBuildInputs = [ ligo ];
-    buildPhase = "make";
-    installPhase = "cp out/registryDAO_storage.tz $out";
-  };
-
-  build-ligo-treasuryDAO-storage = pkgs.stdenv.mkDerivation {
-    name = "baseDAO-ligo";
-    src = ./ligo;
-    nativeBuildInputs = [ ligo ];
-    buildPhase = "make";
-    installPhase = "cp out/treasuryDAO_storage.tz $out";
+    installPhase = "mkdir -p $out; cp -r out/* $out";
   };
 
   # nixpkgs has weeder 2, but we use weeder 1

--- a/docs/specification-ligo.md
+++ b/docs/specification-ligo.md
@@ -53,10 +53,6 @@ For example a "treasury" style DAO would have a `proposal_metadata` containing:
 ```
 and an empty `contract_extra`.
 
-Lastly, there is one more `(string, bytes) map` type synonym: `custom_entrypoints`,
-used to execute arbitrary logic on the contract, see [its section](#custom-entrypoints)
-for more information on its content and usage.
-
 DAO configuration value parameters are captured by the `config` type:
 
 ```ocaml
@@ -84,18 +80,52 @@ type config =
   // ^ Determine the maximum value of voting period that is allowed to be set.
   ; min_voting_period : nat
   // ^ Determine the minimum value of voting period that is allowed to be set.
-
-  ; custom_entrypoints : custom_entrypoints
-  // ^ Packed arbitrary lambdas associated to a name for custom execution.
   }
 ```
+
+## Startup Configuration
+
+As a measure to fit into the origination operation limits, the contract `code`
+does not contain the entrypoints logic, instead these (except for one) are
+stored as lambdas in the storage.
+
+To support loading the entrypoints in the contract as well as other initial
+operations, the contract starts in a startup mode and contains a `startup`
+entrypoint (which is the one exception from above) to manage the transition.
+
+Here it's only possible to:
+1. use `startup` to add or remove entrypoints from the storage.
+2. call any endpoint, but only if the `sender` is `admin`.
+3. use `startup` to exit the startup mode, which is irreversible.
+
+To track this functionality we have `startup_storage` defined as:
+```ocaml
+type storable_entrypoint = (bytes * (storage * config)) -> (operation list * storage)
+
+type stored_entrypoints = (string, storable_entrypoint) big_map
+
+type startup_storage =
+  { starting_up : bool
+  // ^ flag, when 'true' the contract is in startup mode
+  ; stored_entrypoints : stored_entrypoints
+  // ^ big_map containing all the entrypoints with their parameter 'pack'ed
+  }
+```
+which constitutes the final piece of our overall storage.
+
+Note that the `stored_entrypoints` `big_map` includes both the standard entrypoint
+as well as any custom ones that one might use, see [its section](#custom-entrypoints)
+for more information on the usage of the latter.
 
 Note:
 - the `token_metadata` type matches the one defined in FA2.
 - the `proposal` type is defined below.
-- `storage` is the storage type of the contract without the configuration.
-- `full_storage` is instead the full storage of the contract, including its configuration,
-which is to say: `type full_storage = storage * config`.
+- `storage` is the storage type of the contract without the `config` and `startup_storage`.
+- stored entrypoints have access to both `storage` and `config` but can only
+modify the `storage`.
+- `full_storage` is instead the full storage of the contract, including its
+configuration and startup values, which is to say:
+`type full_storage = startup_storage * (storage * config)`.
 
 
 ```ocaml
@@ -127,8 +157,10 @@ These values are:
 
 This chapter provides a high-level overview of the contract's logic.
 
-- The contract maintains a ledger of address and its balance (frozen and unfrozen tokens)
+- The contract maintains a ledger of address and its balance (frozen and unfrozen tokens).
 - The contract manages a special role called "Administrator".
+- The contract starts in a startup mode where it's only operable by the Administrator,
+  to let entrypoints be loaded into its storage, before moving out of it.
 - The contract stores a list of proposals that can be in one of the states: "ongoing", "rejected", or "accepted".
 - Migration forms a two-step process:
   + After the migration starts, the contract `migration_status` state is set to `MigratingTo targetAddress` state.
@@ -216,8 +248,10 @@ The list of erros may be inaccurate and incomplete, it will be updated during th
 | `PROPOSER_NOT_EXIST_IN_LEDGER`  | Expect a proposer address to exist in Ledger but it is not found                                            |
 | `PROPOSAL_NOT_UNIQUE`           | Trying to propose a proposal that is already existed in the Storage.                                        |
 | `MISSIGNED`                     | Parameter signature does not match the expected one - for permits.                                          |
-| `ENTRYPOINT_NOT_FOUND`          | Throw when `CallCustom` is called with a non-existing entrypoint                                            |
-| `UNPACKING_FAILED`              | Throw when unpacking of the stored lambda in a 'CallCustom' call fails                                      |
+| `ENTRYPOINT_NOT_FOUND`          | Throw when a non-existing entrypoint is called (with `CallCustom` or otherwise)                             |
+| `UNPACKING_FAILED`              | Throw when unpacking of a stored entrypoint or its parameter fails                                          |
+| `IN_STARTUP`                    | The contract is still in startup mode, which needs to be ended before operating with the main logic.        |
+| `NOT_IN_STARTUP`                | The contract is not in startup mode anymore, but needs to be to call the `startup` entrypoint               |
 
 # Entrypoints
 
@@ -238,6 +272,9 @@ Full list:
 * [`drop_proposal`](#drop_proposal)
 * [`migrate`](#migrate)
 * [`confirm_migration`](#confirm_migration)
+* [`GetVotePermitCounter`](#getvotepermitcounter)
+* [`startup`](#startup)
+* [`CallCustom`](#callcustom)
 
 Format:
 ```
@@ -253,6 +290,8 @@ Parameter (in Michelson): X
 * Each entrypoint MUST be callable using the standard entrypoints machinery of Michelson by specifying **entrypoint_name** and a value of the type `X` (its argument).
 * The previous bullet point implies that each `X` must have a field annotations with the corresponding entrypoint name.
 In the definitions below it may be omitted, but it is still implied.
+* All entrypoint except `startup` can only be called by the Administrator while
+the contract is in startup mode, otherwise they will fail with `IN_STARTUP`.
 
 Note: CameLIGO definitions are provided only for readability.
 If Michelson type contradicts what's written in CameLIGO definition, the Michelson definition takes precedence.
@@ -821,19 +860,46 @@ Parameter (in Michelson):
 
 - For `vote` entrypoint with permit, returns the current suitable counter for constructing permit signature.
 
+## Startup mode
+
+The contract has a startup mode that can be managed and exited at the
+beginning of its life-cycle, see [Startup Configuration](#startup-configuration).
+
+To do this the contract `parameter` has:
+
+### **startup**
+
+```ocaml
+type startup_parameter = (string * (bytes option)) option
+
+Startup of startup_parameter
+```
+
+Parameter (in Michelson):
+```
+(option %startup
+  (pair
+    string
+    (option bytes)
+  )
+)
+```
+
+- If called with `Some` value it `unpack`s a storable entrypoint lambda from the
+  received `bytes` and stores it associating it to the given `string` name.
+- Fails with `UNPACKING_FAILED` if `unpack` from the point above fails.
+- If called with `None` ends the startup mode, by updating the `starting_up` flag.
+- Fails with `NOT_IN_STARTUP` if the stored `starting_up` flag is `false`.
+- Fails with `NOT_ADMIN` if the sender of this call is not contract Administrator.
+
 ## Custom entrypoints
 
 BaseDAO allows DAOs to define their own additional entrypoints.
 
-This is done with the use of the `config` option `custom_entrypoints`, which is
-a `(string, bytes) map` that associates a `string` "entrypoint name" with the
-`bytes` of a `pack`ed lambda with the signature:
-
-```ocaml
-bytes * full_storage -> operation list * storage
-```
-
-where the bytes is the packed parameter of the custom entrypoint.
+This is done with the use of the `startup_storage` option `stored_entrypoints`,
+which is a `big_map` that associates a `string` "entrypoint name" with the
+lambda accepting `bytes` as its `pack`ed parameter, see
+[Startup Configuration](#startup-configuration).
 
 To call one of these "custom entrypoints" the contract `parameter` has:
 

--- a/ligo/Makefile
+++ b/ligo/Makefile
@@ -17,12 +17,36 @@ BUILD = $(LIGO) compile-contract --syntax cameligo
 # Compile storage
 BUILD_STORAGE = $(LIGO) compile-storage --syntax cameligo
 
+# Compile parameter
+BUILD_PARAMETER = $(LIGO) compile-parameter --syntax cameligo
+
 # Where to put build files
 OUT ?= out
 
 .PHONY: all clean test
 
-all: $(OUT)/baseDAO.tz $(OUT)/registryDAO_storage.tz $(OUT)/treasuryDAO_storage.tz
+all: \
+	$(OUT)/baseDAO.tz \
+	$(OUT)/trivialDAO_storage.tz \
+	$(OUT)/registryDAO_storage.tz \
+	$(OUT)/treasuryDAO_storage.tz \
+	$(OUT)/entrypoints/accept_ownership.tz \
+	$(OUT)/entrypoints/balance_of.tz \
+	$(OUT)/entrypoints/burn.tz \
+	$(OUT)/entrypoints/confirm_migration.tz \
+	$(OUT)/entrypoints/drop_proposal.tz \
+	$(OUT)/entrypoints/flush.tz \
+	$(OUT)/entrypoints/get_vote_permit_counter.tz \
+	$(OUT)/entrypoints/migrate.tz \
+	$(OUT)/entrypoints/mint.tz \
+	$(OUT)/entrypoints/propose.tz \
+	$(OUT)/entrypoints/set_quorum_threshold.tz \
+	$(OUT)/entrypoints/set_voting_period.tz \
+	$(OUT)/entrypoints/transfer.tz \
+	$(OUT)/entrypoints/transfer_contract_tokens.tz \
+	$(OUT)/entrypoints/transfer_ownership.tz \
+	$(OUT)/entrypoints/update_operators.tz \
+	$(OUT)/entrypoints/vote.tz
 
 # Compile LIGO contract into its michelson representation.
 $(OUT)/baseDAO.tz: src/**
@@ -41,7 +65,25 @@ ifeq ($(OPTIMIZE), true)
 	# ============== Optimizing contract ============== #
 	$(MORLEY) optimize --contract $(OUT)/baseDAO.tz --output $(OUT)/baseDAO.tz
 endif
+	#
 
+$(OUT)/entrypoints/%.tz: src/**
+	# ==== Compiling parameter for storable entrypoint ==== #
+	mkdir -p $(OUT)/entrypoints
+	$(BUILD_PARAMETER) --output-file $(OUT)/entrypoints/$*.tz src/startup.mligo base_DAO_contract 'make_ep_param("$*", storable_$*)'
+	# ============== Compilation successful =============== #
+	# See "$(OUT)/entrypoints/$*.tz" for compilation result #
+	#
+
+$(OUT)/trivialDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
+$(OUT)/trivialDAO_storage.tz : token_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
+$(OUT)/trivialDAO_storage.tz: src/**
+	# ============== Compiling TrivialDAO storage ============== #
+	mkdir -p $(OUT)
+	$(BUILD_STORAGE) --output-file $(OUT)/trivialDAO_storage.tz src/base_DAO.mligo base_DAO_contract 'default_full_storage(("$(admin_address)": address), ("$(token_address)": address))'
+	# ================= Compilation successful ================= #
+	# See "$(OUT)/trivialDAO_storage.tz" for compilation result  #
+	#
 
 $(OUT)/registryDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
 $(OUT)/registryDAO_storage.tz : token_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
@@ -51,13 +93,12 @@ $(OUT)/registryDAO_storage.tz : s_max = 100n
 $(OUT)/registryDAO_storage.tz : c = 1n
 $(OUT)/registryDAO_storage.tz : d = 0n
 $(OUT)/registryDAO_storage.tz: src/**
-
 	# ============== Compiling RegistryDAO storage ============== #
 	mkdir -p $(OUT)
 	$(BUILD_STORAGE) --output-file $(OUT)/registryDAO_storage.tz src/registryDAO.mligo base_DAO_contract 'default_registry_DAO_full_storage(("$(admin_address)": address), ("$(token_address)": address), ${a}, $(b), $(s_max), $(c), $(d))'
-	# ============== Compilation successful ============== #
+	# ================= Compilation successful ================= #
 	# See "$(OUT)/registryDAO_storage.tz" for compilation result #
-
+	#
 
 $(OUT)/treasuryDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
 $(OUT)/treasuryDAO_storage.tz : token_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
@@ -69,17 +110,17 @@ $(OUT)/treasuryDAO_storage.tz : d = 0n
 $(OUT)/treasuryDAO_storage.tz : y = 0mutez
 $(OUT)/treasuryDAO_storage.tz : z = 100mutez
 $(OUT)/treasuryDAO_storage.tz: src/**
-
 	# ============== Compiling TreasuryDAO storage ============== #
 	mkdir -p $(OUT)
 	$(BUILD_STORAGE) --output-file $(OUT)/treasuryDAO_storage.tz src/treasuryDAO.mligo base_DAO_contract 'default_treasury_DAO_full_storage(("$(admin_address)": address), ("$(token_address)": address), (${a}, $(b), $(s_max), $(c), $(d), $(y), $(z)))'
 	# ============== Compilation successful ============== #
 	# See "$(OUT)/treasuryDAO_storage.tz" for compilation result #
+	#
 
-
-test: $(OUT)/baseDAO.tz $(OUT)/registryDAO_storage.tz $(OUT)/treasuryDAO_storage.tz
+test: all
 	$(MAKE) -C .. test PACKAGE=baseDAO-ligo-meta \
     BASEDAO_LIGO_PATH=../$(OUT)/baseDAO.tz \
+    BASEDAO_LIGO_EPS_DIR_PATH=../$(OUT)/entrypoints/ \
     REGISTRY_STORAGE_PATH=../$(OUT)/registryDAO_storage.tz \
     TREASURY_STORAGE_PATH=../$(OUT)/treasuryDAO_storage.tz
 

--- a/ligo/Makefile
+++ b/ligo/Makefile
@@ -70,7 +70,7 @@ endif
 $(OUT)/entrypoints/%.tz: src/**
 	# ==== Compiling parameter for storable entrypoint ==== #
 	mkdir -p $(OUT)/entrypoints
-	$(BUILD_PARAMETER) --output-file $(OUT)/entrypoints/$*.tz src/startup.mligo base_DAO_contract 'make_ep_param("$*", storable_$*)'
+	$(BUILD_PARAMETER) --output-file $(OUT)/entrypoints/$*.tz src/startup.mligo startup_contract 'make_ep_param("$*", storable_$*)'
 	# ============== Compilation successful =============== #
 	# See "$(OUT)/entrypoints/$*.tz" for compilation result #
 	#

--- a/ligo/README.md
+++ b/ligo/README.md
@@ -58,25 +58,29 @@ Because of this the contract starts in a "startup" mode and a series of operatio
 is necessary to load these entrypoint lambdas into the contract, before it can
 be actually used.
 
+To load (or override) an entrypoint into the storage, you can use:
+`tezos-client transfer 0 from alice to myDAO --entrypoint 'startup' --arg '(Some (Pair "<ep_name>", (Some <ep_bytes>)))'`
+which can also be used to load custom entrypoints.
+
+For example, a simple custom entrypoint might look like:
+`tezos-client transfer 0 from alice to myDAO --entrypoint 'startup' --arg '(Some (Pair "simple_ep" (Some 0x05020000000a03170316053d036d0342)))'`
+
 All the standard entrypoint lambdas are provided in `ligo/src/startup.mligo`
 (with some more information) and can be complied into parameters to push them to
 the contract with the `ligo compile-parameter` command.
 
 This is also included in the `Makefile` and using `make all` will provide each
-parameter in the `out/entrypoints` directory.
-
-For example, to load (or override) an entrypoint into the storage, you can use:
-`tezos-client transfer 0 from alice to myDAO --arg <ep_parameter>`
-which can also be used to load custom entrypoints.
+parameter in the `out/entrypoints` directory, whose content is ready to be passed
+as `--arg` to the command above.
 
 As long as "startup" mode is going on only the `admin` can call a stored
 entrypoint.
 
 To remove a previously loaded entrypoint you can instead use
-`tezos-client transfer 0 from alice to myDAO --arg '(Left (Some (Pair "<ep_name>", None)))'`
+`tezos-client transfer 0 from alice to myDAO --entrypoint 'startup' --arg '(Some (Pair "<ep_name>", None))'`
 
 Once all the entrypoints are loaded, you can exit the "startup" mode using:
-`tezos-client transfer 0 from alice to myDAO --arg '(Left (None))'`
+`tezos-client transfer 0 from alice to myDAO --entrypoint 'startup' --arg 'None'`
 IMPORTANT: this is irreversible, be careful when doing so.
 
 ## Testing

--- a/ligo/haskell/baseDAO-ligo-meta.cabal
+++ b/ligo/haskell/baseDAO-ligo-meta.cabal
@@ -39,6 +39,8 @@ library
     , baseDAO
     , cleveland
     , containers
+    , directory
+    , filepath
     , fmt
     , lens
     , lorentz

--- a/ligo/haskell/package.yaml
+++ b/ligo/haskell/package.yaml
@@ -91,6 +91,8 @@ library:
     - baseDAO
     - cleveland
     - containers
+    - directory
+    - filepath
     - fmt
     - lens
     - lorentz

--- a/ligo/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/ligo/haskell/src/Ligo/BaseDAO/Types.hs
@@ -172,9 +172,9 @@ mkStorageL admin votingPeriod quorumThreshold extra metadata =
     quorumThresholdDef = 4
 
 data ConfigL = ConfigL
-  { cProposalCheck :: '[ProposeParamsL, StorageL] :-> '[Bool]
-  , cRejectedProposalReturnValue :: '[ProposalL, StorageL] :-> '["slash_amount" :! Natural]
-  , cDecisionLambda :: '[ProposalL, StorageL] :-> '[List Operation, StorageL]
+  { cProposalCheck :: '[ProposeParamsL, ContractExtraL] :-> '[Bool]
+  , cRejectedProposalReturnValue :: '[ProposalL, ContractExtraL] :-> '["slash_amount" :! Natural]
+  , cDecisionLambda :: '[ProposalL, ContractExtraL] :-> '[List Operation, ContractExtraL]
 
   , cMaxProposals :: Natural
   , cMaxVotes :: Natural

--- a/ligo/haskell/test/Ligo/BaseDAO/Contract.hs
+++ b/ligo/haskell/test/Ligo/BaseDAO/Contract.hs
@@ -16,6 +16,6 @@ baseDAOContractLigo :: Contract (ToT ParameterL) (ToT FullStorage)
 baseDAOContractLigo =
   $(fetchContract @(ToT ParameterL) @(ToT FullStorage) "BASEDAO_LIGO_PATH")
 
-baseDAOEntrypointsParameter :: [ParameterL]
+baseDAOEntrypointsParameter :: [StartupParameter]
 baseDAOEntrypointsParameter =
-  $(fetchValues @ParameterL "ligo/haskell/test/entrypoints" "BASEDAO_LIGO_EPS_DIR_PATH")
+  $(fetchValues @StartupParameter "ligo/haskell/test/entrypoints" "BASEDAO_LIGO_EPS_DIR_PATH")

--- a/ligo/haskell/test/Ligo/BaseDAO/Contract.hs
+++ b/ligo/haskell/test/Ligo/BaseDAO/Contract.hs
@@ -4,6 +4,7 @@
 -- | LIGO version of the contract.
 module Ligo.BaseDAO.Contract
   ( baseDAOContractLigo
+  , baseDAOEntrypointsParameter
   ) where
 
 import Michelson.Typed
@@ -14,3 +15,7 @@ import Ligo.Util
 baseDAOContractLigo :: Contract (ToT ParameterL) (ToT FullStorage)
 baseDAOContractLigo =
   $(fetchContract @(ToT ParameterL) @(ToT FullStorage) "BASEDAO_LIGO_PATH")
+
+baseDAOEntrypointsParameter :: [ParameterL]
+baseDAOEntrypointsParameter =
+  $(fetchValues @ParameterL "ligo/haskell/test/entrypoints" "BASEDAO_LIGO_EPS_DIR_PATH")

--- a/ligo/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/ligo/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -5,6 +5,8 @@ module Test.Ligo.BaseDAO.Proposal
   ( test_BaseDAO_Proposal
   ) where
 
+import Universum
+
 import Test.Tasty (TestTree)
 
 import BaseDAO.ShareTest.Proposal
@@ -12,5 +14,5 @@ import Ligo.BaseDAO.Types (dynRecUnsafe)
 import Test.Ligo.BaseDAO.Common
 
 test_BaseDAO_Proposal :: TestTree
-test_BaseDAO_Proposal =
-  mkBaseDaoProposalTests (originateLigoDaoWithConfigDesc dynRecUnsafe)
+test_BaseDAO_Proposal = mkBaseDaoProposalTests $
+  withDefaultStartup . originateLigoDaoWithConfigDesc dynRecUnsafe

--- a/ligo/haskell/test/Test/Ligo/BaseDAO/Token.hs
+++ b/ligo/haskell/test/Test/Ligo/BaseDAO/Token.hs
@@ -21,21 +21,22 @@ import Test.Ligo.BaseDAO.Common
 test_BaseDAO_Token :: TestTree
 test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
   [ nettestScenario "can burn tokens from any accounts"
-      $ uncapsNettest $ Share.burnScenario
-        $ originateLigoDaoWithBalance dynRecUnsafe defaultConfigL
+      $ uncapsNettest $ Share.burnScenario . withDefaultStartup
+        $ originateLigoDaoWithBalance [] dynRecUnsafe defaultConfigL
           (\o1 _ ->
               [ ((o1, DAO.unfrozenTokenId), 10)
               , ((o1, DAO.frozenTokenId), 10)
               ]
           )
   , nettestScenario "can mint tokens to any accounts"
-      $ uncapsNettest $ Share.mintScenario
-        $ originateLigoDaoWithBalance dynRecUnsafe defaultConfigL
+      $ uncapsNettest $ Share.mintScenario . withDefaultStartup
+        $ originateLigoDaoWithBalance [] dynRecUnsafe defaultConfigL
           (\o1 _ ->
               [ ((o1, DAO.unfrozenTokenId), 0)
               , ((o1, DAO.frozenTokenId), 0)
               ]
           )
   , nettestScenario "can call transfer tokens entrypoint"
-      $ uncapsNettest $ Share.transferContractTokensScenario originateLigoDao
+      $ uncapsNettest $ Share.transferContractTokensScenario $
+        withDefaultStartup originateLigoDao
   ]

--- a/ligo/haskell/test/Test/Ligo/BaseDAO/Token/FA2.hs
+++ b/ligo/haskell/test/Test/Ligo/BaseDAO/Token/FA2.hs
@@ -13,6 +13,7 @@ import Test.Tasty (TestTree, testGroup)
 
 import Lorentz.Contracts.BaseDAO.Types
 
+import BaseDAO.ShareTest.Common (OriginateFn)
 import qualified BaseDAO.ShareTest.FA2 as Share
 import qualified Ligo.BaseDAO.Types as Ligo
 
@@ -24,42 +25,42 @@ test_BaseDAO_FA2 :: TestTree
 test_BaseDAO_FA2 = testGroup "BaseDAO FA2 tests:"
   [ testGroup "Operator:"
       [ nettestScenario "allows zero transfer from non-existent operator"
-          $ uncapsNettest $ Share.zeroTransferScenario originateLigoDao
+          $ uncapsNettest $ Share.zeroTransferScenario startedUpLigoDao
       , nettestScenario "allows valid transfer and check balance"
-          $ uncapsNettest $ Share.validTransferScenario originateLigoDao
+          $ uncapsNettest $ Share.validTransferScenario startedUpLigoDao
       , nettestScenario "validates token id"
-          $ uncapsNettest $ Share.validateTokenScenario originateLigoDao
+          $ uncapsNettest $ Share.validateTokenScenario startedUpLigoDao
       , nettestScenario "accepts an empty list of transfers"
-          $ uncapsNettest $ Share.emptyTransferListScenario originateLigoDao
+          $ uncapsNettest $ Share.emptyTransferListScenario startedUpLigoDao
       , nettestScenario "aborts if there is a failure (due to low balance)"
-          $ uncapsNettest $ Share.lowBalanceScenario originateLigoDao
+          $ uncapsNettest $ Share.lowBalanceScenario startedUpLigoDao
       , nettestScenario "aborts if there is a failure (due to non existent source account)"
-          $ uncapsNettest $ Share.noSourceAccountScenario originateLigoDao
+          $ uncapsNettest $ Share.noSourceAccountScenario startedUpLigoDao
       , nettestScenario "aborts if there is a failure (due to bad operator)"
-          $ uncapsNettest $ Share.badOperatorScenario originateLigoDao
+          $ uncapsNettest $ Share.badOperatorScenario startedUpLigoDao
       , nettestScenario "cannot transfer foreign money"
-          $ uncapsNettest $ Share.noForeignMoneyScenario originateLigoDao
+          $ uncapsNettest $ Share.noForeignMoneyScenario startedUpLigoDao
       ]
   , testGroup "Owner:"
       [ nettestScenario "allows valid transfer and check balance"
-          $ uncapsNettest $ Share.validTransferOwnerScenario originateLigoDao
+          $ uncapsNettest $ Share.validTransferOwnerScenario startedUpLigoDao
       , nettestScenario "allows updating operator "
-          $ uncapsNettest $ Share.updatingOperatorScenario originateLigoDao
+          $ uncapsNettest $ Share.updatingOperatorScenario startedUpLigoDao
       , nettestScenario "allows balanceOf request"
-          $ uncapsNettest $ Share.balanceOfOwnerScenario originateLigoDao
+          $ uncapsNettest $ Share.balanceOfOwnerScenario startedUpLigoDao
       , nettestScenario "validates token id"
-          $ uncapsNettest $ Share.validateTokenOwnerScenario originateLigoDao
+          $ uncapsNettest $ Share.validateTokenOwnerScenario startedUpLigoDao
       , nettestScenario "aborts if there is a failure (due to low balance)"
-          $ uncapsNettest $ Share.lowBalanceOwnerScenario originateLigoDao
+          $ uncapsNettest $ Share.lowBalanceOwnerScenario startedUpLigoDao
       , nettestScenario "cannot transfer foreign money"
-          $ uncapsNettest $ Share.noForeignMoneyOwnerScenario originateLigoDao
+          $ uncapsNettest $ Share.noForeignMoneyOwnerScenario startedUpLigoDao
       ]
   , testGroup "Admin:"
     [ nettestScenario "transfer tokens from any address to any address"
-        $ uncapsNettest $ Share.adminTransferScenario originateLigoDao
+        $ uncapsNettest $ Share.adminTransferScenario startedUpLigoDao
     , nettestScenario "transfer frozen tokens"
-        $ uncapsNettest $ Share.adminTransferFrozenScenario
-        $ originateLigoDaoWithBalance Ligo.dynRecUnsafe Ligo.defaultConfigL
+        $ uncapsNettest $ Share.adminTransferFrozenScenario $ withDefaultStartup
+        $ originateLigoDaoWithBalance [] Ligo.dynRecUnsafe Ligo.defaultConfigL
             (\owner1 owner2 ->
                 [ ((owner1, frozenTokenId), 100)
                 , ((owner2, frozenTokenId), 100)
@@ -68,10 +69,13 @@ test_BaseDAO_FA2 = testGroup "BaseDAO FA2 tests:"
     ]
   , testGroup "Entrypoints respect migration status"
       [ nettestScenario "transfer respects migration status"
-          $ uncapsNettest $ Share.transferAfterMigrationScenario originateLigoDao
+          $ uncapsNettest $ Share.transferAfterMigrationScenario startedUpLigoDao
       , nettestScenario "update operator respects migration status "
-          $ uncapsNettest $ Share.updatingOperatorAfterMigrationScenario originateLigoDao
+          $ uncapsNettest $ Share.updatingOperatorAfterMigrationScenario startedUpLigoDao
       , nettestScenario "balanceOf request respects migration status"
-          $ uncapsNettest $ Share.balanceOfRequestAfterMigrationScenario originateLigoDao
+          $ uncapsNettest $ Share.balanceOfRequestAfterMigrationScenario startedUpLigoDao
       ]
   ]
+  where
+    startedUpLigoDao :: MonadNettest caps base m => OriginateFn Ligo.ParameterL m
+    startedUpLigoDao = withDefaultStartup originateLigoDao

--- a/ligo/src/base_DAO.mligo
+++ b/ligo/src/base_DAO.mligo
@@ -3,52 +3,155 @@
 
 // Corresponds to BaseDAO.hs module
 
-#include "management.mligo"
-#include "permit.mligo"
-#include "proposal.mligo"
+#include "common.mligo"
+#include "defaults.mligo"
 #include "token.mligo"
 
-let base_DAO_contract
-  (action, full_store : parameter * full_storage)
-    : operation list * full_storage
-  =
-  let store : storage = full_store.0 in
-  let config : config = full_store.1 in
-  match action with
-  // entrypoints that require the contract to not be migrated
-    M_left (mp) ->
-      begin
-        let store = ensure_not_migrated(store)
-        in match mp with
-            // entrypoint that won't necessarily check for xtz
-              M_left (p) -> call_custom(p, full_store)
-            // entrypoints that won't accept any xtz
-            | M_right (fbp) ->
-                let (ops, store) =
-                  if Tezos.amount > 0tez
-                    then
-                      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-                        ("FORBIDDEN_XTZ", ()) : return)
-                    else
-                      begin
-                        match fbp with
-                            Call_FA2 (p) -> call_fa2(p, store)
-                          | Drop_proposal (p) -> drop_proposal(p, config, store)
-                          | Transfer_ownership (p) -> transfer_ownership(p, store)
-                          | Accept_ownership (p) -> accept_ownership(p, store)
-                          | Migrate (p) -> migrate(p, store)
-                          | Confirm_migration (p) -> confirm_migration(p, store)
-                          | Propose (p) -> propose(p, config, store)
-                          | Vote (p) -> vote(p, config, store)
-                          | Set_voting_period (p) -> set_voting_period(p, config, store)
-                          | Set_quorum_threshold (p) -> set_quorum_threshold(p, config, store)
-                          | Flush (p) -> flush (p, config, store)
-                          | Burn (p) -> burn(p, store)
-                          | Mint (p) -> mint(p, store)
-                          | GetVotePermitCounter (p) -> get_vote_permit_counter (p, store)
-                      end
-                in (ops, (store, config))
-      end
-  // entrypoint that also work when the contract has been migrated
-  | M_right (p) -> let (ops, store) = transfer_contract_tokens(p, store) in
-      (ops, (store, config))
+(*
+ * Utility function to fetch and call an entrypoint lambda from startup_storage.
+ * IMPORTANT: NO CHECKS ARE DONE HERE.
+ *)
+let call_stored_ep
+  (ep_name, packed_param, full_store : string * bytes * full_storage)
+    : return =
+  let startup_store = full_store.0 in
+  let config_store = full_store.1 in
+  match Map.find_opt ep_name startup_store.stored_entrypoints with
+  | Some lambda -> lambda(packed_param, config_store)
+  | None -> ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
+              ("ENTRYPOINT_NOT_FOUND", ()) : return)
+
+(*
+ * Returns name and packed parameter of a stored entrypoint that is part of FA2.
+ *
+ * Note: entrypoint parameters are packed as-is except for "Balance_of",
+ * see 'startup.mligo' for more info.
+ *)
+let fa2_eps(param : fa2_parameter) : (string * bytes) =
+  match param with
+  | Transfer p -> ("transfer", Bytes.pack p)
+  | Balance_of p ->
+    let callback_address = Tezos.address(p.callback)
+    in ("balance_of", Bytes.pack (p.requests, callback_address))
+  | Update_operators p -> ("update_operators", Bytes.pack p)
+
+(*
+ * Returns name and packed parameter of a stored entrypoint that requires no xtz
+ * to be transferred.
+ * This checks for such xtz condition.
+ *
+ * Note: entrypoint parameters are packed as-is except for "GetVotePermitCounter"
+ * and 'Vote`, see 'startup.mligo' for more info.
+ *)
+let requiring_no_xtz (param : forbid_xtz_params) : (string * bytes) =
+  // check for no xtz
+  if Tezos.amount > 0tez
+  then ([%Michelson ({| { FAILWITH } |} : string * unit -> (string * bytes))]
+        ("FORBIDDEN_XTZ", ()) : (string * bytes))
+  else
+    match param with
+    | Call_FA2 p -> fa2_eps p
+    | Drop_proposal p -> ("drop_proposal", Bytes.pack p)
+    | Transfer_ownership p -> ("transfer_ownership", Bytes.pack p)
+    | Accept_ownership p -> ("accept_ownership", Bytes.pack p)
+    | Migrate p -> ("migrate", Bytes.pack p)
+    | Confirm_migration p -> ("confirm_migration", Bytes.pack p)
+    | Propose p -> ("propose", Bytes.pack p)
+    | Vote p -> ("vote", Bytes.pack (p, Tezos.self_address))
+    | Set_voting_period p -> ("set_voting_period", Bytes.pack p)
+    | Set_quorum_threshold p -> ("set_quorum_threshold", Bytes.pack p)
+    | Flush p -> ("flush", Bytes.pack p)
+    | Burn p -> ("burn", Bytes.pack p)
+    | Mint p -> ("mint", Bytes.pack p)
+    | GetVotePermitCounter p ->
+      let callback_address = Tezos.address(p.callback)
+      in ("get_vote_permit_counter", Bytes.pack (p.param, callback_address))
+
+(*
+ * Returns name and packed parameter of a stored entrypoint that requires the
+ * contract to not be migrated.
+ * This checks for such migration condition.
+ *)
+let requiring_no_migration (param, store : migratable_parameter * storage) : (string * bytes) =
+  // check not migrated
+  let store = match store.migration_status with
+    | Not_in_migration -> store
+    | MigratingTo p_ -> store
+    | MigratedTo (new_addr) ->
+      ([%Michelson ({| { FAILWITH } |} : string * address -> storage)]
+        ("MIGRATED", new_addr) : storage)
+  in match param with
+    // custom entrypoint that won't necessarily check for xtz
+    | M_left p -> p
+    // standard entrypoints that won't accept any xtz
+    | M_right p -> requiring_no_xtz p
+
+(*
+ * The DAO contract after startup has terminated.
+ * This will check for such startup condition, but still allow execution for 'admin'.
+ *)
+let running_contract
+  (action, full_store : running_parameter * full_storage)
+    : operation list * full_storage =
+  let startup_store : startup_storage = full_store.0 in
+  let store : storage = full_store.1.0 in
+  let config : config = full_store.1.1 in
+  if (startup_store.starting_up && not (Tezos.sender = store.admin))
+  then (failwith "IN_STARTUP" : operation list * full_storage)
+  else
+    let (ep_name, packed_param) = match action with
+      // entrypoints that require the contract to not be migrated
+      | M_left p -> requiring_no_migration (p, store)
+      // entrypoint that also work when the contract has been migrated
+      | M_right p -> ("transfer_contract_tokens", Bytes.pack p)
+    in
+    let (ops, store) = call_stored_ep (ep_name, packed_param, full_store) in
+    (ops, (startup_store, (store, config)))
+
+(*
+ * The DAO contract before startup has terminated.
+ * This is basically the only entrypoint ('%startup') residing in the 'CODE'
+ * section of the contract, as all the others are stored.
+ * This will check for such startup condition and for the sender to be 'admin'.
+ *)
+let startup_contract
+  (param, full_store : startup_parameter * full_storage)
+    : operation list * full_storage =
+  let startup_store : startup_storage = full_store.0 in
+  let config_store : configured_storage = full_store.1 in
+  let store_ = authorize_admin(config_store.0) in
+  if startup_store.starting_up
+  then
+    let startup_store = match param with
+      | Some upd_param ->
+        begin
+          let (ep_name, upd_type) = upd_param in
+          let upd = match upd_type with
+            | Some upd_bytes ->
+              begin
+              match (Bytes.unpack upd_bytes : storable_entrypoint option) with
+                | Some upd_lam -> Some upd_lam
+                | None -> (failwith "NOT_EP_LAMBDA" : storable_entrypoint option)
+              end
+            | None -> (None : (storable_entrypoint option))
+          in
+          let ep_map = Map.update ep_name upd startup_store.stored_entrypoints in
+          {startup_store with stored_entrypoints = ep_map}
+        end
+      | None ->
+        {startup_store with starting_up = false}
+    in (nil_op, (startup_store, config_store))
+  else (failwith "NOT_IN_STARTUP" : operation list * full_storage)
+
+(*
+ * The actual DAO contract, which in this version is the same independently from
+ * the DAO logic.
+ *)
+let base_DAO_contract (param, full_store : parameter * full_storage)
+    : operation list * full_storage =
+  let startup_store : startup_storage = full_store.0 in
+  let store : storage = full_store.1.0 in
+  let config : config = full_store.1.1 in
+  match param with
+    | M_left p -> startup_contract (p, full_store)
+    | M_right p -> running_contract (p, full_store)

--- a/ligo/src/base_DAO.mligo
+++ b/ligo/src/base_DAO.mligo
@@ -24,7 +24,7 @@ let base_DAO_contract
               M_left (p) -> call_custom(p, full_store)
             // entrypoints that won't accept any xtz
             | M_right (fbp) ->
-                let result =
+                let (ops, store) =
                   if Tezos.amount > 0tez
                     then
                       ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
@@ -47,8 +47,8 @@ let base_DAO_contract
                           | Mint (p) -> mint(p, store)
                           | GetVotePermitCounter (p) -> get_vote_permit_counter (p, store)
                       end
-                in (result.0, (result.1, config))
+                in (ops, (store, config))
       end
   // entrypoint that also work when the contract has been migrated
-  | M_right (p) -> let result = transfer_contract_tokens(p, store) in
-      (result.0, (result.1, config))
+  | M_right (p) -> let (ops, store) = transfer_contract_tokens(p, store) in
+      (ops, (store, config))

--- a/ligo/src/defaults.mligo
+++ b/ligo/src/defaults.mligo
@@ -4,9 +4,9 @@
 #include "types.mligo"
 
 let default_config : config = {
-    proposal_check = (fun (params, store : propose_params * storage) -> true);
-    rejected_proposal_return_value = (fun (proposal, store : proposal * storage) -> 0n);
-    decision_lambda = (fun (proposal, store : proposal * storage) -> (([] : (operation list)), store));
+    proposal_check = (fun (params, extras : propose_params * contract_extra) -> true);
+    rejected_proposal_return_value = (fun (proposal, extras : proposal * contract_extra) -> 0n);
+    decision_lambda = (fun (proposal, extras : proposal * contract_extra) -> (([] : (operation list)), extras));
 
     max_proposals = 500n;
     max_votes = 1000n;

--- a/ligo/src/defaults.mligo
+++ b/ligo/src/defaults.mligo
@@ -14,7 +14,6 @@ let default_config : config = {
     min_quorum_threshold = 1n;
     max_voting_period = 2592000n; // 60 * 60 * 24 * 30
     min_voting_period = 1n;
-    custom_entrypoints = (Map.empty : (string, bytes) map);
     }
 
 let default_storage (admin , token_address : (address * address)) : storage = {
@@ -33,5 +32,10 @@ let default_storage (admin , token_address : (address * address)) : storage = {
     permits_counter = 0n;
 }
 
+let default_startup_storage : startup_storage = {
+    starting_up = true;
+    stored_entrypoints = (Big_map.empty : stored_entrypoints);
+    }
+
 let default_full_storage (admin, token_address : (address * address)) : full_storage =
-  (default_storage (admin, token_address), default_config)
+  (default_startup_storage, (default_storage (admin, token_address), default_config))

--- a/ligo/src/management.mligo
+++ b/ligo/src/management.mligo
@@ -31,7 +31,7 @@ let transfer_ownership
  *)
 let accept_ownership(param, store : unit * storage) : return =
   if store.pending_owner = Tezos.sender
-    then (([] : operation list), { store with admin = store.pending_owner })
+    then (([] : operation list), { store with admin = Tezos.sender })
     else
       ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
         ("NOT_PENDING_ADMIN", ()) : return)
@@ -73,7 +73,6 @@ let confirm_migration(param, store : unit * storage) : return =
 let call_custom(param, full_storage : custom_ep_param * full_storage) : return_with_full_storage =
   let ep_name = param.0 in
   let config = full_storage.1 in
-  let storage = full_storage.0 in
   let packed_param = param.1 in
 
   match Map.find_opt ep_name config.custom_entrypoints with

--- a/ligo/src/proposal.mligo
+++ b/ligo/src/proposal.mligo
@@ -155,9 +155,14 @@ let check_vote_limit_reached
           ("MAX_VOTES_REACHED", ()) : vote_param)
     else vote_param
 
-let vote(votes, config, store : vote_param_permited list * config * storage): return =
+// Note: we require this because we want to put the entrypoint in a lamba and so
+// we need the contract address to be provided (can't use 'SELF_ADDRESS' because
+// currently LIGO compiles it to 'SELF; ADDRESS').
+let vote_with_self
+  (votes, ctrt_address, config, store : vote_param_permited list * address * config * storage)
+    : return =
   let accept_vote = fun (store, pp : storage * vote_param_permited) ->
-    let (param, author, store) = verify_permit_protected_vote (pp, store) in
+    let (param, author, store) = verify_permit_protected_vote (pp, ctrt_address, store) in
     let proposal = check_if_proposal_exist (param.proposal_key, store) in
     let vote_param = check_vote_limit_reached (config, proposal, param) in
     let store = ensure_voting_period_is_not_over (proposal, store) in
@@ -168,6 +173,9 @@ let vote(votes, config, store : vote_param_permited list * config * storage): re
   ( ([] : operation list)
   , List.fold accept_vote votes store
   )
+
+let vote(votes, config, store : vote_param_permited list * config * storage): return =
+  vote_with_self(votes, Tezos.self_address, config, store)
 
 // -----------------------------------------------------------------
 // Admin entrypoints

--- a/ligo/src/proposal.mligo
+++ b/ligo/src/proposal.mligo
@@ -71,16 +71,16 @@ let check_proposal_limit_reached (config, propose_params, store : config * propo
           ("MAX_PROPOSALS_REACHED", ()) : storage)
     else store
 
-let freeze (tokens, addr, store : nat * address * storage): storage =
-  let store = debit_from (tokens, addr, unfrozen_token_id, store) in
-  let store = credit_to (tokens, addr, frozen_token_id, store) in
-  store
+let freeze (tokens, addr, ledger : nat * address * ledger): ledger =
+  let ledger = debit_from (tokens, addr, unfrozen_token_id, ledger) in
+  let ledger = credit_to (tokens, addr, frozen_token_id, ledger) in
+  ledger
 
 [@inline]
-let unfreeze (tokens, addr, store : nat * address * storage): storage =
-  let store = debit_from (tokens, addr, frozen_token_id, store) in
-  let store = credit_to (tokens, addr, unfrozen_token_id, store) in
-  store
+let unfreeze (tokens, addr, ledger : nat * address * ledger): ledger =
+  let ledger = debit_from (tokens, addr, frozen_token_id, ledger) in
+  let ledger = credit_to (tokens, addr, unfrozen_token_id, ledger) in
+  ledger
 
 let add_proposal (propose_params, store : propose_params * storage): storage =
   let proposal_key = ensure_proposal_is_unique (propose_params, store) in
@@ -106,8 +106,8 @@ let propose (param, config, store : propose_params * config * storage): return =
   let store = check_proposal_limit_reached (config, param, store) in
   let store = check_proposer_unfrozen_token (param, store) in
 
-  let store = freeze (param.frozen_token, Tezos.sender, store) in
-  let store = add_proposal (param, store) in
+  let ledger = freeze (param.frozen_token, Tezos.sender, store.ledger) in
+  let store = add_proposal (param, {store with ledger = ledger}) in
   ( ([] : operation list)
   , store
   )
@@ -134,8 +134,6 @@ let check_voter_unfrozen_token (vote_param, author, store : vote_param * address
 let submit_vote (proposal, vote_param, author, store : proposal * vote_param * address * storage): storage =
   let proposal_key = vote_param.proposal_key in
 
-  let store = freeze (vote_param.vote_amount, author, store) in
-
   let proposal =
     if vote_param.vote_type
       then { proposal with upvotes = proposal.upvotes + vote_param.vote_amount }
@@ -147,7 +145,8 @@ let submit_vote (proposal, vote_param, author, store : proposal * vote_param * a
     } in
 
   { store with
-    proposals = Map.add proposal_key proposal store.proposals
+      ledger = freeze (vote_param.vote_amount, author, store.ledger)
+    ; proposals = Map.add proposal_key proposal store.proposals
   }
 
 [@inline]
@@ -223,7 +222,7 @@ let check_balance_less_then_frozen_value
 
 [@inline]
 let burn_frozen_token (tokens, addr, store : nat * address * storage): storage =
-  debit_from(tokens, addr, frozen_token_id, store)
+  {store with ledger = debit_from(tokens, addr, frozen_token_id, store.ledger)}
 
 // Burn the "slash_amount" calculated by "config.rejected_proposal_return_value".
 // See the Haskell version for details.
@@ -237,14 +236,14 @@ let burn_slash_amount (slash_amount, frozen_tokens, addr, store : nat * nat * ad
   burn_frozen_token (to_burn, addr, store)
 
 let unfreeze_proposer_and_voter_token
-  (config, is_accepted, proposal, proposal_key, store :
-    config * bool * proposal * proposal_key * storage): storage =
+  (rejected_proposal_return, is_accepted, proposal, proposal_key, store :
+    (proposal * storage -> nat) * bool * proposal * proposal_key * storage): storage =
   // unfreeze_proposer_token
   let (tokens, store) =
     if is_accepted
     then (proposal.proposer_frozen_token, store)
     else
-      let slash_amount = config.rejected_proposal_return_value (proposal, store) in
+      let slash_amount = rejected_proposal_return (proposal, store) in
       let frozen_tokens = proposal.proposer_frozen_token in
       let store = burn_slash_amount(slash_amount, frozen_tokens, proposal.proposer, store) in
       let tokens =
@@ -256,12 +255,12 @@ let unfreeze_proposer_and_voter_token
     in
   let tokens = check_balance_less_then_frozen_value
               (tokens, proposal.proposer, proposal, proposal_key, store) in
-  let store = unfreeze(tokens, proposal.proposer, store) in
+  let ledger = unfreeze(tokens, proposal.proposer, store.ledger) in
   // unfreeze_voter_token
-  let do_unfreeze = fun (store, (addr, tokens) : storage * (address * nat)) ->
-    unfreeze(tokens, addr, store)
+  let do_unfreeze = fun (ledger, (addr, tokens) : ledger * (address * nat)) ->
+    unfreeze(tokens, addr, ledger)
     in
-  List.fold do_unfreeze proposal.voters store
+  {store with ledger = List.fold do_unfreeze proposal.voters ledger}
 
 [@inline]
 let is_voting_period_over (proposal, store : proposal * storage): bool =
@@ -293,7 +292,7 @@ let handle_proposal_is_over
     let cond =    do_total_vote_meet_quorum_threshold(proposal, store)
                && proposal.upvotes > proposal.downvotes
     in
-    let store = unfreeze_proposer_and_voter_token (config, cond, proposal, proposal_key, store) in
+    let store = unfreeze_proposer_and_voter_token (config.rejected_proposal_return_value, cond, proposal, proposal_key, store) in
     let (new_ops, store) =
       if cond
       then config.decision_lambda (proposal, store)
@@ -339,7 +338,7 @@ let drop_proposal (proposal_key, config, store : proposal_key * config * storage
     if   do_total_vote_meet_quorum_threshold(proposal, store)
       && proposal.upvotes > proposal.downvotes
     then
-      let store = unfreeze_proposer_and_voter_token (config, true, proposal, proposal_key, store) in
+      let store = unfreeze_proposer_and_voter_token (config.rejected_proposal_return_value, true, proposal, proposal_key, store) in
       let store = delete_proposal (proposal.start_date, proposal_key, store) in
       (([] : operation list), store)
     else

--- a/ligo/src/registryDAO.mligo
+++ b/ligo/src/registryDAO.mligo
@@ -168,9 +168,9 @@ let registry_DAO_decision_lambda (proposal, store : proposal * storage) : return
       in (([] : operation list), { store with extra = new_ce })
 
 let default_registry_DAO_full_storage (admin, token_address, a, b, s_max, c, d
-    : (address * address * nat * nat * nat * nat * nat)) : full_storage = let
-  fs = default_full_storage (admin, token_address) in
-  let new_storage = { fs.0 with
+    : (address * address * nat * nat * nat * nat * nat)) : full_storage =
+  let (startup, (store, config)) = default_full_storage (admin, token_address) in
+  let new_storage = { store with
     extra = Map.literal [
           ("registry" , Bytes.pack (Map.empty : registry));
           ("registry_affected" , Bytes.pack (Map.empty : registry_affected));
@@ -181,9 +181,9 @@ let default_registry_DAO_full_storage (admin, token_address, a, b, s_max, c, d
           ("d" , Bytes.pack d); // slash_division_value
           ];
   } in
-  let new_config = { fs.1 with
+  let new_config = { config with
     proposal_check = registry_DAO_proposal_check;
     rejected_proposal_return_value = registry_DAO_rejected_proposal_return_value;
     decision_lambda = registry_DAO_decision_lambda;
     } in
-  (new_storage, new_config)
+  (startup, (new_storage, new_config))

--- a/ligo/src/startup.mligo
+++ b/ligo/src/startup.mligo
@@ -26,9 +26,9 @@
 
 // Helpers
 
-let make_ep_param (ep_name, stored_ep : string * storable_entrypoint) : parameter =
+let make_ep_param (ep_name, stored_ep : string * storable_entrypoint) : startup_parameter =
   let packed_ep = Bytes.pack stored_ep in
-  (M_left (Some (ep_name, Some packed_ep)) : parameter)
+  (Some (ep_name, Some packed_ep) : startup_parameter)
 
 // Management
 

--- a/ligo/src/startup.mligo
+++ b/ligo/src/startup.mligo
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2020 TQ Tezos
+// SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+// Utility module for contract startup.
+//
+// To keep origination size small enough we store the entrypoints as lambdas in
+// the storage.
+// This module exports a 'make_ep_param' function that can create the 'parameter'
+// to fill an entrypoint and several 'storable_<ep_name>' functions that are
+// lambdas that can be used with said helper function.
+// These correspond to their entrypoint code, except for 'balance_of' and
+// 'get_vote_permit_counter' (which cannot receive a contract directly so they
+// need to get an address instead) as well as 'vote' (that cannot execute the
+// 'SELF_ADDRESS' instruction in a lambda, so it needs to receive it as well).
+
+
+// this is imported only to fill the 'ligo' command's 'ENTRY_POINT' parameter
+#include "base_DAO.mligo"
+
+#include "management.mligo"
+#include "proposal.mligo"
+#include "token.mligo"
+#include "token/fa2.mligo"
+
+#include "types.mligo"
+
+// Helpers
+
+let make_ep_param (ep_name, stored_ep : string * storable_entrypoint) : parameter =
+  let packed_ep = Bytes.pack stored_ep in
+  (M_left (Some (ep_name, Some packed_ep)) : parameter)
+
+// Management
+
+let storable_transfer_ownership (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : transfer_ownership_param option) with
+  | Some param -> transfer_ownership(param, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_accept_ownership (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : unit option) with
+  | Some param -> accept_ownership(param, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_migrate (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : migrate_param option) with
+  | Some param -> migrate(param, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_confirm_migration (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : unit option) with
+  | Some param -> confirm_migration(param, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+
+// Proposal
+
+let storable_drop_proposal (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : proposal_key option) with
+  | Some param -> drop_proposal(param, config_store.1, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_propose (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : propose_params option) with
+  | Some param -> propose(param, config_store.1, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_vote (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : (vote_param_permited list * address) option) with
+  | Some param ->
+    let (vote_param, ctrt_address) = param in
+    vote_with_self(vote_param, ctrt_address, config_store.1, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_set_voting_period (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : voting_period option) with
+  | Some param -> set_voting_period(param, config_store.1, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_set_quorum_threshold (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : quorum_threshold option) with
+  | Some param -> set_quorum_threshold(param, config_store.1, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_flush (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : nat option) with
+  | Some param -> flush(param, config_store.1, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_get_vote_permit_counter (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : (unit * address) option) with
+  | Some param ->
+      begin
+      let (unit_par, callback_address) = param in
+      match (Tezos.get_contract_opt(callback_address) : nat contract option) with
+      | Some callback_contract ->
+        let ep_param = {param = unit_par; callback = callback_contract}
+        in get_vote_permit_counter(ep_param, config_store.0)
+      | None -> (failwith "UNPACKING_FAILED" : return)
+    end
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+
+// Token
+
+let storable_burn (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : burn_param option) with
+  | Some param -> burn(param, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_mint (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : mint_param option) with
+  | Some param -> mint(param, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_transfer_contract_tokens (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : transfer_contract_tokens_param option) with
+  | Some param -> transfer_contract_tokens(param, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+
+// FA2
+
+let storable_transfer (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : transfer_params option) with
+  | Some param -> transfer(param, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_balance_of (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : (balance_request_item list * address) option) with
+  | Some param ->
+    begin
+      let (request_list, callback_address) = param in
+      match (Tezos.get_contract_opt(callback_address) : balance_response_item list contract option) with
+      | Some callback_contract ->
+        let ep_param = {requests = request_list; callback = callback_contract}
+        in balance_of(ep_param, config_store.0)
+      | None -> (failwith "UNPACKING_FAILED" : return)
+    end
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)
+
+let storable_update_operators (packed_param, config_store : bytes * configured_storage) : return =
+  match ((Bytes.unpack packed_param) : update_operators_param option) with
+  | Some param -> update_operators(param, config_store.0)
+  | None -> (failwith "ENTRYPOINT_NOT_FOUND" : return)

--- a/ligo/src/token.mligo
+++ b/ligo/src/token.mligo
@@ -15,13 +15,13 @@ let call_fa2(param, store : fa2_parameter * storage) : return =
 
 let burn(param, store : burn_param * storage) : return =
   let store = authorize_admin(store) in
-  let store = debit_from (param.amount, param.from_, param.token_id, store)
-  in (([] : operation list), store)
+  let ledger = debit_from (param.amount, param.from_, param.token_id, store.ledger)
+  in (([] : operation list), { store with ledger = ledger })
 
 let mint(param, store : mint_param * storage) : return =
   let store = authorize_admin(store) in
-  let store = credit_to (param.amount, param.to_, param.token_id, store)
-  in (([] : operation list), store)
+  let ledger = credit_to (param.amount, param.to_, param.token_id, store.ledger)
+  in (([] : operation list), {store with ledger = ledger})
 
 let transfer_contract_tokens
     (param, store : transfer_contract_tokens_param * storage) : return =

--- a/ligo/src/token.mligo
+++ b/ligo/src/token.mligo
@@ -7,12 +7,6 @@
 #include "types.mligo"
 #include "token/fa2.mligo"
 
-let call_fa2(param, store : fa2_parameter * storage) : return =
-  match param with
-    Transfer (p) -> transfer (p, store)
-  | Balance_of (p) -> balance_of(p, store)
-  | Update_operators (p) -> update_operators(p, store)
-
 let burn(param, store : burn_param * storage) : return =
   let store = authorize_admin(store) in
   let ledger = debit_from (param.amount, param.from_, param.token_id, store.ledger)

--- a/ligo/src/token/fa2.mligo
+++ b/ligo/src/token/fa2.mligo
@@ -94,9 +94,11 @@ let validate_token_type (token_id : token_id): token_id =
 let balance_of (params, store : balance_request_params * storage): return =
   let check_one (req : balance_request_item): balance_response_item =
     let valid_token_id = validate_token_type(req.token_id) in
-    match Big_map.find_opt (req.owner, valid_token_id) store.ledger with
-      Some bal -> { request = req; balance = bal}
-    | None -> { request = req; balance = 0n}
+    let bal =
+      match Big_map.find_opt (req.owner, valid_token_id) store.ledger with
+        Some bal -> bal
+      | None -> 0n
+    in { request = req; balance = bal}
   in
   let result = List.map check_one params.requests in
   let transfer_operation = Tezos.transaction result 0mutez params.callback

--- a/ligo/src/types.mligo
+++ b/ligo/src/types.mligo
@@ -248,8 +248,4 @@ type return_with_full_storage = operation list * full_storage
 
 let nil_op = ([] : operation list)
 
-// Remove this when everything is covered
-[@inline]
-let not_implemented (func : string) = (failwith(func ^ " is not implemented"): return)
-
 #endif  // TYPES_H included

--- a/ligo/src/types.mligo
+++ b/ligo/src/types.mligo
@@ -237,9 +237,9 @@ type parameter = (startup_parameter, "startup", running_parameter, "") michelson
 // -- Config -- //
 
 type config =
-  { proposal_check : propose_params * storage -> bool
-  ; rejected_proposal_return_value : proposal * storage -> nat
-  ; decision_lambda : proposal * storage -> operation list * storage
+  { proposal_check : propose_params * contract_extra -> bool
+  ; rejected_proposal_return_value : proposal * contract_extra -> nat
+  ; decision_lambda : proposal * contract_extra -> operation list * contract_extra
 
   ; max_proposals : nat
   ; max_votes : nat

--- a/ligo/src/types.mligo
+++ b/ligo/src/types.mligo
@@ -207,21 +207,34 @@ type migratable_parameter =
   (custom_ep_param, "CallCustom", forbid_xtz_params, "") michelson_or
 
 (*
- * Full parameter of the contract. Made up of entrypoints that could get
- * migrated, and 'Transfer_contract_tokens' which should keep working even
- * after migration.
+ * Full parameter of the running (aka not starting up) contract.
+ * Made up of entrypoints that could get migrated, and 'Transfer_contract_tokens'
+ * which should keep working even after migration.
  *)
-type parameter =
+type running_parameter =
   (migratable_parameter, "", transfer_contract_tokens_param, "Transfer_contract_tokens") michelson_or
 
+(*
+ * Full parameter of the starting up contract.
+ * This is used to load or remove lambdas for the entrypoint into the contract
+ * before it can actually be used.
+ *
+ * The outer-most 'option' is used to either modify an entrypoint ('Some') or
+ * put the contract in "running mode" ('None').
+ * The 'string' is the name associated to an entrypoint (custom or not)
+ * and the 'bytes' should contain the relative packed 'storable_entrypoint' or
+ * 'None' to remove it from the contract.
+ *)
+type startup_parameter = (string * (bytes option)) option
+
+(*
+ * Full parameter of the contract.
+ * Made of a 'Left' option for a startup process or the 'Right' on to interact
+ * with the running contract.
+ *)
+type parameter = (startup_parameter, "startup", running_parameter, "") michelson_or
+
 // -- Config -- //
-
-type custom_entrypoints = (string, bytes) map
-
-type decision_lambda_input =
-  { proposal : proposal
-  ; storage : storage
-  }
 
 type config =
   { proposal_check : propose_params * storage -> bool
@@ -234,17 +247,39 @@ type config =
   ; min_quorum_threshold : nat
   ; max_voting_period : nat
   ; min_voting_period : nat
-
-  ; custom_entrypoints : custom_entrypoints
   }
 
-type full_storage = storage * config
+type configured_storage = storage * config
+
+(*
+ * The type of an entrypoint that can be stored in the storage.
+ * Note that it is only able to affect the 'storage' and that it receives its
+ * parameter as packed 'bytes'.
+ *)
+type storable_entrypoint = (bytes * configured_storage) -> (operation list * storage)
+
+(*
+ * big_map containing all the entrypoints, indexed by a string
+ * representing their name, each being a lambda with access to full_storage and
+ * a packed parameter.
+ *)
+type stored_entrypoints = (string, storable_entrypoint) big_map
+
+(*
+ * Part of the 'full_storage' that can only be modified during the startup phase
+ * of the contract.
+ * It contains the stored 'storable_entrypoint' as well as the startup flag.
+ *)
+type startup_storage =
+  { starting_up : bool
+  ; stored_entrypoints : stored_entrypoints
+  }
+
+type full_storage = startup_storage * configured_storage
 
 // -- Misc -- //
 
 type return = operation list * storage
-
-type return_with_full_storage = operation list * full_storage
 
 let nil_op = ([] : operation list)
 


### PR DESCRIPTION
## Description

The first two commits of this PR are an attempt to reduce the cost without being to aggressive.
The refactoring that resulted from them (mostly the fist) has been quite successful, but it's still not nearly enough to fit into the limits.

The commit that follows (still a WIP because of missing tests and docs update) solves the origination problem by moving the entrypoint code from the `code` section to lambdas stored in the `storage` and provides a way to generate the parameter needed to load these lambdas into an originated contract

## Related issue(s)

Resolves #123

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
