### PR TITLE
[#138] Move all inlined constants to storage

### DIFF
--- a/ligo/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/ligo/haskell/src/Ligo/BaseDAO/Types.hs
@@ -121,6 +121,7 @@ data ParameterL
 data StorageL = StorageL
   { sAdmin :: Address
   , sExtra :: ContractExtraL
+  , sFrozenTokenId :: FA2.TokenId
   , sLedger :: Ledger
   , sMetadata :: TZIP16.MetadataMap BigMap
   , sMigrationStatus :: MigrationStatus
@@ -133,6 +134,7 @@ data StorageL = StorageL
   , sTokenAddress :: Address
   , sVotingPeriod :: VotingPeriod
   , sTotalSupply :: TotalSupply
+  , sUnfrozenTokenId :: FA2.TokenId
   , sFixedProposalFeeInToken :: Natural
   }
   deriving stock (Show)
@@ -174,6 +176,8 @@ mkStorageL admin votingPeriod quorumThreshold extra metadata =
     , sVotingPeriod = argDef #votingPeriod votingPeriodDef votingPeriod
     , sTotalSupply = M.fromList [(frozenTokenId, 0), (unfrozenTokenId, 0)]
     , sFixedProposalFeeInToken = 0
+    , sUnfrozenTokenId = unfrozenTokenId
+    , sFrozenTokenId = frozenTokenId
     }
   where
     votingPeriodDef = 60 * 60 * 24 * 7  -- 7 days

--- a/ligo/src/defaults.mligo
+++ b/ligo/src/defaults.mligo
@@ -36,6 +36,8 @@ let default_storage (admin , token_address , metadata : address * address * meta
         ; (unfrozen_token_id, 0n)
         ];
     fixed_proposal_fee_in_token = 0n;
+    frozen_token_id = frozen_token_id;
+    unfrozen_token_id = unfrozen_token_id;
 }
 
 let default_full_storage (admin, token_address, metadata_map : address * address * metadata_map) : full_storage =

--- a/ligo/src/token/fa2.mligo
+++ b/ligo/src/token/fa2.mligo
@@ -76,8 +76,8 @@ let transfer_item (store, ti : storage * transfer_item): storage =
     if tx.amount = 0n then store
     else (
       let valid_token_id =
-        if tx.token_id = unfrozen_token_id then tx.token_id
-        else if tx.token_id = frozen_token_id then (
+        if tx.token_id = store.unfrozen_token_id then tx.token_id
+        else if tx.token_id = store.frozen_token_id then (
           if sender = store.admin then tx.token_id
           else
             (failwith("FROZEN_TOKEN_NOT_TRANSFERABLE") : token_id)
@@ -106,7 +106,7 @@ let transfer (params, store : transfer_params * storage): return =
 // -----------------------------------------------------------------
 
 [@inline]
-let validate_token_type (token_id : token_id): token_id =
+let validate_token_type (token_id, unfrozen_token_id, frozen_token_id : token_id * nat * nat): token_id =
   if (token_id = unfrozen_token_id || token_id = frozen_token_id) then
     token_id
   else ([%Michelson ({| { FAILWITH } |} : string * unit -> token_id)]
@@ -114,7 +114,7 @@ let validate_token_type (token_id : token_id): token_id =
 
 let balance_of (params, store : balance_request_params * storage): return =
   let check_one (req : balance_request_item): balance_response_item =
-    let valid_token_id = validate_token_type(req.token_id) in
+    let valid_token_id = validate_token_type(req.token_id, store.unfrozen_token_id, store.frozen_token_id) in
     let bal =
       match Big_map.find_opt (req.owner, valid_token_id) store.ledger with
         Some bal -> bal
@@ -129,7 +129,7 @@ let balance_of (params, store : balance_request_params * storage): return =
 // Update operators entrypoint
 // -----------------------------------------------------------------
 [@inline]
-let validate_operator_token (token_id : token_id): token_id =
+let validate_operator_token (token_id, unfrozen_token_id, frozen_token_id : token_id * nat * nat): token_id =
   if (token_id = unfrozen_token_id) then
     token_id
   else if (token_id = frozen_token_id) then
@@ -143,7 +143,7 @@ let update_one (store, param: storage * update_operator): storage =
       Add_operator p -> (Some unit, p)
     | Remove_operator p -> ((None : unit option), p)
   in
-  let valid_token_id = validate_operator_token (operator_param.token_id) in
+  let valid_token_id = validate_operator_token (operator_param.token_id, store.unfrozen_token_id, store.frozen_token_id) in
   if (sender = operator_param.owner) then
     let key: operator = { owner = operator_param.owner; operator = operator_param.operator} in
     let updated_operators = Big_map.update key operator_update store.operators

--- a/ligo/src/types.mligo
+++ b/ligo/src/types.mligo
@@ -143,6 +143,8 @@ type storage =
   ; permits_counter : nonce
   ; total_supply : total_supply
   ; fixed_proposal_fee_in_token : nat
+  ; unfrozen_token_id : token_id
+  ; frozen_token_id : token_id
   }
 
 // -- Parameter -- //

--- a/src/Lorentz/Contracts/BaseDAO/Proposal.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Proposal.hs
@@ -87,7 +87,7 @@ checkProposerUnfrozenToken
   => '[ProposeParams pm, store] :-> '[ProposeParams pm, store]
 checkProposerUnfrozenToken = do
   duupX @2
-  push unfrozenTokenId
+  stGetField #sUnfrozenTokenId
   sender
   pair
 
@@ -131,15 +131,17 @@ freeze = do
   duupX @3
   stackType @(Natural : Address : store : Natural : Address : s)
 
-  push unfrozenTokenId
+  duupX @3
+  stToField #sUnfrozenTokenId
   pair
   dip swap; swap; dip swap
   stackType @(store : Address : (TokenId, Natural) : Natural : Address : s)
   callCachedFunc debitFrom
 
   stackType @(store : Natural : Address : s)
+  stGetField #sFrozenTokenId
+  swap
   dip $ do
-    push frozenTokenId
     pair
     swap
 
@@ -156,15 +158,17 @@ unfreeze = do
   duupX @3
   stackType @(Natural : Address : store : Natural : Address : s)
 
-  push frozenTokenId
+  duupX @3
+  stToField #sFrozenTokenId
   pair
   dip swap; swap; dip swap
   stackType @(store : Address : (TokenId, Natural) : Natural : Address : s)
   callCachedFunc debitFrom
 
   stackType @(store : Natural : Address : s)
+  stGetField #sUnfrozenTokenId
+  swap
   dip $ do
-    push unfrozenTokenId
     pair
     swap
 
@@ -231,7 +235,7 @@ checkVoterUnfrozenToken
    => VoteParam pm : store : s :-> VoteParam pm : store : s
 checkVoterUnfrozenToken = do
   duupX @2
-  push unfrozenTokenId; dupL #author; pair
+  stGetField #sUnfrozenTokenId; dupL #author; pair
 
   stGet #sLedger; ifSome nop
     ( do
@@ -423,7 +427,8 @@ checkBalanceLessThanFrozenValue = do
   swap; dip swap
   stackType @[Address, store, "unfreeze_value" :! Natural, Proposal pm, ProposalKey pm, [Operation]]
   dupTop2
-  push frozenTokenId; swap; pair
+  dip (stGetField #sFrozenTokenId)
+  pair
 
   stGet #sLedger; ifSome nop $ do
     failCustomNoArg #pROPOSER_NOT_EXIST_IN_LEDGER
@@ -444,7 +449,7 @@ burnFrozenToken
   => (Address : Natural : store : s)
   :-> store : s
 burnFrozenToken = do
-  dip $ do push frozenTokenId; pair
+  dip $ do duupX @2; stToField #sFrozenTokenId; pair
   dig @2
   callCachedFunc debitFrom
 


### PR DESCRIPTION
## Description

This PR moves constants inlined in the code to the storage. Particularly, `unfrozen_token_id` and `frozen_token_id` were moved to the storage in both the Ligo and Lorentz versions. In the Lorentz version, the `Config` type has its fields inlined in various parts at the `Proposal` module, and it also has been moved to the storage and its usages properly updated.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #138

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [X] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [X] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [X] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [X] My code complies with the [style guide](../tree/master/docs/code-style.md).
