### PR TITLE
[#166] Replace nat views with void entrypoints

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -53,7 +53,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://gitlab.com/morley-framework/morley.git
-    tag: 13bd68194cfabd0f3350eae4166f3277c4621149
+    tag: 28e7b38f9628cfdc0b770571bcd9c2b65e73448a
     subdir: code/cleveland
             code/lorentz
             code/morley

--- a/docs/specification-ligo.md
+++ b/docs/specification-ligo.md
@@ -258,7 +258,7 @@ Full list:
 * [`drop_proposal`](#drop_proposal)
 * [`migrate`](#migrate)
 * [`confirm_migration`](#confirm_migration)
-* [`GetVotePermitCounter`](#getvotepermitcounter)
+* [`get_vote_permit_counter`](#get_vote_permit_counter)
 * [`get_total_supply`](#get_total_supply)
 * [`freeze`](#freeze)
 * [`unfreeze`](#unfreeze)
@@ -839,26 +839,27 @@ Parameter (in Michelson):
 
 ## Views
 
-### **GetVotePermitCounter**
+### **Get_vote_permit_counter**
 
 ```ocaml
 type vote_permit_counter_param =
   [@layout:comb]
   { param : unit
-  ; callback : nat contract
+  ; postprocess : nat -> nat
   }
 
-GetVotePermitCounter of vote_permit_counter_param
+Get_vote_permit_counter of vote_permit_counter_param
 ```
 
 Parameter (in Michelson):
 ```
-(pair %getVotePermitCounter
+(pair %get_vote_permit_counter
   (unit %param)
-  (contract %callback nat)
+  (lambda %postprocess nat nat)
 )
 ```
 
+- A `void` entrypoint as defined in [TZIP-4](https://gitlab.com/tzip/tzip/-/blob/23c5640db0e2242878b4f2dfacf159a5f6d2544e/proposals/tzip-4/tzip-4.md#void-entrypoints).
 - For `vote` entrypoint with permit, returns the current suitable counter for constructing permit signature.
 
 ### **get_total_supply**
@@ -867,7 +868,7 @@ Parameter (in Michelson):
 type get_total_supply_param =
   [@layout:comb]
   { token_id : token_id
-  ; callback : nat contract
+  ; postprocess : nat -> nat
   }
 
 Get_total_supply of get_total_supply_param
@@ -877,10 +878,11 @@ Parameter (in Michelson):
 ```
 (pair %get_total_supply
   (nat %token_id)
-  (contract %callback nat)
+  (lambda %postprocess nat nat)
 )
 ```
 
+- A `void` entrypoint as defined in [TZIP-4](https://gitlab.com/tzip/tzip/-/blob/23c5640db0e2242878b4f2dfacf159a5f6d2544e/proposals/tzip-4/tzip-4.md#void-entrypoints).
 - Return the total number of tokens for the given token id.
 - Fail with `FA2_TOKEN_UNDEFINED` if the given token id is not equal to `0` or `1`.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -253,7 +253,7 @@ Full list:
 * [`drop_proposal`](#drop_proposal)
 * [`migrate`](#migrate)
 * [`confirm_migration`](#confirm_migration)
-* [`GetVotePermitCounter`](#getvotepermitcounter)
+* [`get_vote_permit_counter`](#get_vote_permit_counter)
 * [`get_total_supply`](#get_total_supply)
 
 Format:
@@ -808,38 +808,40 @@ unit
 
 ## Views
 
-### **GetVotePermitCounter**
+### **get_vote_permit_counter**
 
 ```haskell
 data Parameter proposalMetadata otherParam
-  = GetVotePermitCounter (View () Natural)
+  = Get_vote_permit_counter (Void () Natural)
 ```
 
 Parameter (in Michelson):
 ```
-(pair %getVotePermitCounter
-  (unit %param)
-  (contract %callback nat)
+(pair %get_vote_permit_counter
+  (unit %voidParam)
+  (lambda %voidResProxy nat nat)
 )
 ```
 
+- A `void` entrypoint as defined in [TZIP-4](https://gitlab.com/tzip/tzip/-/blob/23c5640db0e2242878b4f2dfacf159a5f6d2544e/proposals/tzip-4/tzip-4.md#void-entrypoints).
 - For `vote` entrypoint with permit, returns the current suitable counter for constructing permit signature.
 
 ### **get_total_supply**
 
 ```haskell
 data Parameter proposalMetadata otherParam
-  = Get_total_supply (View TokenId Natural)
+  = Get_total_supply (Void TokenId Natural)
 ```
 
 Parameter (in Michelson):
 ```
 (pair %get_total_supply
-  (nat %token_id)
-  (contract %callback nat)
+  (nat %voidParam)
+  (contract %voidResProxy nat)
 )
 ```
 
+- A `void` entrypoint as defined in [TZIP-4](https://gitlab.com/tzip/tzip/-/blob/23c5640db0e2242878b4f2dfacf159a5f6d2544e/proposals/tzip-4/tzip-4.md#void-entrypoints).
 - Return the total number of tokens for the given token id.
 - Fail with `FA2_TOKEN_UNDEFINED` if the given token id is not equal to `0` or `1`.
 

--- a/ligo/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/ligo/haskell/src/Ligo/BaseDAO/Types.hs
@@ -100,8 +100,8 @@ data ForbidXTZParam
   | Drop_proposal ProposalKeyL
   | Flush Natural
   | Freeze FreezeParam
-  | GetVotePermitCounter (View () Nonce)
-  | Get_total_supply (View FA2.TokenId Natural)
+  | Get_vote_permit_counter (Void_ () Nonce)
+  | Get_total_supply (Void_ FA2.TokenId Natural)
   | Migrate MigrateParam
   | Mint MintParam
   | Set_fixed_fee_in_token Natural

--- a/ligo/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/ligo/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -160,14 +160,13 @@ test_BaseDAO_Proposal =
           checkTokenBalance unfrozenTokenId dao proposer 48
 
           -- Check total supply
-          let getTotalSupply tokenId consumer = call dao (Call @"Get_total_supply") (mkView tokenId consumer)
-          consumer <- originateSimple "consumer" [] contractConsumer
-          withSender (AddressResolved proposer) $ getTotalSupply unfrozenTokenId consumer
-          checkStorage (AddressResolved $ toAddress consumer) (toVal [148 :: Natural]) -- initial = 200
+          withSender (AddressResolved proposer) $
+            call dao (Call @"Get_total_supply") (mkVoid unfrozenTokenId)
+              & expectError (VoidResult (148 :: Natural)) -- initial = 200
 
-          consumer2 <- originateSimple "consumer" [] contractConsumer
-          withSender (AddressResolved proposer) $ getTotalSupply frozenTokenId consumer2
-          checkStorage (AddressResolved $ toAddress consumer2) (toVal [52 :: Natural]) -- initial = 0
+          withSender (AddressResolved proposer) $
+            call dao (Call @"Get_total_supply") (mkVoid frozenTokenId)
+              & expectError (VoidResult (52 :: Natural)) -- initial = 0
 
     , nettestScenario "cannot propose with insufficient tokens to pay the fee" $
         uncapsNettest $ do
@@ -529,10 +528,9 @@ voteWithPermitNonce _ originateFn = do
     call dao (Call @"Vote") [params2]
 
   -- Check counter
-  consumer <- originateSimple "consumer" [] contractConsumer
   withSender (AddressResolved owner1) $
-    call dao (Call @"GetVotePermitCounter") (mkView () consumer)
-  checkStorage (AddressResolved $ toAddress consumer) (toVal [2 :: Natural])
+    call dao (Call @"Get_vote_permit_counter") (mkVoid ())
+      & expectError (VoidResult (2 :: Natural))
 
 flushNotAffectOngoingProposals
   :: forall caps base m.
@@ -620,13 +618,13 @@ flushAcceptedProposals _ originateFn = do
   checkTokenBalance (unfrozenTokenId) dao owner2 97 -- voter
 
   -- Check total supply (After flush, no changes are made.)
-  consumer <- originateSimple "consumer" [] contractConsumer
-  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView unfrozenTokenId consumer)
-  checkStorage (AddressResolved $ toAddress consumer) (toVal [187 :: Natural]) -- initial = 200
+  withSender (AddressResolved owner1) $
+    call dao (Call @"Get_total_supply") (mkVoid unfrozenTokenId)
+      & expectError (VoidResult (187 :: Natural)) -- initial = 200
 
-  consumer2 <- originateSimple "consumer" [] contractConsumer
-  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView frozenTokenId consumer2)
-  checkStorage (AddressResolved $ toAddress consumer2) (toVal [13 :: Natural]) -- initial = 0
+  withSender (AddressResolved owner1) $
+    call dao (Call @"Get_total_supply") (mkVoid frozenTokenId)
+      & expectError (VoidResult (13 :: Natural)) -- initial = 0
 
 
 flushAcceptedProposalsWithAnAmount
@@ -1112,13 +1110,13 @@ validProposal  _ originateFn = do
   checkTokenBalance unfrozenTokenId dao owner1 90
 
   -- Check total supply
-  consumer <- originateSimple "consumer" [] contractConsumer
-  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView unfrozenTokenId consumer)
-  checkStorage (AddressResolved $ toAddress consumer) (toVal [190 :: Natural]) -- initial = 200
+  withSender (AddressResolved owner1) $
+    call dao (Call @"Get_total_supply") (mkVoid unfrozenTokenId)
+      & expectError (VoidResult (190 :: Natural)) -- initial = 200
 
-  consumer2 <- originateSimple "consumer" [] contractConsumer
-  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView frozenTokenId consumer2)
-  checkStorage (AddressResolved $ toAddress consumer2) (toVal [10 :: Natural]) -- initial = 0
+  withSender (AddressResolved owner1) $
+    call dao (Call @"Get_total_supply") (mkVoid frozenTokenId)
+      & expectError (VoidResult (10 :: Natural)) -- initial = 0
 
 rejectProposal
   :: forall caps base m.

--- a/ligo/src/base_DAO.mligo
+++ b/ligo/src/base_DAO.mligo
@@ -33,7 +33,7 @@ let requiring_no_xtz (param, store, config : forbid_xtz_params * storage * confi
     | Flush (p) -> flush (p, config, store)
     | Burn (p) -> burn(p, store)
     | Mint (p) -> mint(p, store)
-    | GetVotePermitCounter (p) -> get_vote_permit_counter(p, store)
+    | Get_vote_permit_counter (p) -> get_vote_permit_counter(p, store)
     | Get_total_supply (p) -> get_total_supply(p, store)
     | Freeze p -> freeze(p, config, store)
     | Unfreeze p -> unfreeze(p, config, store)

--- a/ligo/src/permit.mligo
+++ b/ligo/src/permit.mligo
@@ -47,17 +47,13 @@ let verify_permit_protected_vote
   | Some permit -> verify_permit_vote (permit, permited.argument, store)
 
 let get_vote_permit_counter (param, store : vote_permit_counter_param * storage) : return =
-  ( Tezos.transaction store.permits_counter 0mutez param.callback
-    :: ([] : operation list)
-  , store
-  )
+  ([%Michelson ({| { FAILWITH } |} : string * nat -> return)]
+    ("VoidResult", param.postprocess store.permits_counter) : return)
 
 let get_total_supply (param, store : get_total_supply_param * storage) : return =
   let result = match Big_map.find_opt param.token_id store.total_supply with
       None ->
         (failwith("FA2_TOKEN_UNDEFINED") : nat)
     | Some v -> v in
-  ( Tezos.transaction result 0mutez param.callback
-    :: ([] : operation list)
-  , store
-  )
+  ([%Michelson ({| { FAILWITH } |} : string * token_id -> return)]
+    ("VoidResult", param.postprocess result) : return)

--- a/ligo/src/types.mligo
+++ b/ligo/src/types.mligo
@@ -225,13 +225,13 @@ type transfer_contract_tokens_param =
 type vote_permit_counter_param =
   [@layout:comb]
   { param : unit
-  ; callback : nat contract
+  ; postprocess : nat -> nat
   }
 
 type get_total_supply_param =
   [@layout:comb]
   { token_id : token_id
-  ; callback : nat contract
+  ; postprocess : nat -> nat
   }
 
 (*
@@ -251,7 +251,7 @@ type forbid_xtz_params =
   | Flush of nat
   | Burn of burn_param
   | Mint of mint_param
-  | GetVotePermitCounter of vote_permit_counter_param
+  | Get_vote_permit_counter of vote_permit_counter_param
   | Get_total_supply of get_total_supply_param
   | Freeze of freeze_param
   | Unfreeze of unfreeze_param

--- a/src/BaseDAO/ShareTest/Proposal/Proposal.hs
+++ b/src/BaseDAO/ShareTest/Proposal/Proposal.hs
@@ -10,7 +10,6 @@ module BaseDAO.ShareTest.Proposal.Proposal
 import Universum
 
 import Lorentz hiding ((>>))
-import Lorentz.Test (contractConsumer)
 import Morley.Nettest
 
 import BaseDAO.ShareTest.Common
@@ -38,13 +37,13 @@ validProposal  _ originateFn = do
   checkTokenBalance unfrozenTokenId dao owner1 90
 
   -- Check total supply
-  consumer <- originateSimple "consumer" [] contractConsumer
-  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView unfrozenTokenId consumer)
-  checkStorage (AddressResolved $ toAddress consumer) (toVal [190 :: Natural]) -- initial = 200
+  withSender (AddressResolved owner1) $
+    call dao (Call @"Get_total_supply") (mkVoid unfrozenTokenId)
+      & expectError (VoidResult (190 :: Natural)) -- initial = 200
 
-  consumer2 <- originateSimple "consumer" [] contractConsumer
-  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView frozenTokenId consumer2)
-  checkStorage (AddressResolved $ toAddress consumer2) (toVal [10 :: Natural]) -- initial = 0
+  withSender (AddressResolved owner1) $
+    call dao (Call @"Get_total_supply") (mkVoid frozenTokenId)
+      & expectError (VoidResult (10 :: Natural)) -- initial = 0
 
   -- TODO [#31]: Currently proposalId is expected to be knowned (checkInStorage)
 

--- a/src/BaseDAO/ShareTest/Token.hs
+++ b/src/BaseDAO/ShareTest/Token.hs
@@ -10,7 +10,6 @@ module BaseDAO.ShareTest.Token
 import Universum
 
 import Lorentz hiding ((>>))
-import Lorentz.Test (contractConsumer)
 import Morley.Nettest
 import Util.Named
 
@@ -46,13 +45,13 @@ burnScenario originateFn = withFrozenCallStack $ do
   checkTokenBalance (DAO.frozenTokenId) dao owner1 5
 
   -- Check total supply
-  consumer <- originateSimple "consumer" [] contractConsumer
-  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView DAO.unfrozenTokenId consumer)
-  checkStorage (AddressResolved $ toAddress consumer) (toVal [10 :: Natural]) -- initial = 20
+  withSender (AddressResolved owner1) $
+    call dao (Call @"Get_total_supply") (mkVoid DAO.unfrozenTokenId)
+      & expectError (VoidResult (10 :: Natural)) -- initial = 20
 
-  consumer2 <- originateSimple "consumer" [] contractConsumer
-  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView DAO.frozenTokenId consumer2)
-  checkStorage (AddressResolved $ toAddress consumer2) (toVal [15 :: Natural]) -- initial = 20
+  withSender (AddressResolved owner1) $
+    call dao (Call @"Get_total_supply") (mkVoid DAO.frozenTokenId)
+      & expectError (VoidResult (15 :: Natural)) -- initial = 20
 
 mintScenario
   :: forall caps base m param pm
@@ -73,13 +72,13 @@ mintScenario originateFn = withFrozenCallStack $ do
   checkTokenBalance (DAO.frozenTokenId) dao owner1 50
 
   -- Check total supply
-  consumer <- originateSimple "consumer" [] contractConsumer
-  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView DAO.unfrozenTokenId consumer)
-  checkStorage (AddressResolved $ toAddress consumer) (toVal [100 :: Natural]) -- initial = 0
+  withSender (AddressResolved owner1) $
+    call dao (Call @"Get_total_supply") (mkVoid DAO.unfrozenTokenId)
+      & expectError (VoidResult (100 :: Natural)) -- initial = 0
 
-  consumer2 <- originateSimple "consumer" [] contractConsumer
-  withSender (AddressResolved owner1) $ call dao (Call @"Get_total_supply") (mkView DAO.frozenTokenId consumer2)
-  checkStorage (AddressResolved $ toAddress consumer2) (toVal [50 :: Natural]) -- initial = 0
+  withSender (AddressResolved owner1) $
+    call dao (Call @"Get_total_supply") (mkVoid DAO.frozenTokenId)
+      & expectError (VoidResult (50 :: Natural)) -- initial = 0
 
 transferContractTokensScenario
   :: forall caps base m param pm

--- a/src/Lorentz/Contracts/BaseDAO.hs
+++ b/src/Lorentz/Contracts/BaseDAO.hs
@@ -74,7 +74,7 @@ baseDaoContract config@Config{..} = toContract $ docGroup (DName cDaoName) $ do
       , #cConfirm_migration /-> confirmMigration
       , #cDrop_proposal /-> dropProposal config
       , #cFlush /-> flush config
-      , #cGetVotePermitCounter /-> view_ $ do
+      , #cGet_vote_permit_counter /-> void_ $ do
           doc $ DDescription getVotePermitCounterDoc
           drop @(); stToField #sPermitsCounter
       , #cMigrate /-> migrate
@@ -85,7 +85,7 @@ baseDaoContract config@Config{..} = toContract $ docGroup (DName cDaoName) $ do
       , #cTransfer_contract_tokens /-> transferContractTokens
       , #cTransfer_ownership /-> transferOwnership
       , #cVote /-> vote config
-      , #cGet_total_supply /-> view_ $ do
+      , #cGet_total_supply /-> void_ $ do
           doc $ DDescription getTotalSupplyDoc
           stGet #sTotalSupply
           ifSome nop (failCustom_ #fA2_TOKEN_UNDEFINED)

--- a/src/Lorentz/Contracts/BaseDAO/Types.hs
+++ b/src/Lorentz/Contracts/BaseDAO/Types.hs
@@ -328,7 +328,7 @@ data Parameter proposalMetadata otherParam
   | Confirm_migration ()
   | Drop_proposal (ProposalKey proposalMetadata)
   | Flush Natural
-  | GetVotePermitCounter (View () Nonce)
+  | Get_vote_permit_counter (Void_ () Nonce)
   | Migrate MigrateParam
   | Mint MintParam
   | Propose (ProposeParams proposalMetadata)
@@ -337,7 +337,7 @@ data Parameter proposalMetadata otherParam
   | Transfer_contract_tokens TransferContractTokensParam
   | Transfer_ownership TransferOwnershipParam
   | Vote [PermitProtected $ VoteParam proposalMetadata]
-  | Get_total_supply (View (FA2.TokenId) Natural)
+  | Get_total_supply (Void_ FA2.TokenId Natural)
   deriving stock (Generic, Show)
 
 -- Note: using this for calling entrypoints with polymorphic arguments may
@@ -350,7 +350,7 @@ type ParameterC param proposalMetadata =
     , "Confirm_migration" :> ()
     , DropProposalEp proposalMetadata
     , FlushEp
-    , "GetVotePermitCounter" :> (View () Nonce)
+    , "Get_vote_permit_counter" :> Void_ () Nonce
     , "Migrate" :> MigrateParam
     , "Mint" :> MintParam
     , ProposeEp proposalMetadata
@@ -359,7 +359,7 @@ type ParameterC param proposalMetadata =
     , "Transfer_contract_tokens" :> TransferContractTokensParam
     , "Transfer_ownership" :> TransferOwnershipParam
     , VoteEp proposalMetadata
-    , "Get_total_supply" :> (View FA2.TokenId Natural)
+    , "Get_total_supply" :> Void_ FA2.TokenId Natural
     ]
   , FA2.ParameterC param
   )

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -103,12 +103,12 @@ packages:
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
       size: 9641
-      sha256: 6de4ad45bb0c007d707c9132cd6c9cdcd0c5d18c79cb921b90790d0d80ae86fa
-    commit: 13bd68194cfabd0f3350eae4166f3277c4621149
+      sha256: d65540c475280e0b74b586f4146b291dde17b389e7bad7c1deef376ec36428d4
+    commit: 28e7b38f9628cfdc0b770571bcd9c2b65e73448a
   original:
     subdir: code/morley
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 13bd68194cfabd0f3350eae4166f3277c4621149
+    commit: 28e7b38f9628cfdc0b770571bcd9c2b65e73448a
 - completed:
     subdir: code/lorentz
     name: lorentz
@@ -116,25 +116,25 @@ packages:
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
       size: 3741
-      sha256: dc462de5ed06b118955daf9784d1a018bcd51141b16cc4d30e7d6ad2045ff311
-    commit: 13bd68194cfabd0f3350eae4166f3277c4621149
+      sha256: fce541c1b843a238687baac6bef5db7c729a346dae1d2ee33195e56c8320a7d0
+    commit: 28e7b38f9628cfdc0b770571bcd9c2b65e73448a
   original:
     subdir: code/lorentz
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 13bd68194cfabd0f3350eae4166f3277c4621149
+    commit: 28e7b38f9628cfdc0b770571bcd9c2b65e73448a
 - completed:
     subdir: code/cleveland
     name: cleveland
     version: 0.1.0
     git: https://gitlab.com/morley-framework/morley.git
     pantry-tree:
-      size: 12513
-      sha256: aa009f6e0bcf0b8c4b6f43247fe361b11ac113bdbf466b78bf69f82879f26115
-    commit: 13bd68194cfabd0f3350eae4166f3277c4621149
+      size: 12580
+      sha256: 0b3c3fe5a806781f4e8538862fcbbacd08d45b2d87c56fc7bd05877eacc54a54
+    commit: 28e7b38f9628cfdc0b770571bcd9c2b65e73448a
   original:
     subdir: code/cleveland
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 13bd68194cfabd0f3350eae4166f3277c4621149
+    commit: 28e7b38f9628cfdc0b770571bcd9c2b65e73448a
 - completed:
     subdir: code/morley-client
     name: morley-client
@@ -143,11 +143,11 @@ packages:
     pantry-tree:
       size: 3175
       sha256: 00f60cb7810aeb4eb22011cac7da5b3c015ce4a106a6cdd9273593e65fe51d28
-    commit: 13bd68194cfabd0f3350eae4166f3277c4621149
+    commit: 28e7b38f9628cfdc0b770571bcd9c2b65e73448a
   original:
     subdir: code/morley-client
     git: https://gitlab.com/morley-framework/morley.git
-    commit: 13bd68194cfabd0f3350eae4166f3277c4621149
+    commit: 28e7b38f9628cfdc0b770571bcd9c2b65e73448a
 - completed:
     name: caps
     version: '0'

--- a/template/snapshot.yaml
+++ b/template/snapshot.yaml
@@ -29,7 +29,7 @@ packages:
       https://gitlab.com/morley-framework/morley.git
     # ^ CI cannot use ssh, so we use http clone here
     commit:
-      13bd68194cfabd0f3350eae4166f3277c4621149 # master
+      28e7b38f9628cfdc0b770571bcd9c2b65e73448a # master
     subdirs:
       - code/morley
       - code/lorentz


### PR DESCRIPTION
## Description

**Problem:** We need to somehow get data from storage but using views is insecure: other contracts can trick DAO into sending operations to arbitrary contracts.

**Solution:** Replace views with `void` entrypoints.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #166 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
