### PR TITLE
[#178] Use unsafe way to compile view code from morley-metadata

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -47,7 +47,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://gitlab.com/morley-framework/morley-metadata.git
-    tag: b66b0e6bb96e1f15388594f7ec724d45b68769c5
+    tag: 8b5ce0bc6f2a28b1091e5da34dc13ca87ec32672
     subdir: code/morley-metadata
 
 source-repository-package

--- a/src/Lorentz/Contracts/RegistryDAO.hs
+++ b/src/Lorentz/Contracts/RegistryDAO.hs
@@ -13,10 +13,8 @@ module Lorentz.Contracts.RegistryDAO
   ) where
 
 import Data.Either (fromRight)
-import Fmt (pretty)
 import Lorentz
 import Universum ((*))
-import qualified Universum as U
 
 import qualified Lorentz.Contracts.BaseDAO as DAO
 import qualified Lorentz.Contracts.BaseDAO.Proposal as DAO
@@ -252,9 +250,6 @@ registryDAOViews
   => [TZIP16.View (ToT (RegistryDaoStorage k v))]
 registryDAOViews = [proposalReceiversListView @k @v]
 
-compileViewCode_ :: ViewCode st ret -> CompiledViewCode st ret
-compileViewCode_ = U.either (U.error . pretty) U.id . compileViewCode
-
 proposalReceiversListView
   :: forall k v. IsoRegistryDaoProposalMetadata k v
   =>  TZIP16.View (ToT (RegistryDaoStorage k v))
@@ -265,7 +260,7 @@ proposalReceiversListView = TZIP16.View
   , vImplementations =
       [  VIMichelsonStorageView $
           mkMichelsonStorageView @(RegistryDaoStorage k v) @(Set Address) Nothing [] $
-            compileViewCode_ $ WithParam @() $ do
+            unsafeCompileViewCode $ WithParam @() $ do
               drop
               stToField #sExtra
               stackType @(RegistryDaoContractExtra k v : _)

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -179,12 +179,12 @@ packages:
     git: https://gitlab.com/morley-framework/morley-metadata.git
     pantry-tree:
       size: 1216
-      sha256: 4fcaefb9c2ce3f6f06e05105e1ba5117cc4b72eaa4d53e8e317ca27f53424c2c
-    commit: b66b0e6bb96e1f15388594f7ec724d45b68769c5
+      sha256: 2790dc9b81ad49c952a639b8618de9aeb37246d7e6694dc5f361c052f1fd78f6
+    commit: 8b5ce0bc6f2a28b1091e5da34dc13ca87ec32672
   original:
     subdir: code/morley-metadata
     git: https://gitlab.com/morley-framework/morley-metadata.git
-    commit: b66b0e6bb96e1f15388594f7ec724d45b68769c5
+    commit: 8b5ce0bc6f2a28b1091e5da34dc13ca87ec32672
 snapshots:
 - completed:
     size: 563099

--- a/template/snapshot.yaml
+++ b/template/snapshot.yaml
@@ -42,6 +42,6 @@ packages:
     subdirs:
       - code/morley-ledgers
   - git: https://gitlab.com/morley-framework/morley-metadata.git
-    commit: b66b0e6bb96e1f15388594f7ec724d45b68769c5 # master
+    commit: 8b5ce0bc6f2a28b1091e5da34dc13ca87ec32672 # master
     subdirs:
       - code/morley-metadata


### PR DESCRIPTION
## Description

`compileViewCode_` function was removed. Its usages were replaced by `unsafeCompileViewCode` from `morley-metadata`

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

Resolves #178 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
