### PR TITLE
[#131] Use `NoErrorArg` and remove `FAILWITH` `Pair "string" Unit` from LIGO

### DIFF
--- a/ligo/haskell/test/Test/Ligo/RegistryDAO.hs
+++ b/ligo/haskell/test/Test/Ligo/RegistryDAO.hs
@@ -243,4 +243,4 @@ test_RegistryDAO =
 expectFailProposalCheck
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectFailProposalCheck = expectCustomError_ #fAIL_PROPOSAL_CHECK
+expectFailProposalCheck = expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK

--- a/ligo/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/ligo/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -65,7 +65,7 @@ validProposal = uncapsNettest $ withFrozenCallStack do
 
   withSender (AddressResolved owner1) $
     call dao (Call @"Propose") (ProposeParams (proposalSize + 1) proposalMeta)
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK
 
   withSender (AddressResolved owner1) $
     call dao (Call @"Propose") (ProposeParams proposalSize proposalMeta)
@@ -148,11 +148,11 @@ flushXtzTransfer = uncapsNettest $ withFrozenCallStack $ do
   withSender (AddressResolved owner1) $ do
   -- due to smaller than min_xtz_amount
     call dao (Call @"Propose") (proposeParams 1)
-      & expectCustomError_ #fAIL_PROPOSAL_CHECK
+      & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK
 
   -- due to bigger than max_xtz_amount
     call dao (Call @"Propose") (proposeParams 6)
-      & expectCustomError_ #fAIL_PROPOSAL_CHECK
+      & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK
 
     call dao (Call @"Propose") (proposeParams 3)
   let key1 = makeProposalKey (proposeParams 3) owner1

--- a/ligo/src/base_DAO.mligo
+++ b/ligo/src/base_DAO.mligo
@@ -18,8 +18,7 @@ let call_stored_ep
   let config_store = full_store.1 in
   match Map.find_opt ep_name startup_store.stored_entrypoints with
   | Some lambda -> lambda(packed_param, config_store)
-  | None -> ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-              ("ENTRYPOINT_NOT_FOUND", ()) : return)
+  | None -> (failwith("ENTRYPOINT_NOT_FOUND") : return)
 
 (*
  * Returns name and packed parameter of a stored entrypoint that is part of FA2.
@@ -46,8 +45,7 @@ let fa2_eps(param : fa2_parameter) : (string * bytes) =
 let requiring_no_xtz (param : forbid_xtz_params) : (string * bytes) =
   // check for no xtz
   if Tezos.amount > 0tez
-  then ([%Michelson ({| { FAILWITH } |} : string * unit -> (string * bytes))]
-        ("FORBIDDEN_XTZ", ()) : (string * bytes))
+  then (failwith("FORBIDDEN_XTZ") : (string * bytes))
   else
     match param with
     | Call_FA2 p -> fa2_eps p

--- a/ligo/src/common.mligo
+++ b/ligo/src/common.mligo
@@ -11,7 +11,6 @@ let authorize_admin (store : storage): storage =
   if sender = store.admin then
     store
   else
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-        ("NOT_ADMIN", ()) : storage)
+    (failwith("NOT_ADMIN") : storage)
 
 #endif

--- a/ligo/src/management.mligo
+++ b/ligo/src/management.mligo
@@ -24,8 +24,7 @@ let accept_ownership(param, store : unit * storage) : return =
   if store.pending_owner = Tezos.sender
     then (([] : operation list), { store with admin = Tezos.sender })
     else
-      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-        ("NOT_PENDING_ADMIN", ()) : return)
+      (failwith("NOT_PENDING_ADMIN") : return)
 
 (*
  * Auth check for admin and sets the migration status to 'MigratingTo' using
@@ -43,13 +42,11 @@ let migrate(param, store : migrate_param * storage) : return =
 let confirm_migration(param, store : unit * storage) : return =
   match store.migration_status with
     Not_in_migration ->
-      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-        ("NOT_MIGRATING", ()) : return)
+        (failwith("NOT_MIGRATING") : return)
   | MigratingTo (new_addr) -> if new_addr = Tezos.sender
       then (([] : operation list), { store with migration_status = MigratedTo (new_addr) })
       else
-        ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-          ("NOT_MIGRATION_TARGET", ()) : return)
+          (failwith("NOT_MIGRATION_TARGET") : return)
   | MigratedTo (new_addr)  ->
       ([%Michelson ({| { FAILWITH } |} : string * address -> return)]
         ("MIGRATED", new_addr) : return)

--- a/ligo/src/token.mligo
+++ b/ligo/src/token.mligo
@@ -26,6 +26,5 @@ let transfer_contract_tokens
       let transfer_operation = Tezos.transaction param.params 0mutez contract
       in (([transfer_operation] : operation list), store)
   | None ->
-      ([%Michelson ({| { FAILWITH } |} : string * unit -> return)]
-        ("FAIL_TRANSFER_CONTRACT_TOKENS", ()) : return)
+      (failwith("FAIL_TRANSFER_CONTRACT_TOKENS") : return)
 

--- a/ligo/src/token/fa2.mligo
+++ b/ligo/src/token/fa2.mligo
@@ -80,8 +80,7 @@ let transfer_item (store, ti : storage * transfer_item): storage =
         else if tx.token_id = frozen_token_id then (
           if sender = store.admin then tx.token_id
           else
-            ([%Michelson ({| { FAILWITH } |} : string * unit -> token_id)]
-              ("FROZEN_TOKEN_NOT_TRANSFERABLE", ()) : token_id)
+            (failwith("FROZEN_TOKEN_NOT_TRANSFERABLE") : token_id)
         ) else
             ([%Michelson ({| { FAILWITH } |} : string * unit -> token_id)]
               ("FA2_TOKEN_UNDEFINED", ()) : token_id)
@@ -134,11 +133,9 @@ let validate_operator_token (token_id : token_id): token_id =
   if (token_id = unfrozen_token_id) then
     token_id
   else if (token_id = frozen_token_id) then
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> token_id)]
-      ("OPERATION_PROHIBITED", ()) : token_id)
+    (failwith("OPERATION_PROHIBITED") : token_id)
   else
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> token_id)]
-      ("FA2_TOKEN_UNDEFINED", ()) : token_id)
+    (failwith("FA2_TOKEN_UNDEFINED") : token_id)
 
 let update_one (store, param: storage * update_operator): storage =
   let (operator_update, operator_param) =
@@ -154,8 +151,7 @@ let update_one (store, param: storage * update_operator): storage =
           operators = updated_operators
         }
   else
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-      ("NOT_OWNER", ()) : storage)
+    (failwith("NOT_OWNER") : storage)
 
 let update_operators (params, store : update_operators_param * storage):return =
   let store = List.fold update_one params store in

--- a/ligo/src/treasuryDAO.mligo
+++ b/ligo/src/treasuryDAO.mligo
@@ -95,8 +95,7 @@ let treasury_DAO_decision_lambda (proposal, extras : proposal * contract_extra)
     (ops, extras)
   else
     // TODO: [#87] Improve handling of failed proposals
-    ([%Michelson ({| { FAILWITH } |} : string * unit -> operation list * contract_extra)]
-        ("FAIL_DECISION_LAMBDA", ()) : operation list * contract_extra)
+    (failwith("FAIL_DECISION_LAMBDA") : operation list * contract_extra)
 
 // A custom entrypoint needed to receive xtz, since most `basedao` entrypoints
 // prohibit non-zero xtz transfer.

--- a/src/BaseDAO/ShareTest/FA2.hs
+++ b/src/BaseDAO/ShareTest/FA2.hs
@@ -173,9 +173,9 @@ updatingOperatorScenario originateFn = do
     & expectCustomError_ #fA2_NOT_OPERATOR
   withSender (AddressResolved owner1) $ do
     call dao (Call @"Update_operators") ([FA2.AddOperator notOwnerParams])
-      & expectCustomError_ #nOT_OWNER
+      & expectCustomErrorNoArg #nOT_OWNER
     call dao (Call @"Update_operators") [FA2.RemoveOperator notOwnerParams]
-      & expectCustomError_ #nOT_OWNER
+      & expectCustomErrorNoArg #nOT_OWNER
 
 lowBalanceScenario
   :: forall caps base m param
@@ -286,7 +286,7 @@ validateTokenScenario originateFn = do
   callWith (params unfrozenTokenId)
 
   callWith (params frozenTokenId)
-    & expectCustomError_ #fROZEN_TOKEN_NOT_TRANSFERABLE
+    & expectCustomErrorNoArg #fROZEN_TOKEN_NOT_TRANSFERABLE
   callWith (params unknownTokenId)
     & expectCustomError_ #fA2_TOKEN_UNDEFINED
 
@@ -311,7 +311,7 @@ validateTokenOwnerScenario originateFn = do
   callWith (params unfrozenTokenId)
 
   callWith (params frozenTokenId)
-    & expectCustomError_ #fROZEN_TOKEN_NOT_TRANSFERABLE
+    & expectCustomErrorNoArg #fROZEN_TOKEN_NOT_TRANSFERABLE
   callWith (params unknownTokenId)
     & expectCustomError_ #fA2_TOKEN_UNDEFINED
 

--- a/src/BaseDAO/ShareTest/Management.hs
+++ b/src/BaseDAO/ShareTest/Management.hs
@@ -289,22 +289,22 @@ confirmMigFinalize withOriginatedFn initialStorage =
 expectNotAdmin
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectNotAdmin = expectCustomError_ #nOT_ADMIN
+expectNotAdmin = expectCustomErrorNoArg #nOT_ADMIN
 
 expectNotPendingOwner
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectNotPendingOwner = expectCustomError_ #nOT_PENDING_ADMIN
+expectNotPendingOwner = expectCustomErrorNoArg #nOT_PENDING_ADMIN
 
 expectNotMigrating
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectNotMigrating = expectCustomError_ #nOT_MIGRATING
+expectNotMigrating = expectCustomErrorNoArg #nOT_MIGRATING
 
 expectNotMigrationTarget
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectNotMigrationTarget = expectCustomError_ #nOT_MIGRATION_TARGET
+expectNotMigrationTarget = expectCustomErrorNoArg #nOT_MIGRATION_TARGET
 
 expectMigrated
   :: (MonadNettest caps base m)
@@ -314,4 +314,4 @@ expectMigrated addr = expectCustomError #mIGRATED addr
 expectForbiddenXTZ
   :: (MonadNettest caps base m)
   => m a -> m ()
-expectForbiddenXTZ = expectCustomError_ #fORBIDDEN_XTZ
+expectForbiddenXTZ = expectCustomErrorNoArg #fORBIDDEN_XTZ

--- a/src/BaseDAO/ShareTest/Proposal/Bounds.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Bounds.hs
@@ -33,7 +33,7 @@ setVotingPeriod _ originateFn = do
 
   withSender (AddressResolved owner1) $
     call dao (Call @"Set_voting_period") param
-    & expectCustomError_ #nOT_ADMIN
+    & expectCustomErrorNoArg #nOT_ADMIN
 
   withSender (AddressResolved admin) $
     call dao (Call @"Set_voting_period") param
@@ -54,7 +54,7 @@ setQuorumThreshold _ originateFn = do
 
   withSender (AddressResolved owner1) $
     call dao (Call @"Set_quorum_threshold") param
-    & expectCustomError_ #nOT_ADMIN
+    & expectCustomErrorNoArg #nOT_ADMIN
 
   withSender (AddressResolved admin) $
     call dao (Call @"Set_quorum_threshold") param
@@ -82,7 +82,7 @@ proposalBoundedValue _ originateFn = do
   withSender (AddressResolved owner1) $ do
     call dao (Call @"Propose") params
     call dao (Call @"Propose") params
-      & expectCustomError_ #mAX_PROPOSALS_REACHED
+      & expectCustomErrorNoArg #mAX_PROPOSALS_REACHED
 
 votesBoundedValue
   :: forall pm param config caps base m.
@@ -112,7 +112,7 @@ votesBoundedValue _ originateFn = do
   withSender (AddressResolved owner1) $ do
     call dao (Call @"Vote") [downvote]
     call dao (Call @"Vote") [upvote]
-      & expectCustomError_ #mAX_VOTES_REACHED
+      & expectCustomErrorNoArg #mAX_VOTES_REACHED
 
 quorumThresholdBound
   :: forall pm param config caps base m.
@@ -133,9 +133,9 @@ quorumThresholdBound _ originateFn = do
     call dao (Call @"Set_quorum_threshold") 1
     call dao (Call @"Set_quorum_threshold") 2
     call dao (Call @"Set_quorum_threshold") 0
-      & expectCustomError_ #oUT_OF_BOUND_QUORUM_THRESHOLD
+      & expectCustomErrorNoArg #oUT_OF_BOUND_QUORUM_THRESHOLD
     call dao (Call @"Set_quorum_threshold") 3
-      & expectCustomError_ #oUT_OF_BOUND_QUORUM_THRESHOLD
+      & expectCustomErrorNoArg #oUT_OF_BOUND_QUORUM_THRESHOLD
 
 votingPeriodBound
   :: forall pm param config caps base m.
@@ -156,6 +156,6 @@ votingPeriodBound _ originateFn = do
     call dao (Call @"Set_voting_period") 1
     call dao (Call @"Set_voting_period") 2
     call dao (Call @"Set_voting_period") 0
-      & expectCustomError_ #oUT_OF_BOUND_VOTING_PERIOD
+      & expectCustomErrorNoArg #oUT_OF_BOUND_VOTING_PERIOD
     call dao (Call @"Set_voting_period") 3
-      & expectCustomError_ #oUT_OF_BOUND_VOTING_PERIOD
+      & expectCustomErrorNoArg #oUT_OF_BOUND_VOTING_PERIOD

--- a/src/BaseDAO/ShareTest/Proposal/Flush.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Flush.hs
@@ -94,7 +94,7 @@ flushAcceptedProposals _ originateFn = do
 
   -- TODO: [#31]
   -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomError_ #pROPOSAL_NOT_EXIST
+  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST
 
   checkTokenBalance (frozenTokenId) dao owner1 0
   checkTokenBalance (unfrozenTokenId) dao owner1 100 -- proposer
@@ -153,13 +153,13 @@ flushAcceptedProposalsWithAnAmount _ originateFn = do
   -- Proposals are flushed
   withSender (AddressResolved owner2) $ do
     call dao (Call @"Vote") [vote key1]
-      & expectCustomError_ #vOTING_PERIOD_OVER
+      & expectCustomErrorNoArg #vOTING_PERIOD_OVER
     call dao (Call @"Vote") [vote key2]
-      & expectCustomError_ #vOTING_PERIOD_OVER
+      & expectCustomErrorNoArg #vOTING_PERIOD_OVER
 
     -- Proposal is over but not affected
     call dao (Call @"Vote") [vote key3]
-      & expectCustomError_ #vOTING_PERIOD_OVER
+      & expectCustomErrorNoArg #vOTING_PERIOD_OVER
 
     -- Proposal is not yet over
     call dao (Call @"Vote") [vote key4]
@@ -205,7 +205,7 @@ flushRejectProposalQuorum _ originateFn = do
 
   -- TODO: [#31]
   -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomError_ #pROPOSAL_NOT_EXIST
+  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST
 
   checkTokenBalance (frozenTokenId) dao owner1 0
   checkTokenBalance (unfrozenTokenId) dao owner1 95 -- proposer: cRejectedValue reduce frozen token by half
@@ -257,7 +257,7 @@ flushRejectProposalNegativeVotes _ originateFn = do
 
   -- TODO: [#31]
   -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomError_ #pROPOSAL_NOT_EXIST
+  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST
 
   checkTokenBalance (frozenTokenId) dao owner1 0
   checkTokenBalance (unfrozenTokenId) dao owner1 95 -- proposer: cRejectedValue reduce frozen token by half
@@ -293,7 +293,7 @@ flushWithBadConfig _ originateFn = do
 
   -- TODO: [#31]
   -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomError_ #pROPOSAL_NOT_EXIST
+  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST
 
   checkTokenBalance (frozenTokenId) dao owner1 0
   checkTokenBalance (unfrozenTokenId) dao owner1 90 -- slash all frozen values
@@ -368,9 +368,9 @@ dropProposal _ originateFn = do
   withSender (AddressResolved admin) $ do
     call dao (Call @"Drop_proposal") key1
     call dao (Call @"Drop_proposal") key2
-      & expectCustomError_ #fAIL_DROP_PROPOSAL_NOT_ACCEPTED
+      & expectCustomErrorNoArg #fAIL_DROP_PROPOSAL_NOT_ACCEPTED
     call dao (Call @"Drop_proposal") key3
-      & expectCustomError_ #fAIL_DROP_PROPOSAL_NOT_OVER
+      & expectCustomErrorNoArg #fAIL_DROP_PROPOSAL_NOT_OVER
 
   -- 30 tokens are frozen in total, but 10 tokens are returned after drop_proposal
   checkTokenBalance (frozenTokenId) dao owner1 20

--- a/src/BaseDAO/ShareTest/Proposal/Proposal.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Proposal.hs
@@ -66,7 +66,7 @@ rejectProposal _ originateFn = do
         }
 
   withSender (AddressResolved owner1) $ call dao (Call @"Propose") params
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK
 
 insufficientTokenProposal
   :: forall pm param config caps base m.
@@ -83,7 +83,7 @@ insufficientTokenProposal _ originateFn = do
         }
 
   withSender (AddressResolved owner1) $ call dao (Call @"Propose") params
-    & expectCustomError_ #pROPOSAL_INSUFFICIENT_BALANCE
+    & expectCustomErrorNoArg #pROPOSAL_INSUFFICIENT_BALANCE
 
 nonUniqueProposal
   :: forall pm param config caps base m.
@@ -96,7 +96,7 @@ nonUniqueProposal _ originateFn = do
   ((owner1, _), _, dao, _) <- originateFn testConfig
   _ <- createSampleProposal 1 owner1 dao
   createSampleProposal 1 owner1 dao
-    & expectCustomError_ #pROPOSAL_NOT_UNIQUE
+    & expectCustomErrorNoArg #pROPOSAL_NOT_UNIQUE
 
 voteValidProposal
   :: forall pm param config caps base m.

--- a/src/BaseDAO/ShareTest/Proposal/Vote.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Vote.hs
@@ -38,7 +38,7 @@ voteNonExistingProposal _ originateFn = do
         }
 
   withSender (AddressResolved owner2) $ call dao (Call @"Vote") [params]
-    & expectCustomError_ #pROPOSAL_NOT_EXIST
+    & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST
 
 voteMultiProposals
   :: forall pm param config caps base m.
@@ -98,7 +98,7 @@ insufficientTokenVote _ originateFn = do
         ]
 
   withSender (AddressResolved owner2) $ call dao (Call @"Vote") params
-    & expectCustomError_ #vOTING_INSUFFICIENT_BALANCE
+    & expectCustomErrorNoArg #vOTING_INSUFFICIENT_BALANCE
 
 voteOutdatedProposal
   :: forall pm param config caps base m.
@@ -125,7 +125,7 @@ voteOutdatedProposal _ originateFn = do
     call dao (Call @"Vote") [params]
     advanceTime (sec 25)
     call dao (Call @"Vote") [params]
-      & expectCustomError_ #vOTING_PERIOD_OVER
+      & expectCustomErrorNoArg #vOTING_PERIOD_OVER
 
 voteWithPermit
   :: forall pm param config caps base m.

--- a/src/BaseDAO/ShareTest/Token.hs
+++ b/src/BaseDAO/ShareTest/Token.hs
@@ -30,7 +30,7 @@ burnScenario originateFn = withFrozenCallStack $ do
 
   withSender (AddressResolved owner1) $
     call dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 10)
-    & expectCustomError_ #nOT_ADMIN
+    & expectCustomErrorNoArg #nOT_ADMIN
 
   withSender (AddressResolved admin) $ do
     call dao (Call @"Burn") (DAO.BurnParam owner1 DAO.unfrozenTokenId 11)
@@ -63,7 +63,7 @@ mintScenario originateFn = withFrozenCallStack $ do
 
   withSender (AddressResolved owner1) $
     call dao (Call @"Mint") (DAO.MintParam owner1 DAO.unfrozenTokenId 10)
-    & expectCustomError_ #nOT_ADMIN
+    & expectCustomErrorNoArg #nOT_ADMIN
 
   withSender (AddressResolved admin) $ do
     call dao (Call @"Mint") (DAO.MintParam owner1 DAO.unfrozenTokenId 100)
@@ -111,7 +111,7 @@ transferContractTokensScenario originateFn = do
 
   withSender (AddressResolved owner1) $
     call dao (Call @"Transfer_contract_tokens") param
-    & expectCustomError_ #nOT_ADMIN
+    & expectCustomErrorNoArg #nOT_ADMIN
 
   withSender (AddressResolved admin) $
     call dao (Call @"Transfer_contract_tokens") param

--- a/src/Lorentz/Contracts/BaseDAO.hs
+++ b/src/Lorentz/Contracts/BaseDAO.hs
@@ -118,7 +118,7 @@ fa2Handler = do
 -- ensureZeroTransfer = do
 --   amount
 --   push zeroMutez
---   if IsEq then nop else failCustom_ #fORBIDDEN_XTZ
+--   if IsEq then nop else failCustomNoArg #fORBIDDEN_XTZ
 
 pushFuncContext
   :: (KnownValue ce, KnownValue pm)

--- a/src/Lorentz/Contracts/BaseDAO/Management.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Management.hs
@@ -80,11 +80,11 @@ confirmMigration = do
   doc $ DRequireRole "migration target contract"
   stGetField #sMigrationStatus
   caseT @MigrationStatus
-    ( #cNotInMigration /-> failCustom_ #nOT_MIGRATING
+    ( #cNotInMigration /-> failCustomNoArg #nOT_MIGRATING
     , #cMigratingTo /-> do
         dup
         sender
-        if IsEq then nop else failCustom_ #nOT_MIGRATION_TARGET
+        if IsEq then nop else failCustomNoArg #nOT_MIGRATION_TARGET
         wrap_ @MigrationStatus #cMigratedTo
         stSetField #sMigrationStatus
     , #cMigratedTo /-> failCustom #mIGRATED
@@ -98,7 +98,7 @@ authorizePendingOwner = do
   doc $ DRequireRole "pending owner"
   stGetField #sPendingOwner
   sender
-  if IsEq then nop else failCustom_ #nOT_PENDING_ADMIN
+  if IsEq then nop else failCustomNoArg #nOT_PENDING_ADMIN
 
 -- Authorise administrator.
 authorizeAdmin ::
@@ -106,4 +106,4 @@ authorizeAdmin ::
 authorizeAdmin = do
   doc $ DRequireRole "administrator"
   stGetField #sAdmin; sender;
-  if IsEq then nop else failCustom_ #nOT_ADMIN
+  if IsEq then nop else failCustomNoArg #nOT_ADMIN

--- a/src/Lorentz/Contracts/BaseDAO/Permit.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Permit.hs
@@ -52,7 +52,7 @@ permitSender = do toField #pKey; hashKey; implicitAccount; address
 -- On failure, this returns packed signed data for which we compared the
 -- signature.
 checkedPermitSender
-  :: NicePackedValue a
+  :: forall a s. NicePackedValue a
   => Permit a : DataToSign a : s :-> Address : s
 checkedPermitSender = do
   dip pack
@@ -61,7 +61,10 @@ checkedPermitSender = do
   checkSignature
   if Holds
   then do dip (drop @(Packed $ DataToSign _)); permitSender
-  else do drop @(Permit _); checkedCoerce_; failCustom #mISSIGNED
+  else do
+    drop @(Permit _);
+    checkedCoerce_ @(Packed $ DataToSign a);
+    failCustom #mISSIGNED
 
 -- | Check that permit is signed by its author, and return the author
 -- and the parameter to work with.

--- a/src/Lorentz/Contracts/BaseDAO/Token.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Token.hs
@@ -68,7 +68,7 @@ transferContractTokens = do
     toField #tcContractAddress
     contractCalling @FA2.Parameter (Call @"Transfer")
     ifSome nop $ do
-      failCustom_ #fAIL_TRANSFER_CONTRACT_TOKENS
+      failCustomNoArg #fAIL_TRANSFER_CONTRACT_TOKENS
     push zeroMutez
   transferTokens
   nil; swap; cons

--- a/src/Lorentz/Contracts/BaseDAO/Token/FA2.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Token/FA2.hs
@@ -83,7 +83,7 @@ transfer = do
           dig @5
           dup
           if_ (dug @5) $
-            failCustom_ #fROZEN_TOKEN_NOT_TRANSFERABLE
+            failCustomNoArg #fROZEN_TOKEN_NOT_TRANSFERABLE
         else failCustom_ #fA2_TOKEN_UNDEFINED
       pair
       dup
@@ -337,7 +337,7 @@ addOperator = do
   Lorentz.sender
   if IsEq
   then nop
-  else failCustom_ #nOT_OWNER
+  else failCustomNoArg #nOT_OWNER
   stackType @("owner" :! Address : "operator" :! Address : Storage ce pm : s)
   pair
   swap
@@ -370,7 +370,7 @@ removeOperator = do
   Lorentz.sender
   if IsEq
   then nop
-  else failCustom_ #nOT_OWNER
+  else failCustomNoArg #nOT_OWNER
   stackType @("owner" :! Address : "operator" :! Address : Storage ce pm : s)
   pair
   swap

--- a/src/Lorentz/Contracts/BaseDAO/Types.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Types.hs
@@ -30,6 +30,7 @@ module Lorentz.Contracts.BaseDAO.Types
   , MintParam (..)
   , TransferContractTokensParam (..)
   , TokenAddressParam
+  , SomeType
 
   , Storage (..)
   , StorageC
@@ -769,28 +770,28 @@ baseDaoAnnOptions = defaultAnnOptions { fieldAnnModifier = dropPrefixThen toSnak
 -- Error
 ------------------------------------------------------------------------
 
-type instance ErrorArg "nOT_OWNER" = ()
+type instance ErrorArg "nOT_OWNER" = NoErrorArg
 
 instance CustomErrorHasDoc "nOT_OWNER" where
   customErrClass = ErrClassActionException
   customErrDocMdCause =
     "The sender of transaction is not owner"
 
-type instance ErrorArg "fROZEN_TOKEN_NOT_TRANSFERABLE" = ()
+type instance ErrorArg "fROZEN_TOKEN_NOT_TRANSFERABLE" = NoErrorArg
 
 instance CustomErrorHasDoc "fROZEN_TOKEN_NOT_TRANSFERABLE" where
   customErrClass = ErrClassActionException
   customErrDocMdCause =
     "The sender tries to transfer frozen token"
 
-type instance ErrorArg "nOT_PENDING_ADMIN" = ()
+type instance ErrorArg "nOT_PENDING_ADMIN" = NoErrorArg
 
 instance CustomErrorHasDoc "nOT_PENDING_ADMIN" where
   customErrClass = ErrClassActionException
   customErrDocMdCause =
     "Received an `accept_ownership` from an address other than what is in the pending owner field"
 
-type instance ErrorArg "nOT_ADMIN" = ()
+type instance ErrorArg "nOT_ADMIN" = NoErrorArg
 
 instance CustomErrorHasDoc "nOT_ADMIN" where
   customErrClass = ErrClassActionException
@@ -805,52 +806,52 @@ instance CustomErrorHasDoc "mIGRATED" where
   customErrDocMdCause =
     "Recieved a call on a migrated contract"
 
-type instance ErrorArg "nOT_MIGRATING" = ()
+type instance ErrorArg "nOT_MIGRATING" = NoErrorArg
 
 instance CustomErrorHasDoc "nOT_MIGRATING" where
   customErrClass = ErrClassActionException
   customErrDocMdCause =
     "Recieved a confirm_migration call on a contract that is not in migration"
 
-type instance ErrorArg "nOT_MIGRATION_TARGET" = ()
+type instance ErrorArg "nOT_MIGRATION_TARGET" = NoErrorArg
 
 instance CustomErrorHasDoc "nOT_MIGRATION_TARGET" where
   customErrClass = ErrClassActionException
   customErrDocMdCause =
     "Recieved a confirm_migration call on a contract from an address other than the new version"
 
-type instance ErrorArg "fORBIDDEN_XTZ" = ()
+type instance ErrorArg "fORBIDDEN_XTZ" = NoErrorArg
 
 instance CustomErrorHasDoc "fORBIDDEN_XTZ" where
   customErrClass = ErrClassActionException
   customErrDocMdCause =
     "Received some XTZ as part of a contract call, which is forbidden"
 
-type instance ErrorArg "fAIL_PROPOSAL_CHECK" = ()
+type instance ErrorArg "fAIL_PROPOSAL_CHECK" = NoErrorArg
 
 instance CustomErrorHasDoc "fAIL_PROPOSAL_CHECK" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to propose a proposal that does not pass `proposalCheck`"
 
-type instance ErrorArg "pROPOSAL_INSUFFICIENT_BALANCE" = ()
+type instance ErrorArg "pROPOSAL_INSUFFICIENT_BALANCE" = NoErrorArg
 
 instance CustomErrorHasDoc "pROPOSAL_INSUFFICIENT_BALANCE" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to propose a proposal without having enough unfrozen token"
 
-type instance ErrorArg "vOTING_INSUFFICIENT_BALANCE" = ()
+type instance ErrorArg "vOTING_INSUFFICIENT_BALANCE" = NoErrorArg
 
 instance CustomErrorHasDoc "vOTING_INSUFFICIENT_BALANCE" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to vote on a proposal without having enough unfrozen token"
 
-type instance ErrorArg "pROPOSAL_NOT_EXIST" = ()
+type instance ErrorArg "pROPOSAL_NOT_EXIST" = NoErrorArg
 
 instance CustomErrorHasDoc "pROPOSAL_NOT_EXIST" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to vote on a proposal that does not exist"
 
-type instance ErrorArg "vOTING_PERIOD_OVER" = ()
+type instance ErrorArg "vOTING_PERIOD_OVER" = NoErrorArg
 
 instance CustomErrorHasDoc "vOTING_PERIOD_OVER" where
   customErrClass = ErrClassActionException
@@ -860,43 +861,43 @@ instance CustomErrorHasDoc "vOTING_PERIOD_OVER" where
 -- Error causes by bounded value
 ------------------------------------------------
 
-type instance ErrorArg "oUT_OF_BOUND_VOTING_PERIOD" = ()
+type instance ErrorArg "oUT_OF_BOUND_VOTING_PERIOD" = NoErrorArg
 
 instance CustomErrorHasDoc "oUT_OF_BOUND_VOTING_PERIOD" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to set voting period that is out of bound."
 
-type instance ErrorArg "oUT_OF_BOUND_QUORUM_THRESHOLD" = ()
+type instance ErrorArg "oUT_OF_BOUND_QUORUM_THRESHOLD" = NoErrorArg
 
 instance CustomErrorHasDoc "oUT_OF_BOUND_QUORUM_THRESHOLD" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to set quorum threshold that is out of bound"
 
-type instance ErrorArg "mAX_PROPOSALS_REACHED" = ()
+type instance ErrorArg "mAX_PROPOSALS_REACHED" = NoErrorArg
 
 instance CustomErrorHasDoc "mAX_PROPOSALS_REACHED" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to propose a proposal when proposals max amount is already reached"
 
-type instance ErrorArg "mAX_VOTES_REACHED" = ()
+type instance ErrorArg "mAX_VOTES_REACHED" = NoErrorArg
 
 instance CustomErrorHasDoc "mAX_VOTES_REACHED" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to vote on a proposal when the votes max amount of that proposal is already reached"
 
-type instance ErrorArg "pROPOSER_NOT_EXIST_IN_LEDGER" = ()
+type instance ErrorArg "pROPOSER_NOT_EXIST_IN_LEDGER" = NoErrorArg
 
 instance CustomErrorHasDoc "pROPOSER_NOT_EXIST_IN_LEDGER" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Expect a proposer address to exist in Ledger but it is not found (Impossible Case)"
 
-type instance ErrorArg "pROPOSAL_NOT_UNIQUE" = ()
+type instance ErrorArg "pROPOSAL_NOT_UNIQUE" = NoErrorArg
 
 instance CustomErrorHasDoc "pROPOSAL_NOT_UNIQUE" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to propose a proposal that is already existed in the Storage."
 
-type instance ErrorArg "fAIL_TRANSFER_CONTRACT_TOKENS" = ()
+type instance ErrorArg "fAIL_TRANSFER_CONTRACT_TOKENS" = NoErrorArg
 
 instance CustomErrorHasDoc "fAIL_TRANSFER_CONTRACT_TOKENS" where
   customErrClass = ErrClassActionException
@@ -908,20 +909,20 @@ instance CustomErrorHasDoc "mISSIGNED" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Invalid signature provided."
 
-type instance ErrorArg "bAD_ENTRYPOINT_PARAMETER" = ()
+type instance ErrorArg "bAD_ENTRYPOINT_PARAMETER" = NoErrorArg
 
 instance CustomErrorHasDoc "bAD_ENTRYPOINT_PARAMETER" where
   customErrClass = ErrClassBadArgument
   customErrDocMdCause = "Value passed to the entrypoint is not valid"
 
-type instance ErrorArg "fAIL_DROP_PROPOSAL_NOT_OVER" = ()
+type instance ErrorArg "fAIL_DROP_PROPOSAL_NOT_OVER" = NoErrorArg
 
 instance CustomErrorHasDoc "fAIL_DROP_PROPOSAL_NOT_OVER" where
   customErrClass = ErrClassActionException
   customErrDocMdCause =
     "An error occurred when trying to drop a proposal due to the proposal's voting period is not over"
 
-type instance ErrorArg "fAIL_DROP_PROPOSAL_NOT_ACCEPTED" = ()
+type instance ErrorArg "fAIL_DROP_PROPOSAL_NOT_ACCEPTED" = NoErrorArg
 
 instance CustomErrorHasDoc "fAIL_DROP_PROPOSAL_NOT_ACCEPTED" where
   customErrClass = ErrClassActionException

--- a/src/Lorentz/Contracts/GameDAO.hs
+++ b/src/Lorentz/Contracts/GameDAO.hs
@@ -153,7 +153,7 @@ instance EntrypointKindHasDoc GameDaoCustomEntrypointsKind where
 
 ----------------------------------------------------------------------------
 
-type instance ErrorArg "fAIL_DECISION_LAMBDA" = ()
+type instance ErrorArg "fAIL_DECISION_LAMBDA" = NoErrorArg
 
 instance CustomErrorHasDoc "fAIL_DECISION_LAMBDA" where
   customErrClass = ErrClassActionException
@@ -215,7 +215,7 @@ decisionLambda = do
     toField #pmConsumerAddr
     contractCallingUnsafe @MText DefEpName
     ifSome nop $ do
-      failCustom_ #fAIL_DECISION_LAMBDA
+      failCustomNoArg #fAIL_DECISION_LAMBDA
     push zeroMutez
   transferTokens
   nil; swap; cons

--- a/src/Lorentz/Contracts/TreasuryDAO.hs
+++ b/src/Lorentz/Contracts/TreasuryDAO.hs
@@ -140,7 +140,7 @@ decisionLambda = do
   if Holds then do
     -- drop; nil
     -- TODO: [#87] Improve handling of failed proposals
-    failCustom_ #fAIL_DECISION_LAMBDA
+    failCustomNoArg #fAIL_DECISION_LAMBDA
   else
     nop
 

--- a/src/Lorentz/Contracts/TreasuryDAO/Types.hs
+++ b/src/Lorentz/Contracts/TreasuryDAO/Types.hs
@@ -143,7 +143,7 @@ instance EntrypointKindHasDoc TreasuryDaoCustomEntrypointsKind where
     \mutez to the contract."
 
 
-type instance ErrorArg "fAIL_DECISION_LAMBDA" = ()
+type instance ErrorArg "fAIL_DECISION_LAMBDA" = NoErrorArg
 
 instance CustomErrorHasDoc "fAIL_DECISION_LAMBDA" where
   customErrClass = ErrClassActionException

--- a/test/Test/GameDAO.hs
+++ b/test/Test/GameDAO.hs
@@ -45,7 +45,7 @@ validProposal = uncapsNettest $ do
       (DAO.ProposeParams
         { ppFrozenToken = 20
         , ppProposalMetadata = sampleMetadataContent $ toAddress consumer
-        }) & expectCustomError_ #fAIL_PROPOSAL_CHECK
+        }) & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK
 
     call dao (Call @"Propose")
       (DAO.ProposeParams

--- a/test/Test/RegistryDAO.hs
+++ b/test/Test/RegistryDAO.hs
@@ -57,10 +57,10 @@ validProposal = uncapsNettest $ do
 
   withSender (AddressResolved owner1) $ do
     call dao (Call @"Propose") (params $ expectedToken - 1)
-      & expectCustomError_ #fAIL_PROPOSAL_CHECK
+      & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK
 
     call dao (Call @"Propose") (params $ expectedToken + 1)
-      & expectCustomError_ #fAIL_PROPOSAL_CHECK
+      & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK
 
   -- Expected token is 58 in this case
   _ <- createSampleProposal (getTokensAmount longNormalProposalMetadata) longNormalProposalMetadata owner1 dao
@@ -102,7 +102,7 @@ validConfigProposal = uncapsNettest $ do
 
   -- Fail due too big proposal size
   _ <- createSampleProposal ((getTokensAmount longNormalProposalMetadata) + 5) longNormalProposalMetadata owner1 dao
-    & expectCustomError_ #fAIL_PROPOSAL_CHECK
+    & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK
 
   -- Expected token is 58 + 5 in this case
   _ <- createSampleProposal ((getTokensAmount normalProposalMetadata) + 5) normalProposalMetadata owner1 dao

--- a/test/Test/TreasuryDAO.hs
+++ b/test/Test/TreasuryDAO.hs
@@ -57,10 +57,10 @@ validProposal = uncapsNettest $ do
 
   withSender (AddressResolved owner1) $ do
     call dao (Call @"Propose") (params $ expectedToken - 1)
-      & expectCustomError_ #fAIL_PROPOSAL_CHECK
+      & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK
 
     call dao (Call @"Propose") (params $ expectedToken + 1)
-      & expectCustomError_ #fAIL_PROPOSAL_CHECK
+      & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK
 
   -- Expected token is 58 in this case
   _ <- createSampleProposal expectedToken proposal owner1 dao


### PR DESCRIPTION
## Description
Problem: In many places we fail with `Pair "string" Unit`, due to the
requirement in older Lorentz version. With the new Lorentz version, we
can fail with a normal string now.

Solution: Bump to latest Lorentz version to be able to use `NoErrorArg`, 
update LIGO code to fail with a normal string where possible. 


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #131 
Depends on #144 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).