### PR TITLE
CI: bump dependencies

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -194,10 +194,10 @@ steps:
       - buildkite-agent artifact download baseDAO.tz assets --step "build-ligo"
       - nix run -f ci.nix packages.baseDAO.exes.baseDAO -c baseDAO print --name RegistryDAO --output assets/RegistryDAO.tz
       - nix run -f ci.nix packages.baseDAO.exes.baseDAO -c baseDAO print --name TreasuryDAO --output assets/TreasuryDAO.tz
-      - nix run -f ci.nix gh -c gh release delete auto-release --yes || true
+      - nix run -f ci.nix pkgs.gitAndTools.gh -c gh release delete auto-release --yes || true
       - nix run -f ci.nix pkgs.git -c git fetch && git tag -f auto-release && git push --force --tags
-      - nix run -f ci.nix gh -c gh release create --prerelease auto-release --title auto-release --notes ""
-      - nix run -f ci.nix gh -c gh release upload auto-release assets/*
+      - nix run -f ci.nix pkgs.gitAndTools.gh -c gh release create --prerelease auto-release --title auto-release --notes ""
+      - nix run -f ci.nix pkgs.gitAndTools.gh -c gh release upload auto-release assets/*
 
 
 notify:

--- a/baseDAO.cabal
+++ b/baseDAO.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.34.3.
 --
 -- see: https://github.com/sol/hpack
 

--- a/cabal.project
+++ b/cabal.project
@@ -9,18 +9,6 @@ packages:
 
 source-repository-package
     type: git
-    location: https://gitlab.com/morley-framework/morley.git
-    tag: 56d74ababeda9aba8e194783fc5e395fa7a6b69a
-    subdir: code/cleveland
-
-source-repository-package
-    type: git
-    location: https://gitlab.com/morley-framework/morley.git
-    tag: 56d74ababeda9aba8e194783fc5e395fa7a6b69a
-    subdir: code/morley-client
-
-source-repository-package
-    type: git
     location: https://github.com/int-index/caps.git
     tag: c5d61837eb358989b581ed82b1e79158c4823b1b
 
@@ -35,6 +23,13 @@ source-repository-package
     location: https://gitlab.com/morley-framework/morley-metadata.git
     tag: 34342cf86e51190b541a68f795899a4328a3db01
     subdir: code/morley-metadata
+
+source-repository-package
+    type: git
+    location: https://gitlab.com/morley-framework/morley.git
+    tag: 56d74ababeda9aba8e194783fc5e395fa7a6b69a
+    subdir: code/cleveland
+            code/morley-client
 
 allow-older: *
 allow-newer: *

--- a/ci.nix
+++ b/ci.nix
@@ -16,6 +16,7 @@ rec {
   weeder-hacks = import sources.haskell-nix-weeder { inherit pkgs; };
   tezos-client = (import "${sources.tezos-packaging}/nix/build/pkgs.nix" {}).ocamlPackages.tezos-client;
   ligo = (import "${sources.ligo}/nix" {}).ligo-bin;
+  morley = (import "${sources.morley}/ci.nix").packages.morley.exes.morley;
 
   # all local packages and their subdirectories
   # we need to know subdirectories to make weeder stuff work
@@ -145,22 +146,4 @@ rec {
       sha256 = "1zwg1xkqxn5b9mmqafg87rmgln47zsmpgdkly165xdzg38smhmng";
     };
   });
-
-  # morley in nixpkgs is very old
-  morley = pkgs.haskellPackages.callHackageDirect {
-    pkg = "morley";
-    ver = "1.11.1";
-    sha256 = "0c9fg4f5dmji5wypa8qsq0bhj1p55l1f6nxdn0sdc721p5rchx28";
-  } {
-    uncaught-exception = pkgs.haskellPackages.callHackageDirect {
-      pkg = "uncaught-exception";
-      ver = "0.1.0";
-      sha256 = "0fqrhyf2jn3ayp3aiirw6mms37w3nwk4h3i7l4hqw481ps0ml16d";
-    } {};
-    cryptonite = pkgs.haskell.lib.doJailbreak (pkgs.haskellPackages.callHackageDirect {
-      pkg = "cryptonite";
-      ver = "0.27";
-      sha256 = "0y8mazalbkbvw60757av1s6q5b8rpyks4lzf5c6dhp92bb0rj5y7";
-    } {});
-  };
 }

--- a/ci.nix
+++ b/ci.nix
@@ -40,7 +40,7 @@ rec {
       {
         # common options for all local packages:
         packages = pkgs.lib.genAttrs local-packages-names (packageName: {
-          package.ghcOptions = with pkgs.lib; concatStringsSep " " (
+          ghcOptions = with pkgs.lib; (
             ["-O0" "-Werror"]
             # produce *.dump-hi files, required for weeder:
             ++ optionals (!release) ["-ddump-to-file" "-ddump-hi"]

--- a/ci.nix
+++ b/ci.nix
@@ -134,13 +134,17 @@ rec {
     hs-pkgs = hs-pkgs-development;
     local-packages = local-packages;
   };
-  # nixpkgs has an older version of stack2cabal which doesn't build
-  # with new libraries, use a newer version
-  stack2cabal = pkgs.haskellPackages.callHackageDirect {
-    pkg = "stack2cabal";
-    ver = "1.0.11";
-    sha256 = "00vn1sjrsgagqhdzswh9jg0cgzdgwadnh02i2fcif9kr5h0khfw9";
-  } { };
+
+  # stack2cabal in nixpkgs is broken because fixes for ghc 8.10 have not
+  # been released to hackage yet, take sources from github
+  stack2cabal = pkgs.haskellPackages.stack2cabal.overrideAttrs (o: {
+    src = pkgs.fetchFromGitHub {
+      owner = "hasufell";
+      repo = "stack2cabal";
+      rev = "afa113beb77569ff21f03fade6ce39edc109598d";
+      sha256 = "1zwg1xkqxn5b9mmqafg87rmgln47zsmpgdkly165xdzg38smhmng";
+    };
+  });
 
   # morley in nixpkgs is very old
   morley = pkgs.haskellPackages.callHackageDirect {

--- a/ci.nix
+++ b/ci.nix
@@ -141,20 +141,6 @@ rec {
     ver = "1.0.11";
     sha256 = "00vn1sjrsgagqhdzswh9jg0cgzdgwadnh02i2fcif9kr5h0khfw9";
   } { };
-  # gh in the nixpkgs is quite old and doesn't support release managing, so we're doing
-  # some ugly workarounds (because of https://github.com/NixOS/nixpkgs/issues/86349) to bump it
-  gh = (pkgs.callPackage "${pkgs.path}/pkgs/applications/version-management/git-and-tools/gh" {
-    buildGoModule = args: pkgs.buildGoModule (args // rec {
-      version = "1.2.0";
-      vendorSha256 = "0ybbwbw4vdsxdq4w75s1i0dqad844sfgs69b3vlscwfm6g3i9h51";
-      src = pkgs.fetchFromGitHub {
-        owner = "cli";
-        repo = "cli";
-        rev = "v${version}";
-        sha256 = "17hbgi1jh4p07r4p5mr7w7p01i6zzr28mn5i4jaki7p0jwfqbvvi";
-      };
-    });
-  });
 
   # morley in nixpkgs is very old
   morley = pkgs.haskellPackages.callHackageDirect {

--- a/ligo/haskell/baseDAO-ligo-meta.cabal
+++ b/ligo/haskell/baseDAO-ligo-meta.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.34.3.
 --
 -- see: https://github.com/sol/hpack
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "cdf9d5b238320b4cd01edc78bcabe4a576c42b4f",
-        "sha256": "04isy1zsw894kh6w71mzq48mvdryfghlhw7d73f7z9wyd7nl2hay",
+        "rev": "a083148b7e4f085e433eacf160dedcb8c3483293",
+        "sha256": "0cir7iznygasb2a3b1q80sb01d3mg68ainy8w1fgfb0h16k7z8nz",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/cdf9d5b238320b4cd01edc78bcabe4a576c42b4f.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/a083148b7e4f085e433eacf160dedcb8c3483293.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-nix-weeder": {
@@ -29,10 +29,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "serokell",
         "repo": "haskell.nix",
-        "rev": "c427aeda2bc82fe4f8ff9354e70bdb4ecb5121b2",
-        "sha256": "1l2n46n5ym42ksyk7mvsh1a89ccdf4kc6k3vn4nvf22rvwm5v0w5",
+        "rev": "43cb0fc8957be7ab027f8bd5d48bc22479032c1f",
+        "sha256": "0m7h9y3rwdgnwmcyjlkrzf8pf1jbrymvxfc5lmzv0i832r1nc318",
         "type": "tarball",
-        "url": "https://github.com/serokell/haskell.nix/archive/c427aeda2bc82fe4f8ff9354e70bdb4ecb5121b2.tar.gz",
+        "url": "https://github.com/serokell/haskell.nix/archive/43cb0fc8957be7ab027f8bd5d48bc22479032c1f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ligo": {
@@ -47,10 +47,10 @@
         "homepage": "",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "66a26e65eb7f9b6cb3f773052da0cd3ac52f015c",
-        "sha256": "09ab1wywcwhqlwy566y00h6q8c7x64qvdk2b82jvadixbanx46wh",
+        "rev": "cc2f27a5b70d89cbb987027d86c477befadfd08f",
+        "sha256": "05rhwkz89bdjxf7d0sv1gjj9mhjisn1r5h9mwinirb4v7krmiz9w",
         "type": "tarball",
-        "url": "https://github.com/serokell/nixpkgs/archive/66a26e65eb7f9b6cb3f773052da0cd3ac52f015c.tar.gz",
+        "url": "https://github.com/serokell/nixpkgs/archive/cc2f27a5b70d89cbb987027d86c477befadfd08f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "stackage.nix": {
@@ -59,10 +59,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "542e9900adbbe3ac445d4a84392cf8b7172d9980",
-        "sha256": "1aj34gp9qgdcw5iqjmjcphrkwvm5nb35jpnalsa7vapga92i51sl",
+        "rev": "5e095b5a139ea53a4758717ba7fa8382e36f6cce",
+        "sha256": "0d2iq90xfgvl1dl98fq3kvccqnkjkq9lr2kzplmqkjrbg0yapb7j",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/stackage.nix/archive/542e9900adbbe3ac445d4a84392cf8b7172d9980.tar.gz",
+        "url": "https://github.com/input-output-hk/stackage.nix/archive/5e095b5a139ea53a4758717ba7fa8382e36f6cce.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos-packaging": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,6 +41,13 @@
         "rev": "b6c3a9d4257bda78af46250a447ce78c5d2291a4",
         "type": "git"
     },
+    "morley": {
+        "sha256": "0g9mdqb7l85z8qa931lxmcqrzhscq6451plz1k18v738ylx4dxmj",
+        "type": "tarball",
+        "url": "https://gitlab.com/morley-framework/morley/-/archive/morley-1.13.0/morley-morley-1.13.0.tar.gz",
+        "url_template": "https://gitlab.com/morley-framework/morley/-/archive/morley-<version>/morley-morley-<version>.tar.gz",
+        "version": "1.13.0"
+    },
     "nixpkgs": {
         "branch": "master",
         "description": "Pinned Nixpkgs tree (master follows nixos-unstable-small, only tags have stable history)",

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -6,25 +6,33 @@ let
   # The fetchers. fetch_<type> fetches specs of type <type>.
   #
 
-  fetch_file = pkgs: spec:
-    if spec.builtin or true then
-      builtins_fetchurl { inherit (spec) url sha256; }
-    else
-      pkgs.fetchurl { inherit (spec) url sha256; };
+  fetch_file = pkgs: name: spec:
+    let
+      name' = sanitizeName name + "-src";
+    in
+      if spec.builtin or true then
+        builtins_fetchurl { inherit (spec) url sha256; name = name'; }
+      else
+        pkgs.fetchurl { inherit (spec) url sha256; name = name'; };
 
   fetch_tarball = pkgs: name: spec:
     let
-      ok = str: ! builtins.isNull (builtins.match "[a-zA-Z0-9+-._?=]" str);
-      # sanitize the name, though nix will still fail if name starts with period
-      name' = stringAsChars (x: if ! ok x then "-" else x) "${name}-src";
+      name' = sanitizeName name + "-src";
     in
       if spec.builtin or true then
         builtins_fetchTarball { name = name'; inherit (spec) url sha256; }
       else
         pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
 
-  fetch_git = spec:
-    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+  fetch_git = name: spec:
+    let
+      ref =
+        if spec ? ref then spec.ref else
+          if spec ? branch then "refs/heads/${spec.branch}" else
+            if spec ? tag then "refs/tags/${spec.tag}" else
+              abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+    in
+      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
 
   fetch_local = spec: spec.path;
 
@@ -40,11 +48,21 @@ let
   # Various helpers
   #
 
+  # https://github.com/NixOS/nixpkgs/pull/83241/files#diff-c6f540a4f3bfa4b0e8b6bafd4cd54e8bR695
+  sanitizeName = name:
+    (
+      concatMapStrings (s: if builtins.isList s then "-" else s)
+        (
+          builtins.split "[^[:alnum:]+._?=-]+"
+            ((x: builtins.elemAt (builtins.match "\\.*(.*)" x) 0) name)
+        )
+    );
+
   # The set of packages used when specs are fetched using non-builtins.
-  mkPkgs = sources:
+  mkPkgs = sources: system:
     let
       sourcesNixpkgs =
-        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) {};
+        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) { inherit system; };
       hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
       hasThisAsNixpkgsPath = <nixpkgs> == ./.;
     in
@@ -64,14 +82,26 @@ let
 
     if ! builtins.hasAttr "type" spec then
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
-    else if spec.type == "file" then fetch_file pkgs spec
+    else if spec.type == "file" then fetch_file pkgs name spec
     else if spec.type == "tarball" then fetch_tarball pkgs name spec
-    else if spec.type == "git" then fetch_git spec
+    else if spec.type == "git" then fetch_git name spec
     else if spec.type == "local" then fetch_local spec
     else if spec.type == "builtin-tarball" then fetch_builtin-tarball name
     else if spec.type == "builtin-url" then fetch_builtin-url name
     else
       abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+
+  # If the environment variable NIV_OVERRIDE_${name} is set, then use
+  # the path directly as opposed to the fetched source.
+  replace = name: drv:
+    let
+      saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
+      ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
+    in
+      if ersatz == "" then drv else
+        # this turns the string into an actual Nix path (for both absolute and
+        # relative paths)
+        if builtins.substring 0 1 ersatz == "/" then /. + ersatz else /. + builtins.getEnv "PWD" + "/${ersatz}";
 
   # Ports of functions for older nix versions
 
@@ -89,25 +119,29 @@ let
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L269
   stringAsChars = f: s: concatStrings (map f (stringToCharacters s));
+  concatMapStrings = f: list: concatStrings (map f list);
   concatStrings = builtins.concatStringsSep "";
 
+  # https://github.com/NixOS/nixpkgs/blob/8a9f58a375c401b96da862d969f66429def1d118/lib/attrsets.nix#L331
+  optionalAttrs = cond: as: if cond then as else {};
+
   # fetchTarball version that is compatible between all the versions of Nix
-  builtins_fetchTarball = { url, name, sha256 }@attrs:
+  builtins_fetchTarball = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchTarball;
     in
       if lessThan nixVersion "1.12" then
-        fetchTarball { inherit name url; }
+        fetchTarball ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
       else
         fetchTarball attrs;
 
   # fetchurl version that is compatible between all the versions of Nix
-  builtins_fetchurl = { url, sha256 }@attrs:
+  builtins_fetchurl = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchurl;
     in
       if lessThan nixVersion "1.12" then
-        fetchurl { inherit url; }
+        fetchurl ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
       else
         fetchurl attrs;
 
@@ -119,14 +153,15 @@ let
         then abort
           "The values in sources.json should not have an 'outPath' attribute"
         else
-          spec // { outPath = fetch config.pkgs name spec; }
+          spec // { outPath = replace name (fetch config.pkgs name spec); }
     ) config.sources;
 
   # The "config" used by the fetchers
   mkConfig =
-    { sourcesFile ? ./sources.json
-    , sources ? builtins.fromJSON (builtins.readFile sourcesFile)
-    , pkgs ? mkPkgs sources
+    { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
+    , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
+    , system ? builtins.currentSystem
+    , pkgs ? mkPkgs sources system
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec
       inherit sources;
@@ -134,5 +169,6 @@ let
       # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
       inherit pkgs;
     };
+
 in
 mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }

--- a/snapshot-stack2cabal.yaml
+++ b/snapshot-stack2cabal.yaml
@@ -9,4 +9,4 @@ resolver: lts-16.5
 packages:
   # the versions must be the same that ci uses, to make sure `stack2cabal` output is identical
   - stack2cabal-1.0.11
-  - hpack-0.34.2
+  - hpack-0.34.3

--- a/snapshot-stack2cabal.yaml
+++ b/snapshot-stack2cabal.yaml
@@ -5,8 +5,9 @@
 # snapshot used for ./scripts/generate-cabal-files.sh script
 name: stack2cabal-snapshot
 
-resolver: lts-16.5
+resolver: lts-17.3
 packages:
   # the versions must be the same that ci uses, to make sure `stack2cabal` output is identical
-  - stack2cabal-1.0.11
+  - git: https://github.com/hasufell/stack2cabal.git
+    commit: afa113beb77569ff21f03fade6ce39edc109598d
   - hpack-0.34.3


### PR DESCRIPTION
Updates dependencies used by CI to keep them up to date

Related issue: https://issues.serokell.io/issue/OPS-1174