### PR TITLE
[#155] Use better names for ligo Makefile arguments

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -26,7 +26,7 @@ Every proposal includes (`proposalMetadata`):
 2. A list of `update` items parameterized by `k` and `v` types. Each `update` item contains a key of the type `k` and a new value of the type `option v`.
 
 Another type of proposal is used to update parameters specified below,
-it takes 5 `option nat` values (called `s_max`, `a`, `b`, `c` and `d` below).
+it takes 5 `option nat` values (called `max_proposal_size`, `frozen_scale_value`, `frozen_extra_value`, `slash_scale_value` and `slash_division_value` below).
 
 Yet a third type of proposal is used to update the set of successful-proposal receiver contract
 addresses. This proposal accept a parameter that has two constructors. The proposal can add to,
@@ -34,15 +34,15 @@ or remove from the set of addresses.
 
 Configuration lambdas are implemented as follows:
 
-* Proposal check: the proposer must lock `a * s + b` tokens where `s = size(pack(proposalMetadata))`.
+* Proposal check: the proposer must lock `frozen_scale_value * s + frozen_extra_value` tokens where `s = size(pack(proposalMetadata))`.
 I. e. `s` is total size of the diff and post ID.
-It should naturally prohibit spam proposals and too big proposals (unless `a` is 0).
-Additionally, we require `s < s_max` as a safety measure because too large proposals can be too costly to deal with in terms of gas.
-`s_max`, `a` and `b` are parameters of the contract specified by the DAO creator.
-Note that by setting `a` to 0 it's possible to require a constant of tokens to be locked.
+It should naturally prohibit spam proposals and too big proposals (unless `frozen_scale_value` is 0).
+Additionally, we require `s < max_proposal_size` as a safety measure because too large proposals can be too costly to deal with in terms of gas.
+`max_proposal_size`, `frozen_scale_value` and `frozen_extra_value` are parameters of the contract specified by the DAO creator.
+Note that by setting `frozen_scale_value` to 0 it's possible to require a constant of tokens to be locked.
 
-* When a proposal is rejected, the returned amount is computed as `c * frozen / d`.
-`c` and `d` are specified by the DAO creator.
+* When a proposal is rejected, the returned amount is computed as `slash_scale_value * frozen / slash_division_value`.
+`slash_scale_value` and `slash_division_value` are specified by the DAO creator.
 One can set them to 1 and 1 by default to always unfreeze all tokens.
 
 * The decision lambda simply applies all updates from the accepted proposal one by one.

--- a/docs/treasury.md
+++ b/docs/treasury.md
@@ -14,21 +14,21 @@ Every proposal (`proposalMetadata`) includes a list of items where each item con
 2. `nat %agoraPostID` is used to refer to an Agora post explaining the proposed transfer and motivation for it.
 
 Another type of proposal is used to update parameters specified below,
-it takes 7 `option nat` values (called `s_max`, `a`, `b`, `c`, `d`, `y` and `z` below).
+it takes 7 `option nat` values (called `max_proposal_size`, `frozen_scale_value`, `frozen_extra_value`, `slash_scale_value`, `slash_division_value`, `min_xtz_amount` and `max_xtz_amount` below).
 
 Configuration lambdas are implemented as follows:
 
-* Proposal check: the proposer must lock `a * s + b` tokens where `s = size(pack(proposalMetadata))`.
+* Proposal check: the proposer must lock `frozen_scale_value * s + frozen_extra_value` tokens where `s = size(pack(proposalMetadata))`.
 I. e. `s` is total size of the transfers and post ID.
-It should naturally prohibit spam proposals and too big proposals (unless `a` is 0).
-Additionally, we require `s < s_max` as a safety measure because too large proposals can be too costly to deal with in terms of gas.
-`s_max`, `a` and `b` are parameters of the contract specified by the DAO creator.
-Note that by setting `a` to 0 it's possible to require a constant of tokens to be locked.
-For XTZ transfers their amount must be in range `[y .. z]`.
-`s_max`, `a`, `b`, `y` and `z` are parameters of the contract specified by the DAO creator.
+It should naturally prohibit spam proposals and too big proposals (unless `frozen_scale_value` is 0).
+Additionally, we require `s < max_proposal_size` as a safety measure because too large proposals can be too costly to deal with in terms of gas.
+`max_proposal_size`, `frozen_scale_value` and `frozen_extra_value` are parameters of the contract specified by the DAO creator.
+Note that by setting `frozen_scale_value` to 0 it's possible to require a constant of tokens to be locked.
+For XTZ transfers their amount must be in range `[min_xtz_amount .. max_xtz_amount]`.
+`max_proposal_size`, `frozen_scale_value`, `frozen_extra_value`, `min_xtz_amount` and `max_xtz_amount` are parameters of the contract specified by the DAO creator.
 Additionally, for XTZ transfers `CONTRACT unit` instruction must pass for the `recipient` address, i. e. this address must be an implicit account or refer to an entrypoint of the `unit` type.
 
-* When a proposal is rejected, the returned amount is computed as `c * frozen / d` just like in Registry DAO.
+* When a proposal is rejected, the returned amount is computed as `slash_scale_value * frozen / slash_division_value` just like in Registry DAO.
 
 * The decision lambda makes all requested transfers one by one. In case of insufficient balance the decision lambda can fail.
   + For XTZ transfers it sends `amount` to the `recepient` address with `unit` parameter. I. e. it returns a single `TRANSFER_TOKENS` operation.

--- a/ligo/Makefile
+++ b/ligo/Makefile
@@ -88,32 +88,32 @@ $(OUT)/trivialDAO_storage.tz: src/**
 
 $(OUT)/registryDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
 $(OUT)/registryDAO_storage.tz : token_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
-$(OUT)/registryDAO_storage.tz : a = 1n
-$(OUT)/registryDAO_storage.tz : b = 0n
-$(OUT)/registryDAO_storage.tz : s_max = 100n
-$(OUT)/registryDAO_storage.tz : c = 1n
-$(OUT)/registryDAO_storage.tz : d = 0n
+$(OUT)/registryDAO_storage.tz : frozen_scale_value = 1n
+$(OUT)/registryDAO_storage.tz : frozen_extra_value = 0n
+$(OUT)/registryDAO_storage.tz : max_proposal_size = 100n
+$(OUT)/registryDAO_storage.tz : slash_scale_value = 1n
+$(OUT)/registryDAO_storage.tz : slash_division_value = 0n
 $(OUT)/registryDAO_storage.tz: src/**
 	# ============== Compiling RegistryDAO storage ============== #
 	mkdir -p $(OUT)
-	$(BUILD_STORAGE) --output-file $(OUT)/registryDAO_storage.tz src/registryDAO.mligo base_DAO_contract 'default_registry_DAO_full_storage(("$(admin_address)": address), ("$(token_address)": address), ${a}, $(b), $(s_max), $(c), $(d))'
+	$(BUILD_STORAGE) --output-file $(OUT)/registryDAO_storage.tz src/registryDAO.mligo base_DAO_contract 'default_registry_DAO_full_storage(("$(admin_address)": address), ("$(token_address)": address), ${frozen_scale_value}, $(frozen_extra_value), $(max_proposal_size), $(slash_scale_value), $(slash_division_value))'
 	# ================= Compilation successful ================= #
 	# See "$(OUT)/registryDAO_storage.tz" for compilation result #
 	#
 
 $(OUT)/treasuryDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
 $(OUT)/treasuryDAO_storage.tz : token_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
-$(OUT)/treasuryDAO_storage.tz : a = 0n
-$(OUT)/treasuryDAO_storage.tz : b = 0n
-$(OUT)/treasuryDAO_storage.tz : s_max = 0n
-$(OUT)/treasuryDAO_storage.tz : c = 0n
-$(OUT)/treasuryDAO_storage.tz : d = 0n
-$(OUT)/treasuryDAO_storage.tz : y = 0mutez
-$(OUT)/treasuryDAO_storage.tz : z = 100mutez
+$(OUT)/treasuryDAO_storage.tz : frozen_scale_value = 0n
+$(OUT)/treasuryDAO_storage.tz : frozen_extra_value = 0n
+$(OUT)/treasuryDAO_storage.tz : max_proposal_size = 0n
+$(OUT)/treasuryDAO_storage.tz : slash_scale_value = 0n
+$(OUT)/treasuryDAO_storage.tz : slash_division_value = 0n
+$(OUT)/treasuryDAO_storage.tz : min_xtz_amount = 0mutez
+$(OUT)/treasuryDAO_storage.tz : max_xtz_amount = 100mutez
 $(OUT)/treasuryDAO_storage.tz: src/**
 	# ============== Compiling TreasuryDAO storage ============== #
 	mkdir -p $(OUT)
-	$(BUILD_STORAGE) --output-file $(OUT)/treasuryDAO_storage.tz src/treasuryDAO.mligo base_DAO_contract 'default_treasury_DAO_full_storage(("$(admin_address)": address), ("$(token_address)": address), (${a}, $(b), $(s_max), $(c), $(d), $(y), $(z)))'
+	$(BUILD_STORAGE) --output-file $(OUT)/treasuryDAO_storage.tz src/treasuryDAO.mligo base_DAO_contract 'default_treasury_DAO_full_storage(("$(admin_address)": address), ("$(token_address)": address), (${frozen_scale_value}, $(frozen_extra_value), $(max_proposal_size), $(slash_scale_value), $(slash_division_value), $(min_xtz_amount), $(max_xtz_amount)))'
 	# ============== Compilation successful ============== #
 	# See "$(OUT)/treasuryDAO_storage.tz" for compilation result #
 	#

--- a/ligo/README.md
+++ b/ligo/README.md
@@ -103,7 +103,7 @@ As with the default storage this can be generated with the `ligo
 compile-storage` command, or `make`:
 
 ```bash
-make admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" s_max=12n a=1n b=0n c=1n d=1n out/registryDAO_storage.tz
+make admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" max_proposal_size=12n frozen_scale_value=1n frozen_extra_value=0n slash_scale_value=1n slash_division_value=1n out/registryDAO_storage.tz
 ```
 
 All the arguments to the above command are optional, and will be filled with
@@ -112,19 +112,20 @@ following dummy addresses and default values.
 ```
 admin_address = "tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af"
 token_address = "tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af"
-a = 1n
-b = 0n
-s_max = 100n
-c = 1n
-d = 0n
+frozen_scale_value = 1n
+frozen_extra_value = 0n
+max_proposal_size = 100n
+slash_scale_value = 1n
+slash_division_value = 0n
 ```
 
 The `default_registry_DAO_full_storage` is a LIGO function defined in
 `ligo/src/registryDAO.mligo`, which returns a LIGO expression for storage,
 which is converted into Michelson using the `compile-storage` command. The
 arguments to this function are the admin address, the token address and the
-configuration parameters described in the Registry spec, which are `a`, `b`,
-`s_max`, `c` and `d`.
+configuration parameters described in the Registry spec, which are
+`frozen_scale_value`, `frozen-extra_value`, `max_proposal_size`,
+`slash_scale_value` and `slash_division_value`.
 
 ### TreasuryDAO
 
@@ -134,7 +135,7 @@ Michelson expression during the BaseDAO origination using the `ligo
 compile-storage` command as follows.
 
 ```bash
-make admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" s_max=12n a=1n b=0n c=1n d=1n y=0mutez z=100mutez out/treasuryDAO_storage.tz
+make admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" max_proposal_size=12n frozen_scale_value=1n frozen_extra_value=0n slash_scale_value=1n slash_division_value=1n min_xtz_amount=0mutez max_xtz_amount=100mutez out/treasuryDAO_storage.tz
 ```
 
 This uses the `default_treasury_DAO_full_storage` which is a LIGO function defined in
@@ -145,4 +146,10 @@ The arguments to this function are:
 - the admin address
 - the token address
 - a tuple value consisting of configuration parameters described in the Treasury spec which are:
-    - `a`, `b`, `s_max`, `c`, `d`, `x`, and `z`.
+    - `frozen_scale_value`,
+    - `frozen_extra_value`,
+    - `max_proposal_size`,
+    - `slash_scale_value`,
+    - `slash_division_value`,
+    - `min_xtz_value`,
+    - `max_xtz_value`.

--- a/ligo/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/ligo/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -146,11 +146,11 @@ flushXtzTransfer = uncapsNettest $ withFrozenCallStack $ do
     proposeParams amt = ProposeParams (metadataSize $ proposalMeta amt) $ proposalMeta amt
 
   withSender (AddressResolved owner1) $ do
-  -- due to smaller than y (min mutez allow)
+  -- due to smaller than min_xtz_amount
     call dao (Call @"Propose") (proposeParams 1)
       & expectCustomError_ #fAIL_PROPOSAL_CHECK
 
-  -- due to bigger than z (max mutez allow)
+  -- due to bigger than max_xtz_amount
     call dao (Call @"Propose") (proposeParams 6)
       & expectCustomError_ #fAIL_PROPOSAL_CHECK
 
@@ -204,13 +204,13 @@ originateTreasuryDaoWithBalance bal =
   let fs = $(fetchValue @FullStorage "ligo/haskell/test/treasuryDAO_storage.tz" "TREASURY_STORAGE_PATH")
       configStore = fsConfigured fs
       testExtra = (sExtra $ csStorage configStore)
-        & setExtra @Natural [mt|a|] 1
-        & setExtra @Natural [mt|b|] 0
-        & setExtra @Natural [mt|c|] 1
-        & setExtra @Natural [mt|d|] 1
-        & setExtra @Natural [mt|s_max|] 1000
-        & setExtra @Natural [mt|y|] 2
-        & setExtra @Natural [mt|z|] 5
+        & setExtra @Natural [mt|frozen_scale_value|] 1
+        & setExtra @Natural [mt|frozen_extra_value|] 0
+        & setExtra @Natural [mt|slash_scale_value|] 1
+        & setExtra @Natural [mt|slash_division_value|] 1
+        & setExtra @Natural [mt|max_proposal_size|] 1000
+        & setExtra @Natural [mt|min_xtz_amount|] 2
+        & setExtra @Natural [mt|max_xtz_amount|] 5
       customEps = Map.toList . unBigMap . ssStoredEntrypoints $ fsStartup fs
 
   in originateLigoDaoWithBalance customEps testExtra (csConfig configStore) bal

--- a/ligo/src/treasuryDAO.mligo
+++ b/ligo/src/treasuryDAO.mligo
@@ -25,11 +25,11 @@ let unpack_transfer_type_list (key_name, p : string * ((string, bytes) map)) : t
 
 let treasury_DAO_proposal_check (params, extras : propose_params * contract_extra) : bool =
   let proposal_size = Bytes.size(Bytes.pack(params.proposal_metadata)) in
-  let frozen_scale_value = unpack_nat("a", extras) in
-  let frozen_extra_value = unpack_nat("b", extras) in
-  let max_proposal_size = unpack_nat("s_max", extras) in
-  let min_xtz_amount = unpack_tez("y", extras) in
-  let max_xtz_amount = unpack_tez("z", extras) in
+  let frozen_scale_value = unpack_nat("frozen_scale_value", extras) in
+  let frozen_extra_value = unpack_nat("frozen_extra_value", extras) in
+  let max_proposal_size = unpack_nat("max_proposal_size", extras) in
+  let min_xtz_amount = unpack_tez("min_xtz_amount", extras) in
+  let max_xtz_amount = unpack_tez("max_xtz_amount", extras) in
 
   let requred_token_lock = frozen_scale_value * proposal_size + frozen_extra_value in
 
@@ -52,8 +52,8 @@ let treasury_DAO_proposal_check (params, extras : propose_params * contract_extr
 
 
 let treasury_DAO_rejected_proposal_return_value (params, extras : proposal * contract_extra) : nat =
-  let slash_scale_value = unpack_nat("c", extras) in
-  let slash_division_value =  unpack_nat("d", extras)
+  let slash_scale_value = unpack_nat("slash_scale_value", extras) in
+  let slash_division_value =  unpack_nat("slash_division_value", extras)
   in (slash_scale_value * params.proposer_frozen_token) / slash_division_value
 
 
@@ -111,16 +111,16 @@ let receive_xtz_entrypoint (params, config_store : bytes * configured_storage)
 let default_treasury_DAO_full_storage (admin, token_address, contract_extra
     : (address * address * treasury_contract_extra)) : full_storage =
   let (startup, (store, config)) = default_full_storage (admin, token_address) in
-  let (a, b, s_max, c, d, y, z) = contract_extra in
+  let (frozen_scale_value, frozen_extra_value, max_proposal_size, slash_scale_value, slash_division_value, min_xtz_amount, max_xtz_amount) = contract_extra in
   let new_storage = { store with
     extra = Map.literal [
-          ("a" , Bytes.pack a); // frozen_scale_value
-          ("b" , Bytes.pack b); // frozen_extra_value
-          ("s_max" , Bytes.pack s_max); // max_proposal_size
-          ("c" , Bytes.pack c); // slash_scale_value
-          ("d" , Bytes.pack d); // slash_division_value
-          ("y" , Bytes.pack y); // min_xtz_amount
-          ("z" , Bytes.pack z); // max_xtz_amount
+          ("frozen_scale_value" , Bytes.pack frozen_scale_value);
+          ("frozen_extra_value" , Bytes.pack frozen_extra_value);
+          ("max_proposal_size" , Bytes.pack max_proposal_size);
+          ("slash_scale_value" , Bytes.pack slash_scale_value);
+          ("slash_division_value" , Bytes.pack slash_division_value);
+          ("min_xtz_amount" , Bytes.pack min_xtz_amount);
+          ("max_xtz_amount" , Bytes.pack max_xtz_amount);
           ];
   } in
   let new_config = { config with

--- a/ligo/src/treasuryDAO/types.mligo
+++ b/ligo/src/treasuryDAO/types.mligo
@@ -39,11 +39,11 @@ type transfer_type =
  *)
 
 type treasury_contract_extra =
-  ( nat // a : frozen_scale_value
-  * nat // b : frozen_extra_value
-  * nat // s_max : max_proposal_size
-  * nat // c : slash_scale_value
-  * nat // d : slash_division_value
-  * tez // y : min_xtz_amount
-  * tez // z : max_xtz_amount
+  ( nat // frozen_scale_value
+  * nat // frozen_extra_value
+  * nat // max_proposal_size
+  * nat // slash_scale_value
+  * nat // slash_division_value
+  * tez // min_xtz_amount
+  * tez // max_xtz_amount
   )

--- a/src/Lorentz/Contracts/RegistryDAO/Types.hs
+++ b/src/Lorentz/Contracts/RegistryDAO/Types.hs
@@ -162,11 +162,11 @@ instance TypeHasDoc UpdateReceivers where
 
 -- | Special proposal that allow updating certain scale values in 'contractExtra'
 data ConfigProposal = ConfigProposal
-  { cpFrozenScaleValue :: Maybe Natural -- a
-  , cpFrozenExtraValue :: Maybe Natural -- b
-  , cpSlashScaleValue :: Maybe Natural -- c
-  , cpSlashDivisionValue :: Maybe Natural -- d
-  , cpMaxProposalSize :: Maybe Natural -- s_max
+  { cpFrozenScaleValue :: Maybe Natural
+  , cpFrozenExtraValue :: Maybe Natural
+  , cpSlashScaleValue :: Maybe Natural
+  , cpSlashDivisionValue :: Maybe Natural
+  , cpMaxProposalSize :: Maybe Natural
   }
   deriving stock (Generic)
   deriving anyclass (IsoValue)

--- a/src/Lorentz/Contracts/TreasuryDAO/Types.hs
+++ b/src/Lorentz/Contracts/TreasuryDAO/Types.hs
@@ -21,13 +21,13 @@ import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 
 -- | TreasuryDAO has mainly configuration fields.
 data TreasuryDaoContractExtra = TreasuryDaoContractExtra
-  { ceFrozenScaleValue :: Natural -- a
-  , ceFrozenExtraValue :: Natural -- b
-  , ceSlashScaleValue :: Natural -- c
-  , ceSlashDivisionValue :: Natural -- d
-  , ceMinXtzAmount :: Mutez -- y
-  , ceMaxXtzAmount :: Mutez -- z
-  , ceMaxProposalSize :: Natural -- s_max
+  { ceFrozenScaleValue :: Natural
+  , ceFrozenExtraValue :: Natural
+  , ceSlashScaleValue :: Natural
+  , ceSlashDivisionValue :: Natural
+  , ceMinXtzAmount :: Mutez
+  , ceMaxXtzAmount :: Mutez
+  , ceMaxProposalSize :: Natural
   }
   deriving stock (Generic)
   deriving anyclass (IsoValue)
@@ -41,13 +41,13 @@ instance TypeHasDoc TreasuryDaoContractExtra where
 
 instance Default TreasuryDaoContractExtra where
   def = TreasuryDaoContractExtra
-    { ceFrozenScaleValue = 1 -- a
-    , ceFrozenExtraValue = 0 -- b
-    , ceSlashScaleValue = 1 -- c
-    , ceSlashDivisionValue = 1 -- d
-    , ceMinXtzAmount = toMutez 1 -- y
-    , ceMaxXtzAmount = toMutez 10000 -- z
-    , ceMaxProposalSize = 1000 -- s_max
+    { ceFrozenScaleValue = 1
+    , ceFrozenExtraValue = 0
+    , ceSlashScaleValue = 1
+    , ceSlashDivisionValue = 1
+    , ceMinXtzAmount = toMutez 1
+    , ceMaxXtzAmount = toMutez 10000
+    , ceMaxProposalSize = 1000
     }
 
 -- | A Treasury DAO proposal, contains list of transfers of 2 types:

--- a/test/Test/RegistryDAO.hs
+++ b/test/Test/RegistryDAO.hs
@@ -73,11 +73,11 @@ validConfigProposal = uncapsNettest $ do
 
   let
     (configMetadata :: RegistryDaoProposalMetadata ByteString ByteString) = ConfigProposalType $ ConfigProposal
-        { cpFrozenScaleValue = Just 1 -- a
-        , cpFrozenExtraValue = Just 5 -- b
-        , cpSlashScaleValue = Just 1 -- c
-        , cpSlashDivisionValue = Just 2 -- d
-        , cpMaxProposalSize = Just 62 -- s_max
+        { cpFrozenScaleValue = Just 1
+        , cpFrozenExtraValue = Just 5
+        , cpSlashScaleValue = Just 1
+        , cpSlashDivisionValue = Just 2
+        , cpMaxProposalSize = Just 62
         }
 
   key1 <- createSampleProposal (getTokensAmount configMetadata) configMetadata owner1 dao


### PR DESCRIPTION
## Description

Problem: Currently, ligo uses unintuitive names like `a`, `b`, `c`, `d`,
`s_max`, `y` and `z`, which is not very good for the user.

Solution: Rename each of these with `frozen_scale_value`,
`frozen_extra_value`, `slash_scale_value`, `slash_division_value`,
`max_proposal_size`, `min_xtz_amount`, `max_xtz_amount`, respectively.
These changes were done in a few variable names, Makefile, docs etc and
old references to the short names were erased.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #155

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [X] If I added new functionality, I added tests covering it.
  - [X] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [X] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [X] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [X] My code complies with the [style guide](../tree/master/docs/code-style.md).
