### PR TITLE
[#137] RegistryDAO  proposal type to maintain proposal receiver contract addresses

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -14,6 +14,7 @@ Application-level types can be stored as part of the contract's metadata as spec
 Extra storage data:
 1. `big_map k v` is the actual key-value storage.
 2. `big_map k proposalId` for each `k` stores IDs of the proposal that affected `k` last time.
+3. `set address` is the set of successful-proposal receiver contract addresses.
 
 We store these two `big_map`s separately because we want to include `proposalId` for deleted keys as well.
 Alternatively, we can merge them and store `option v` values.
@@ -26,6 +27,10 @@ Every proposal includes (`proposalMetadata`):
 
 Another type of proposal is used to update parameters specified below,
 it takes 5 `option nat` values (called `s_max`, `a`, `b`, `c` and `d` below).
+
+Yet a third type of proposal is used to update the set of successful-proposal receiver contract
+addresses. This proposal accept a parameter that has two constructors. The proposal can add to,
+or remove from the set of addresses.
 
 Configuration lambdas are implemented as follows:
 

--- a/ligo/src/registryDAO/types.mligo
+++ b/ligo/src/registryDAO/types.mligo
@@ -10,3 +10,13 @@ type registry_value = string
 type registry = (registry_key, registry_value) map
 type registry_affected = (registry_key, proposal_key) map
 type registry_diff = (registry_key * registry_value option) list
+type proposal_receivers = address set
+
+type update_receiver_param =
+  | Add_receivers of (address list)
+  | Remove_receivers of (address list)
+
+type proposal_type =
+  | Normal_proposal of registry_diff
+  | Update_receivers_proposal of update_receiver_param
+  | Configuration_proposal

--- a/src/BaseDAO/CLI.hs
+++ b/src/BaseDAO/CLI.hs
@@ -41,6 +41,7 @@ import Util.Main (wrapMain)
 import Util.Named
 
 import qualified Lorentz.Contracts.BaseDAO as DAO
+import qualified Lorentz.Contracts.RegistryDAO as RegistryDAO
 
 ------------------------------------------------------------------------
 -- DAO
@@ -159,6 +160,7 @@ metadataConfigParser = do
 data AllCmdLnArgs
   = ContractRegistryCmd CmdLnArgs
   | PrintMetadata DAO.MetadataConfig
+  | PrintMetadataRegistry DAO.MetadataConfig
 
 allArgsParser :: DGitRevision -> ContractRegistry -> Opt.Parser AllCmdLnArgs
 allArgsParser gitRev registry = asum
@@ -169,6 +171,11 @@ allArgsParser gitRev registry = asum
       mkCommandParser "print-metadata"
         (PrintMetadata <$> metadataConfigParser)
         "Print known part of TZIP-16 metadata."
+
+  , Opt.hsubparser $
+      mkCommandParser "print-metadata-registry"
+        (PrintMetadataRegistry <$> metadataConfigParser)
+        "Print known part of TZIP-16 metadata for RegistryDAO contract."
   ]
 
 mkCommandParser
@@ -191,7 +198,10 @@ serveContractRegistry execName gitRev contracts version =
         runContractRegistry contracts cmdLnArgs
       PrintMetadata config ->
         putTextLn . decodeUtf8 . encodePretty $
-          DAO.knownBaseDAOMetadata (DAO.mkMetadataSettings config)
+          DAO.knownBaseDAOMetadata (DAO.mkMetadataSettings @() @() config)
+      PrintMetadataRegistry config ->
+        putTextLn . decodeUtf8 . encodePretty $
+          (RegistryDAO.knownRegistryDAOMetadata @MText @MText config)
 
 contractRegistryProgramInfo
   :: Version

--- a/src/Lorentz/Contracts/BaseDAO/TZIP16Metadata.hs
+++ b/src/Lorentz/Contracts/BaseDAO/TZIP16Metadata.hs
@@ -70,7 +70,7 @@ defaultMetadataConfig =
     }
 
 -- | Construct settings for Lorentz version of the contract.
-mkMetadataSettings :: MetadataConfig -> MetadataSettings (Storage () ())
+mkMetadataSettings :: (IsoValue ce, IsoValue pm) => MetadataConfig -> MetadataSettings (Storage ce pm)
 mkMetadataSettings msConfig = MetadataSettings
   { msConfig
   , mcOperatorsL = sOperatorsL

--- a/src/Lorentz/Contracts/RegistryDAO/Types.hs
+++ b/src/Lorentz/Contracts/RegistryDAO/Types.hs
@@ -11,6 +11,7 @@ module Lorentz.Contracts.RegistryDAO.Types
   , ConfigProposal (..)
   , IsoRegistryDaoProposalMetadata
   , AgoraPostId (..)
+  , UpdateReceivers
   ) where
 
 import Lorentz
@@ -20,6 +21,7 @@ import qualified Lorentz.Contracts.BaseDAO.Types as DAO
 
 data RegistryDaoContractExtra k v = RegistryDaoContractExtra
   { ceRegistry :: BigMap k (RegistryEntry k v)
+  , ceProposalReceivers :: Set Address
   , ceFrozenScaleValue :: Natural
   , ceFrozenExtraValue :: Natural
   , ceSlashScaleValue :: Natural
@@ -48,6 +50,7 @@ instance (Ord k, NiceComparable k, IsoValue v, TypeHasDoc k, TypeHasDoc v)
 instance Default (RegistryDaoContractExtra k v) where
   def = RegistryDaoContractExtra
     { ceRegistry = def
+    , ceProposalReceivers = def
     , ceFrozenScaleValue = 1
     , ceFrozenExtraValue = 0
     , ceSlashScaleValue = 1
@@ -86,6 +89,7 @@ instance (NiceComparable k, Ord k, IsoValue v, TypeHasDoc k, TypeHasDoc v)
 data RegistryDaoProposalMetadata k v
   = NormalProposalType (NormalProposal k v)
   | ConfigProposalType ConfigProposal
+  | UpdateReceiversType UpdateReceivers
   deriving stock (Generic)
 
 type IsoRegistryDaoProposalMetadata k v = (NiceComparable k, Ord k, IsoValue k, KnownValue v)
@@ -140,6 +144,21 @@ instance HasAnnotation AgoraPostId where
 
 instance TypeHasDoc AgoraPostId where
   typeDocMdDescription = "Describe an Agora post ID."
+
+-- | Special proposal that allow updating reciever proposal list
+data UpdateReceivers
+  = AddReceivers [Address]
+  | RemoveReceivers [Address]
+  deriving stock (Generic)
+  deriving anyclass (IsoValue)
+
+instance HasAnnotation UpdateReceivers where
+  annOptions = DAO.baseDaoAnnOptions
+
+instance TypeHasDoc UpdateReceivers where
+  typeDocMdDescription =
+    "Describe a proposal in Registry DAO. It is used to \
+    \update the list of receiver proposal contract addresses stored in contract extra"
 
 -- | Special proposal that allow updating certain scale values in 'contractExtra'
 data ConfigProposal = ConfigProposal

--- a/test/Test/RegistryDAO.hs
+++ b/test/Test/RegistryDAO.hs
@@ -82,8 +82,8 @@ validConfigProposal = uncapsNettest $ do
 
   key1 <- createSampleProposal (getTokensAmount configMetadata) configMetadata owner1 dao
 
-  checkTokenBalance (DAO.frozenTokenId) dao owner1 31
-  checkTokenBalance (DAO.unfrozenTokenId) dao owner1 69
+  checkTokenBalance (DAO.frozenTokenId) dao owner1 33
+  checkTokenBalance (DAO.unfrozenTokenId) dao owner1 67
 
   let
     upvote = DAO.NoPermit DAO.VoteParam


### PR DESCRIPTION
## Description

1. Adds a new proposal types to add/remove from the list of contract addressed stored in the contractExtra field. 
2. Adds a new field to registryDAO's extra data.
3. Refactor some LIGO code that decides on the proposal type.
4. Partially add the TZIP-16 storage view to fetch the stored list of contract addresses.

I got in a bit of a mess, and went in circles for a bit, trying to find a way to include the storage view in the Lorentz version of RegistryDAO contract. The issue is that the contract metadata appear to be exposed to the external world during the printing metadata command of the CLI app only. But right now this only prints the main metadata, and does not print metadata for the derived contracts. 

So right now,  I have just left the metadata for registryDAO with the TZIP-16 view, in code [1], without exposing it. Would include it after the reviews/suggestions. A LIGO version of the view is left as well [2], just in case we decide on how to include it in the contract.

[1] https://github.com/tqtezos/baseDAO/compare/sras/%23137-reg-dao-pm-receiver?expand=1#diff-7a8fd3451f076274d8fe7e7f0cc176f645f6a21720cf188542d899bc744d7a47R232

[2] https://github.com/tqtezos/baseDAO/compare/sras/%23137-reg-dao-pm-receiver?expand=1#diff-cfa339bf11943633d70899871b33165e430650d4c23245b9a565df0624c7cfd3R236

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #137 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
