### PR TITLE
[#126] Implement `total_supply` off-chain view

### DIFF
--- a/docs/specification-ligo.md
+++ b/docs/specification-ligo.md
@@ -273,6 +273,7 @@ Full list:
 * [`migrate`](#migrate)
 * [`confirm_migration`](#confirm_migration)
 * [`GetVotePermitCounter`](#getvotepermitcounter)
+* [`get_total_supply`](#get_total_supply)
 * [`startup`](#startup)
 * [`CallCustom`](#callcustom)
 
@@ -859,6 +860,29 @@ Parameter (in Michelson):
 ```
 
 - For `vote` entrypoint with permit, returns the current suitable counter for constructing permit signature.
+
+### **get_total_supply**
+
+```ocaml
+type get_total_supply_param =
+  [@layout:comb]
+  { token_id : token_id
+  ; callback : nat contract
+  }
+
+Get_total_supply of get_total_supply_param
+```
+
+Parameter (in Michelson):
+```
+(pair %get_total_supply
+  (nat %token_id)
+  (contract %callback nat)
+)
+```
+
+- Return the total number of tokens for the given token id.
+- Fail with `FA2_TOKEN_UNDEFINED` if the given token id is not equal to `0` or `1`.
 
 ## Startup mode
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -253,6 +253,8 @@ Full list:
 * [`drop_proposal`](#drop_proposal)
 * [`migrate`](#migrate)
 * [`confirm_migration`](#confirm_migration)
+* [`GetVotePermitCounter`](#getvotepermitcounter)
+* [`get_total_supply`](#get_total_supply)
 
 Format:
 ```
@@ -815,10 +817,31 @@ data Parameter proposalMetadata otherParam
 
 Parameter (in Michelson):
 ```
-nat
+(pair %getVotePermitCounter
+  (unit %param)
+  (contract %callback nat)
+)
 ```
 
 - For `vote` entrypoint with permit, returns the current suitable counter for constructing permit signature.
+
+### **get_total_supply**
+
+```haskell
+data Parameter proposalMetadata otherParam
+  = Get_total_supply (View TokenId Natural)
+```
+
+Parameter (in Michelson):
+```
+(pair %get_total_supply
+  (nat %token_id)
+  (contract %callback nat)
+)
+```
+
+- Return the total number of tokens for the given token id.
+- Fail with `FA2_TOKEN_UNDEFINED` if the given token id is not equal to `0` or `1`.
 
 ## Custom entrypoints
 

--- a/ligo/Makefile
+++ b/ligo/Makefile
@@ -37,6 +37,7 @@ all: \
 	$(OUT)/entrypoints/drop_proposal.tz \
 	$(OUT)/entrypoints/flush.tz \
 	$(OUT)/entrypoints/get_vote_permit_counter.tz \
+	$(OUT)/entrypoints/get_total_supply.tz \
 	$(OUT)/entrypoints/migrate.tz \
 	$(OUT)/entrypoints/mint.tz \
 	$(OUT)/entrypoints/propose.tz \

--- a/ligo/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/ligo/haskell/src/Ligo/BaseDAO/Types.hs
@@ -91,6 +91,7 @@ data ForbidXTZParam
   | Drop_proposal ProposalKeyL
   | Flush Natural
   | GetVotePermitCounter (View () Nonce)
+  | Get_total_supply (View FA2.TokenId Natural)
   | Migrate MigrateParam
   | Mint MintParam
   | Propose ProposeParamsL
@@ -131,6 +132,7 @@ data StorageL = StorageL
   , sQuorumThreshold :: QuorumThreshold
   , sTokenAddress :: Address
   , sVotingPeriod :: VotingPeriod
+  , sTotalSupply :: TotalSupply
   }
   deriving stock (Show)
 
@@ -143,6 +145,9 @@ instance StoreHasSubmap StorageL "sLedger" LedgerKey LedgerValue where
 
 instance StoreHasSubmap StorageL "sOperators" ("owner" :! Address, "operator" :! Address) () where
   storeSubmapOps = storeSubmapOpsDeeper #sOperators
+
+instance StoreHasSubmap StorageL "sTotalSupply" FA2.TokenId Natural where
+  storeSubmapOps = storeSubmapOpsDeeper #sTotalSupply
 
 mkStorageL
   :: "admin" :! Address
@@ -166,6 +171,7 @@ mkStorageL admin votingPeriod quorumThreshold extra metadata =
     , sQuorumThreshold = argDef #quorumThreshold quorumThresholdDef quorumThreshold
     , sTokenAddress = genesisAddress
     , sVotingPeriod = argDef #votingPeriod votingPeriodDef votingPeriod
+    , sTotalSupply = M.fromList [(frozenTokenId, 0), (unfrozenTokenId, 0)]
     }
   where
     votingPeriodDef = 60 * 60 * 24 * 7  -- 7 days

--- a/ligo/haskell/test/Test/Ligo/BaseDAO/Common.hs
+++ b/ligo/haskell/test/Test/Ligo/BaseDAO/Common.hs
@@ -22,7 +22,7 @@ import Morley.Nettest
 import Tezos.Core (unsafeMkMutez)
 import Util.Named
 
-import BaseDAO.ShareTest.Common (OriginateFn)
+import BaseDAO.ShareTest.Common (OriginateFn, totalSupplyFromLedger)
 import BaseDAO.ShareTest.Proposal.Config ()
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -65,6 +65,7 @@ originateLigoDaoWithBalance customEps extra configL balFunc = do
               )
               { sLedger = bal
               , sOperators = operators
+              , sTotalSupply = totalSupplyFromLedger bal
               }
           , csConfig = configL
           }

--- a/ligo/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
+++ b/ligo/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
@@ -7,24 +7,36 @@ module Test.Ligo.BaseDAO.OffChainViews
 
 import Universum hiding (view)
 
+import qualified Data.Map as M
+import Lorentz (BigMap(..))
 import Named (defaults, (!))
 import Test.Tasty (TestTree)
 
 import Tezos.Address
 
+import BaseDAO.ShareTest.Common (totalSupplyFromLedger)
 import BaseDAO.ShareTest.OffChainViews
 import qualified Ligo.BaseDAO.Types as DAO
 import qualified Ligo.BaseDAO.TZIP16Metadata as DAO
 import qualified Lorentz.Contracts.BaseDAO.TZIP16Metadata as DAO
 
-defaultStorage :: DAO.StorageL
-defaultStorage =
-  DAO.mkStorageL
-  ! #admin (unsafeParseAddress "tz1M6dcor9QNTFr9Ri68cBYvpxrogZaMttuE")
+offChainViewStorage :: DAO.StorageL
+offChainViewStorage =
+  (DAO.mkStorageL
+  ! #admin addr
   ! #extra DAO.dynRecUnsafe
   ! #metadata mempty
   ! defaults
+  ) { DAO.sLedger = bal
+    , DAO.sTotalSupply = totalSupplyFromLedger bal
+    }
+  where
+    addr = unsafeParseAddress "tz1M6dcor9QNTFr9Ri68cBYvpxrogZaMttuE"
+    bal = BigMap $ M.fromList $
+      [ ((addr, DAO.unfrozenTokenId), 100)
+      , ((addr, DAO.frozenTokenId), 200)
+      ]
 
 test_FA2 :: TestTree
 test_FA2 =
-  mkFA2Tests defaultStorage (DAO.mkMetadataSettingsL DAO.defaultMetadataConfig)
+  mkFA2Tests offChainViewStorage (DAO.mkMetadataSettingsL DAO.defaultMetadataConfig)

--- a/ligo/haskell/test/Test/Ligo/BaseDAO/Token.hs
+++ b/ligo/haskell/test/Test/Ligo/BaseDAO/Token.hs
@@ -23,9 +23,11 @@ test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
   [ nettestScenario "can burn tokens from any accounts"
       $ uncapsNettest $ Share.burnScenario . withDefaultStartup
         $ originateLigoDaoWithBalance [] dynRecUnsafe defaultConfigL
-          (\o1 _ ->
+          (\o1 o2 ->
               [ ((o1, DAO.unfrozenTokenId), 10)
               , ((o1, DAO.frozenTokenId), 10)
+              , ((o2, DAO.unfrozenTokenId), 10) -- for total supply
+              , ((o2, DAO.frozenTokenId), 10)-- for total supply
               ]
           )
   , nettestScenario "can mint tokens to any accounts"

--- a/ligo/haskell/test/Test/Ligo/RegistryDAO.hs
+++ b/ligo/haskell/test/Test/Ligo/RegistryDAO.hs
@@ -25,7 +25,7 @@ import Michelson.Typed.Convert (untypeValue)
 import Morley.Nettest
 import Morley.Nettest.Tasty (nettestScenarioCaps)
 
-import BaseDAO.ShareTest.Common (makeProposalKey)
+import BaseDAO.ShareTest.Common (totalSupplyFromLedger, makeProposalKey)
 import Ligo.BaseDAO.Contract
 import Ligo.BaseDAO.Types
 import Ligo.Util
@@ -210,7 +210,14 @@ test_RegistryDAO =
       fs = $(fetchValue @FullStorage "ligo/haskell/test/registryDAO_storage.tz" "REGISTRY_STORAGE_PATH")
       oldConfigured = fsConfigured fs
       oldStorage = csStorage oldConfigured
-      newStorage = oldStorage { sAdmin = admin, sLedger = BigMap $ Map.fromList [((w, FA2.theTokenId), defaultTokenBalance) | w <- wallets] }
+
+      ledger = BigMap $ Map.fromList [((w, FA2.theTokenId), defaultTokenBalance) | w <- wallets]
+
+      newStorage = oldStorage
+        { sAdmin = admin
+        , sLedger = ledger
+        , sTotalSupply = totalSupplyFromLedger ledger
+        }
       newConfigured = oldConfigured { csStorage = newStorage }
       in fs { fsConfigured = newConfigured }
 

--- a/ligo/src/base_DAO.mligo
+++ b/ligo/src/base_DAO.mligo
@@ -64,8 +64,11 @@ let requiring_no_xtz (param : forbid_xtz_params) : (string * bytes) =
     | Burn p -> ("burn", Bytes.pack p)
     | Mint p -> ("mint", Bytes.pack p)
     | GetVotePermitCounter p ->
-      let callback_address = Tezos.address(p.callback)
-      in ("get_vote_permit_counter", Bytes.pack (p.param, callback_address))
+        let callback_address = Tezos.address(p.callback)
+        in ("get_vote_permit_counter", Bytes.pack (p.param, callback_address))
+    | Get_total_supply p ->
+        let callback_address = Tezos.address(p.callback)
+        in ("get_total_supply", Bytes.pack (p.token_id, callback_address))
 
 (*
  * Returns name and packed parameter of a stored entrypoint that requires the

--- a/ligo/src/defaults.mligo
+++ b/ligo/src/defaults.mligo
@@ -30,6 +30,10 @@ let default_storage (admin , token_address : (address * address)) : storage = {
     proposals = (Big_map.empty : (proposal_key, proposal) big_map);
     proposal_key_list_sort_by_date = (Set.empty : (timestamp * proposal_key) set);
     permits_counter = 0n;
+    total_supply = Map.literal
+        [ (frozen_token_id, 0n)
+        ; (unfrozen_token_id, 0n)
+        ]
 }
 
 let default_startup_storage : startup_storage = {

--- a/ligo/src/permit.mligo
+++ b/ligo/src/permit.mligo
@@ -51,3 +51,13 @@ let get_vote_permit_counter (param, store : vote_permit_counter_param * storage)
     :: ([] : operation list)
   , store
   )
+
+let get_total_supply (param, store : get_total_supply_param * storage) : return =
+  let result = match Big_map.find_opt param.token_id store.total_supply with
+      None ->
+        (failwith("FA2_TOKEN_UNDEFINED") : nat)
+    | Some v -> v in
+  ( Tezos.transaction result 0mutez param.callback
+    :: ([] : operation list)
+  , store
+  )

--- a/ligo/src/token.mligo
+++ b/ligo/src/token.mligo
@@ -9,13 +9,13 @@
 
 let burn(param, store : burn_param * storage) : return =
   let store = authorize_admin(store) in
-  let ledger = debit_from (param.amount, param.from_, param.token_id, store.ledger)
-  in (([] : operation list), { store with ledger = ledger })
+  let (ledger, total_supply) = debit_from (param.amount, param.from_, param.token_id, store.ledger, store.total_supply)
+  in (([] : operation list), { store with ledger = ledger; total_supply = total_supply})
 
 let mint(param, store : mint_param * storage) : return =
   let store = authorize_admin(store) in
-  let ledger = credit_to (param.amount, param.to_, param.token_id, store.ledger)
-  in (([] : operation list), {store with ledger = ledger})
+  let (ledger, total_supply) = credit_to (param.amount, param.to_, param.token_id, store.ledger, store.total_supply)
+  in (([] : operation list), {store with ledger = ledger; total_supply = total_supply})
 
 let transfer_contract_tokens
     (param, store : transfer_contract_tokens_param * storage) : return =

--- a/ligo/src/types.mligo
+++ b/ligo/src/types.mligo
@@ -21,6 +21,8 @@ type ledger_key = address * token_id
 type ledger_value = nat
 type ledger = (ledger_key, ledger_value) big_map
 
+type total_supply = (token_id, nat) map
+
 type transfer_destination =
   [@layout:comb]
   { to_ : address
@@ -125,6 +127,7 @@ type storage =
   ; proposals : (proposal_key, proposal) big_map
   ; proposal_key_list_sort_by_date : (timestamp * proposal_key) set
   ; permits_counter : nonce
+  ; total_supply : total_supply
   }
 
 // -- Parameter -- //
@@ -179,6 +182,12 @@ type vote_permit_counter_param =
   ; callback : nat contract
   }
 
+type get_total_supply_param =
+  [@layout:comb]
+  { token_id : token_id
+  ; callback : nat contract
+  }
+
 (*
  * Entrypoints that forbids Tz transfers
  *)
@@ -197,6 +206,7 @@ type forbid_xtz_params =
   | Burn of burn_param
   | Mint of mint_param
   | GetVotePermitCounter of vote_permit_counter_param
+  | Get_total_supply of get_total_supply_param
 
 (*
  * Entrypoints that should not work after migration.
@@ -282,5 +292,9 @@ type full_storage = startup_storage * configured_storage
 type return = operation list * storage
 
 let nil_op = ([] : operation list)
+
+let unfrozen_token_id: nat = 0n
+
+let frozen_token_id: nat = 1n
 
 #endif  // TYPES_H included

--- a/src/BaseDAO/ShareTest/Proposal/Flush.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Flush.hs
@@ -102,6 +102,16 @@ flushAcceptedProposals _ originateFn = do
   checkTokenBalance (frozenTokenId) dao owner2 0
   checkTokenBalance (unfrozenTokenId) dao owner2 100 -- voter
 
+  -- Check total supply (After flush, no changes are made.)
+  consumer <- originateSimple "consumer" [] contractConsumer
+  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView unfrozenTokenId consumer)
+  checkStorage (AddressResolved $ toAddress consumer) (toVal [200 :: Natural]) -- initial = 200
+
+  consumer2 <- originateSimple "consumer" [] contractConsumer
+  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView frozenTokenId consumer2)
+  checkStorage (AddressResolved $ toAddress consumer2) (toVal [0 :: Natural]) -- initial = 0
+
+
 flushAcceptedProposalsWithAnAmount
   :: forall pm param config caps base m.
     ( MonadNettest caps base m, ProposalMetadataFromNum pm

--- a/src/BaseDAO/ShareTest/Proposal/Proposal.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Proposal.hs
@@ -10,6 +10,7 @@ module BaseDAO.ShareTest.Proposal.Proposal
 import Universum
 
 import Lorentz hiding ((>>))
+import Lorentz.Test (contractConsumer)
 import Morley.Nettest
 
 import BaseDAO.ShareTest.Common
@@ -35,6 +36,16 @@ validProposal  _ originateFn = do
   withSender (AddressResolved owner1) $ call dao (Call @"Propose") params
   checkTokenBalance frozenTokenId dao owner1 10
   checkTokenBalance unfrozenTokenId dao owner1 90
+
+  -- Check total supply
+  consumer <- originateSimple "consumer" [] contractConsumer
+  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView unfrozenTokenId consumer)
+  checkStorage (AddressResolved $ toAddress consumer) (toVal [190 :: Natural]) -- initial = 200
+
+  consumer2 <- originateSimple "consumer" [] contractConsumer
+  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView frozenTokenId consumer2)
+  checkStorage (AddressResolved $ toAddress consumer2) (toVal [10 :: Natural]) -- initial = 0
+
   -- TODO [#31]: Currently proposalId is expected to be knowned (checkInStorage)
 
   -- TODO [#31]

--- a/src/Lorentz/Contracts/BaseDAO.hs
+++ b/src/Lorentz/Contracts/BaseDAO.hs
@@ -85,6 +85,10 @@ baseDaoContract config@Config{..} = toContract $ docGroup (DName cDaoName) $ do
       , #cTransfer_contract_tokens /-> transferContractTokens
       , #cTransfer_ownership /-> transferOwnership
       , #cVote /-> vote config
+      , #cGet_total_supply /-> view_ $ do
+          doc $ DDescription getTotalSupplyDoc
+          stGet #sTotalSupply
+          ifSome nop (failCustom_ #fA2_TOKEN_UNDEFINED)
       )
   where
     -- By default we insert the CAST instruction at the beginning of

--- a/src/Lorentz/Contracts/BaseDAO/Doc.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Doc.hs
@@ -27,6 +27,7 @@ module Lorentz.Contracts.BaseDAO.Doc
    , transferContractTokensDoc
 
    , getVotePermitCounterDoc
+   , getTotalSupplyDoc
 
    , callCustomDoc
    ) where
@@ -175,6 +176,11 @@ getVotePermitCounterDoc = [md|
 
   Return value increases by number of votes where a permit was provided
   with each successful call of an entrypoint.
+  |]
+
+getTotalSupplyDoc :: Markdown
+getTotalSupplyDoc = [md|
+  Return the total number of tokens for the given token-id if known or fail if not.
   |]
 
 callCustomDoc :: Markdown

--- a/test/Test/BaseDAO/OffChainViews.hs
+++ b/test/Test/BaseDAO/OffChainViews.hs
@@ -7,23 +7,34 @@ module Test.BaseDAO.OffChainViews
 
 import Universum hiding (view)
 
+import qualified Data.Map as M
+import Lorentz (BigMap(..))
 import Named (defaults, (!))
 import Test.Tasty (TestTree)
-
 import Tezos.Address
 
+import BaseDAO.ShareTest.Common (totalSupplyFromLedger)
 import BaseDAO.ShareTest.OffChainViews
 import qualified Lorentz.Contracts.BaseDAO.Types as DAO
 import qualified Lorentz.Contracts.BaseDAO.TZIP16Metadata as DAO
 
-defaultStorage :: DAO.Storage () ()
-defaultStorage =
-  DAO.mkStorage
-  ! #admin (unsafeParseAddress "tz1M6dcor9QNTFr9Ri68cBYvpxrogZaMttuE")
+offChainViewStorage :: DAO.Storage () ()
+offChainViewStorage =
+  (DAO.mkStorage
+  ! #admin addr
   ! #extra ()
   ! #metadata mempty
   ! defaults
+  ) { DAO.sLedger = bal
+    , DAO.sTotalSupply = totalSupplyFromLedger bal
+    }
+  where
+    addr = unsafeParseAddress "tz1M6dcor9QNTFr9Ri68cBYvpxrogZaMttuE"
+    bal = BigMap $ M.fromList $
+      [ ((addr, DAO.unfrozenTokenId), 100)
+      , ((addr, DAO.frozenTokenId), 200)
+      ]
 
 test_FA2 :: TestTree
 test_FA2 =
-  mkFA2Tests defaultStorage (DAO.mkMetadataSettings DAO.defaultMetadataConfig)
+  mkFA2Tests offChainViewStorage (DAO.mkMetadataSettings DAO.defaultMetadataConfig)

--- a/test/Test/BaseDAO/Token.hs
+++ b/test/Test/BaseDAO/Token.hs
@@ -22,9 +22,11 @@ test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
   [ nettestScenario "can burn tokens from any accounts"
       $ uncapsNettest $ Share.burnScenario
         $ originateTrivialDaoWithBalance
-          (\o1 _ ->
+          (\o1 o2 ->
               [ ((o1, DAO.unfrozenTokenId), 10)
               , ((o1, DAO.frozenTokenId), 10)
+              , ((o2, DAO.unfrozenTokenId), 10) -- for total supply
+              , ((o2, DAO.frozenTokenId), 10) -- for total supply
               ]
           )
   , nettestScenario "can mint tokens to any accounts"

--- a/test/Test/Common.hs
+++ b/test/Test/Common.hs
@@ -23,6 +23,7 @@ import Morley.Nettest
 import Named (defaults, (!))
 import Util.Named ((.!))
 
+import BaseDAO.ShareTest.Common (totalSupplyFromLedger)
 import qualified Lorentz.Contracts.BaseDAO as DAO
 import Lorentz.Contracts.BaseDAO.Types
 import qualified Lorentz.Contracts.BaseDAO.Types as DAO
@@ -77,6 +78,7 @@ originateBaseDaoWithBalance contractExtra config balFunc = do
           ! #metadata mempty
           ! defaults
           ) { sLedger = BigMap bal
+            , sTotalSupply = totalSupplyFromLedger (BigMap bal)
             , sOperators = BigMap operators
             }
       , odContract = DAO.baseDaoContract config

--- a/test/Test/Integrational/Common.hs
+++ b/test/Test/Integrational/Common.hs
@@ -15,6 +15,7 @@ import Lorentz.Test
 import Named (defaults, (!))
 import Util.Named ((.!))
 
+import BaseDAO.ShareTest.Common (totalSupplyFromLedger)
 import qualified Lorentz.Contracts.BaseDAO as DAO
 import Lorentz.Contracts.BaseDAO.Types
 
@@ -49,6 +50,7 @@ lOriginateBaseDao contractExtra config = do
                     ! defaults
         )
         { sLedger = BigMap bal
+        , sTotalSupply = totalSupplyFromLedger (BigMap bal)
         , sOperators = BigMap operators
         }
 


### PR DESCRIPTION
## Description

Problem: TZIP-12 specs say that `total_supply` SHOULD be provided but we
do not track total supply yet.

Solution: Track total supply for all the tokens, add off-chain and
on-chain `total_supply` view, and add tests to cover all the cases.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #126 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
