### PR TITLE
[#152] Allow specifying a TZIP-16 metadata contract in the LIGO version

### DIFF
--- a/ligo/Makefile
+++ b/ligo/Makefile
@@ -64,10 +64,11 @@ endif
 
 $(OUT)/trivialDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
 $(OUT)/trivialDAO_storage.tz : token_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
+$(OUT)/trivialDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/trivialDAO_storage.tz: src/**
 	# ============== Compiling TrivialDAO storage ============== #
 	mkdir -p $(OUT)
-	$(BUILD_STORAGE) --output-file $(OUT)/trivialDAO_storage.tz src/base_DAO.mligo base_DAO_contract 'default_full_storage(("$(admin_address)": address), ("$(token_address)": address))'
+	$(BUILD_STORAGE) --output-file $(OUT)/trivialDAO_storage.tz src/base_DAO.mligo base_DAO_contract 'default_full_storage(("$(admin_address)": address), ("$(token_address)": address), $(metadata_map))'
 	# ================= Compilation successful ================= #
 	# See "$(OUT)/trivialDAO_storage.tz" for compilation result  #
 	#
@@ -79,10 +80,11 @@ $(OUT)/registryDAO_storage.tz : frozen_extra_value = 0n
 $(OUT)/registryDAO_storage.tz : max_proposal_size = 100n
 $(OUT)/registryDAO_storage.tz : slash_scale_value = 1n
 $(OUT)/registryDAO_storage.tz : slash_division_value = 0n
+$(OUT)/registryDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/registryDAO_storage.tz: src/**
 	# ============== Compiling RegistryDAO storage ============== #
 	mkdir -p $(OUT)
-	$(BUILD_STORAGE) --output-file $(OUT)/registryDAO_storage.tz src/registryDAO.mligo base_DAO_contract 'default_registry_DAO_full_storage(("$(admin_address)": address), ("$(token_address)": address), ${frozen_scale_value}, $(frozen_extra_value), $(max_proposal_size), $(slash_scale_value), $(slash_division_value))'
+	$(BUILD_STORAGE) --output-file $(OUT)/registryDAO_storage.tz src/registryDAO.mligo base_DAO_contract 'default_registry_DAO_full_storage(("$(admin_address)": address), ("$(token_address)": address), ${frozen_scale_value}, $(frozen_extra_value), $(max_proposal_size), $(slash_scale_value), $(slash_division_value), $(metadata_map))'
 	# ================= Compilation successful ================= #
 	# See "$(OUT)/registryDAO_storage.tz" for compilation result #
 	#
@@ -96,10 +98,11 @@ $(OUT)/treasuryDAO_storage.tz : slash_scale_value = 0n
 $(OUT)/treasuryDAO_storage.tz : slash_division_value = 0n
 $(OUT)/treasuryDAO_storage.tz : min_xtz_amount = 0mutez
 $(OUT)/treasuryDAO_storage.tz : max_xtz_amount = 100mutez
+$(OUT)/treasuryDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/treasuryDAO_storage.tz: src/**
 	# ============== Compiling TreasuryDAO storage ============== #
 	mkdir -p $(OUT)
-	$(BUILD_STORAGE) --output-file $(OUT)/treasuryDAO_storage.tz src/treasuryDAO.mligo base_DAO_contract 'default_treasury_DAO_full_storage(("$(admin_address)": address), ("$(token_address)": address), (${frozen_scale_value}, $(frozen_extra_value), $(max_proposal_size), $(slash_scale_value), $(slash_division_value), $(min_xtz_amount), $(max_xtz_amount)))'
+	$(BUILD_STORAGE) --output-file $(OUT)/treasuryDAO_storage.tz src/treasuryDAO.mligo base_DAO_contract 'default_treasury_DAO_full_storage(("$(admin_address)": address), ("$(token_address)": address), (${frozen_scale_value}, $(frozen_extra_value), $(max_proposal_size), $(slash_scale_value), $(slash_division_value), $(min_xtz_amount), $(max_xtz_amount)), $(metadata_map))'
 	# ============== Compilation successful ============== #
 	# See "$(OUT)/treasuryDAO_storage.tz" for compilation result #
 	#

--- a/ligo/README.md
+++ b/ligo/README.md
@@ -31,10 +31,10 @@ This can be converted to a Michelson expression with the `ligo compile-storage`
 command, which is included in the Makefile so it can be run using `make`.
 
 ```bash
-make admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" out/trivialDAO_storage.tz
+make admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" metadata_map=(Big_map.empty : metadata_map) out/trivialDAO_storage.tz
 ```
 
-Note: Both arguments are optional and will be equal to the values above if not
+Note: All arguments are optional and will be equal to the values above if not
 specified.
 
 Note also that `make all` will generate `out/trivialDAO_storage.tz` with these
@@ -99,7 +99,7 @@ As with the default storage this can be generated with the `ligo
 compile-storage` command, or `make`:
 
 ```bash
-make admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" max_proposal_size=12n frozen_scale_value=1n frozen_extra_value=0n slash_scale_value=1n slash_division_value=1n out/registryDAO_storage.tz
+make admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" max_proposal_size=12n frozen_scale_value=1n frozen_extra_value=0n slash_scale_value=1n slash_division_value=1n metadata_map=(Big_map.empty : metadata_map) out/registryDAO_storage.tz
 ```
 
 All the arguments to the above command are optional, and will be filled with
@@ -113,6 +113,7 @@ frozen_extra_value = 0n
 max_proposal_size = 100n
 slash_scale_value = 1n
 slash_division_value = 0n
+metadata_map = (Big_map.empty : metadata_map)
 ```
 
 The `default_registry_DAO_full_storage` is a LIGO function defined in
@@ -121,7 +122,8 @@ which is converted into Michelson using the `compile-storage` command. The
 arguments to this function are the admin address, the token address and the
 configuration parameters described in the Registry spec, which are
 `frozen_scale_value`, `frozen-extra_value`, `max_proposal_size`,
-`slash_scale_value` and `slash_division_value`.
+`slash_scale_value` and `slash_division_value`. Additionally, a `metadata`
+parameter is accepted, accepting a `big_map` as described in TZIP-16.
 
 ### TreasuryDAO
 
@@ -131,7 +133,7 @@ Michelson expression during the BaseDAO origination using the `ligo
 compile-storage` command as follows.
 
 ```bash
-make admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" max_proposal_size=12n frozen_scale_value=1n frozen_extra_value=0n slash_scale_value=1n slash_division_value=1n min_xtz_amount=0mutez max_xtz_amount=100mutez out/treasuryDAO_storage.tz
+make admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" max_proposal_size=12n frozen_scale_value=1n frozen_extra_value=0n slash_scale_value=1n slash_division_value=1n min_xtz_amount=0mutez max_xtz_amount=100mutez metadata_map=(Big_map.empty : metadata_map) out/treasuryDAO_storage.tz
 ```
 
 This uses the `default_treasury_DAO_full_storage` which is a LIGO function defined in
@@ -149,3 +151,4 @@ The arguments to this function are:
     - `slash_division_value`,
     - `min_xtz_value`,
     - `max_xtz_value`.
+- a `big_map` containing metadata as described in TZIP-16

--- a/ligo/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/ligo/haskell/src/Ligo/BaseDAO/Types.hs
@@ -16,6 +16,7 @@ module Ligo.BaseDAO.Types
   , DynamicRec (..)
   , dynRecUnsafe
   , mkStorageL
+  , mkMetadataMap
   , mkConfigL
   , defaultConfigL
   , mkFullStorageL
@@ -24,7 +25,7 @@ module Ligo.BaseDAO.Types
   ) where
 
 import Lorentz
-import Universum (One(..), fromIntegral, (*))
+import Universum (One(..), fromIntegral, maybe, (*))
 
 import Control.Lens (makeLensesFor)
 import qualified Data.Map as M
@@ -169,6 +170,20 @@ mkStorageL admin votingPeriod quorumThreshold extra metadata =
   where
     votingPeriodDef = 60 * 60 * 24 * 7  -- 7 days
     quorumThresholdDef = 4
+
+mkMetadataMap
+  :: "metadataHostAddress" :! Address
+  -> "metadataHostChain" :? TZIP16.ExtChainId
+  -> "metadataKey" :! MText
+  -> TZIP16.MetadataMap BigMap
+mkMetadataMap hostAddress hostChain key =
+  TZIP16.metadataURI . TZIP16.tezosStorageUri host $ arg #metadataKey key
+  where
+    host = maybe
+      TZIP16.contractHost
+      TZIP16.foreignContractHost
+      (argF #metadataHostChain hostChain)
+      (arg #metadataHostAddress hostAddress)
 
 data ConfigL = ConfigL
   { cProposalCheck :: '[ProposeParamsL, ContractExtraL] :-> '[Bool]

--- a/ligo/src/defaults.mligo
+++ b/ligo/src/defaults.mligo
@@ -17,13 +17,13 @@ let default_config : config = {
     custom_entrypoints = (Map.empty : custom_entrypoints);
     }
 
-let default_storage (admin , token_address : (address * address)) : storage = {
+let default_storage (admin , token_address , metadata : address * address * metadata_map) : storage = {
     ledger = (Big_map.empty : ledger);
     operators = (Big_map.empty : operators);
     token_address = token_address;
     admin = admin;
     pending_owner = admin;
-    metadata = (Big_map.empty : (string, bytes) big_map);
+    metadata = metadata;
     migration_status = Not_in_migration;
     voting_period = 11n;
     quorum_threshold = 2n;
@@ -37,5 +37,5 @@ let default_storage (admin , token_address : (address * address)) : storage = {
         ]
 }
 
-let default_full_storage (admin, token_address : address * address) : full_storage =
-  (default_storage (admin, token_address), default_config)
+let default_full_storage (admin, token_address, metadata_map : address * address * metadata_map) : full_storage =
+  (default_storage (admin, token_address, metadata_map), default_config)

--- a/ligo/src/registryDAO.mligo
+++ b/ligo/src/registryDAO.mligo
@@ -217,9 +217,9 @@ let registry_DAO_decision_lambda (proposal, extras : proposal * contract_extra)
         | None -> new_ce
       in (([] : operation list), new_ce)
 
-let default_registry_DAO_full_storage (admin, token_address, frozen_scale_value, frozen_extra_value, max_proposal_size, slash_scale_value, slash_division_value
-    : (address * address * nat * nat * nat * nat * nat)) : full_storage =
-  let (store, config) = default_full_storage (admin, token_address) in
+let default_registry_DAO_full_storage (admin, token_address, frozen_scale_value, frozen_extra_value, max_proposal_size, slash_scale_value, slash_division_value, metadata_map
+    : (address * address * nat * nat * nat * nat * nat * metadata_map)) : full_storage =
+  let (store, config) = default_full_storage (admin, token_address, metadata_map) in
   let new_storage = { store with
     extra = Map.literal [
           ("registry" , Bytes.pack (Map.empty : registry));
@@ -238,7 +238,6 @@ let default_registry_DAO_full_storage (admin, token_address, frozen_scale_value,
     decision_lambda = registry_DAO_decision_lambda;
     } in
   (new_storage, new_config)
-
 
 // We are not using this right now, but just leaving here in case we might want it
 // soon.

--- a/ligo/src/treasuryDAO.mligo
+++ b/ligo/src/treasuryDAO.mligo
@@ -36,16 +36,9 @@ let treasury_DAO_proposal_check (params, extras : propose_params * contract_extr
   if (params.frozen_token = requred_token_lock) && (proposal_size < max_proposal_size) then
     let ts = unpack_transfer_type_list("transfers", params.proposal_metadata) in
     let is_all_transfers_valid (is_valid, transfer_type: bool * transfer_type) =
-      if is_valid then
-        match transfer_type with
-            Token_transfer_type tt -> is_valid
-          | Xtz_transfer_type xt ->
-              if (min_xtz_amount <= xt.amount && xt.amount <= max_xtz_amount) then
-                is_valid
-              else
-                false
-      else
-        false
+      match transfer_type with
+        | Token_transfer_type tt -> is_valid
+        | Xtz_transfer_type xt -> is_valid && min_xtz_amount <= xt.amount && xt.amount <= max_xtz_amount
     in List.fold is_all_transfers_valid ts true
   else
     false
@@ -106,9 +99,9 @@ let receive_xtz_entrypoint (params, full_store : bytes * full_storage) : return 
 // Storage Generator
 // -------------------------------------
 
-let default_treasury_DAO_full_storage (admin, token_address, contract_extra
-    : (address * address * treasury_contract_extra)) : full_storage =
-  let (store, config) = default_full_storage (admin, token_address) in
+let default_treasury_DAO_full_storage (admin, token_address, contract_extra, metadata_map
+    : address * address * treasury_contract_extra * metadata_map) : full_storage =
+  let (store, config) = default_full_storage (admin, token_address, metadata_map) in
   let (frozen_scale_value, frozen_extra_value, max_proposal_size, slash_scale_value, slash_division_value, min_xtz_amount, max_xtz_amount) = contract_extra in
   let new_storage = { store with
     extra = Map.literal [

--- a/ligo/src/types.mligo
+++ b/ligo/src/types.mligo
@@ -109,6 +109,7 @@ type permit =
   ; signature : signature
   }
 
+type metadata_map = (string, bytes) big_map
 type contract_extra = (string, bytes) map
 
 // -- Storage -- //
@@ -119,7 +120,7 @@ type storage =
   ; token_address : address
   ; admin : address
   ; pending_owner : address
-  ; metadata : (string, bytes) big_map
+  ; metadata : metadata_map
   ; migration_status : migration_status
   ; voting_period : voting_period
   ; quorum_threshold : quorum_threshold


### PR DESCRIPTION
## Description

Problem: We currently can't specify any parameters for metadata when
creating a contract with LIGO.

Solution: Have the `default_{registry,treasury}_DAO_full_storage`
functions accept a `(string, bytes) big_map` corresponding to the
metadata. In the Makefile, add `metadata_map` fields which the user can
specify.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #152

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [X] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [X] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [X] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [X] My code complies with the [style guide](../tree/master/docs/code-style.md).
