### PR TITLE
[#175] make the quorum a fraction of Total Supply

### DIFF
--- a/haskell/test/Test/Ligo/BaseDAO/Integrational/Management.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Integrational/Management.hs
@@ -41,7 +41,7 @@ checkVotingPeriodTracking  = do
     mkFullStorage
       ! #admin admin
       ! #votingPeriod 10
-      ! #quorumThreshold 10
+      ! #quorumThreshold (QuorumThreshold 10 100)
       ! #extra dynRecUnsafe
       ! #metadata mempty
       ! #now now

--- a/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
@@ -45,7 +45,7 @@ checkFreezeHistoryTracking  = do
     mkFullStorage
       ! #admin admin
       ! #votingPeriod 10
-      ! #quorumThreshold 10
+      ! #quorumThreshold (QuorumThreshold 10 100)
       ! #extra dynRecUnsafe
       ! #metadata mempty
       ! #now now

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Bounds.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Bounds.hs
@@ -40,7 +40,7 @@ setQuorumThreshold
 setQuorumThreshold originateFn = do
   ((owner1, _), _, dao, admin) <- originateFn testConfig
 
-  let param = 100
+  let param = QuorumThreshold 80 100
 
   withSender (AddressResolved owner1) $
     call dao (Call @"Set_quorum_threshold") param

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
@@ -148,7 +148,8 @@ testConfig
   => ConfigDesc config
 testConfig =
   ConfigDesc (proposalFrozenTokensMinBound 10) >>-
-  ConfigDesc configConsts{ cmMinVotingPeriod = Just 10, cmMinQuorumThreshold = Just 1 }
+  ConfigDesc configConsts
+    { cmMinVotingPeriod = Just 10, cmMinQuorumThreshold = Just (DAO.QuorumThreshold 1 100) }
 
 -- | Config with longer voting period and bigger quorum threshold
 -- Needed for vote related tests that do not call `flush`
@@ -157,7 +158,8 @@ voteConfig
   => ConfigDesc config
 voteConfig = ConfigDesc $
   ConfigDesc (proposalFrozenTokensMinBound 10) >>-
-  ConfigDesc configConsts{ cmMinVotingPeriod = Just 120, cmMinQuorumThreshold = Just 4 }
+  ConfigDesc configConsts
+    { cmMinVotingPeriod = Just 120, cmMinQuorumThreshold = Just (DAO.QuorumThreshold 4 100) }
 
 configWithRejectedProposal
   :: AreConfigDescsExt config '[RejectedProposalReturnValue]

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -87,7 +87,10 @@ flushTokenTransfer = uncapsNettest $ withFrozenCallStack $ do
       , ((owner2_, unfrozenTokenId), 100)
       ]
 
-  -- Set RegistryDAO as operator of the address that is mean to transfer the tokens
+  withSender (AddressResolved admin) $
+    call dao (Call @"Set_quorum_threshold") $ QuorumThreshold 1 100
+
+  -- Set RegistryDAO as operator of the address that is meant to transfer the tokens
   let opParams = FA2.OperatorParam
         { opOwner = owner2
         , opOperator = toAddress dao
@@ -126,7 +129,7 @@ flushTokenTransfer = uncapsNettest $ withFrozenCallStack $ do
   let
     upvote = NoPermit VoteParam
         { vVoteType = True
-        , vVoteAmount = 1
+        , vVoteAmount = 2
         , vProposalKey = key1
         }
 

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -10,8 +10,8 @@ let default_config : config = {
 
     max_proposals = 500n;
     max_votes = 1000n;
-    max_quorum_threshold = 1000n;
-    min_quorum_threshold = 1n;
+    max_quorum_threshold = {numerator = 99n; denominator = 100n}; // 99%
+    min_quorum_threshold = {numerator = 1n; denominator = 100n}; // 1%
     max_voting_period = 2592000n; // 60 * 60 * 24 * 30
     min_voting_period = 1n;
     custom_entrypoints = (Map.empty : custom_entrypoints);
@@ -25,7 +25,7 @@ let default_storage (admin , token_address , now_val, metadata : address * addre
     pending_owner = admin;
     metadata = metadata;
     voting_period = 11n;
-    quorum_threshold = 2n;
+    quorum_threshold = {numerator = 1n; denominator = 10n}; // 10%
     extra = (Map.empty : (string, bytes) map);
     proposals = (Big_map.empty : (proposal_key, proposal) big_map);
     proposal_key_list_sort_by_date = (Set.empty : (timestamp * proposal_key) set);

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -124,7 +124,15 @@ type proposal =
   }
 
 type voting_period = nat
-type quorum_threshold = nat
+
+// Quorum threshold that a proposal needs to meet in order to be accepted,
+// expressed as a fraction of the total_supply of frozen tokens.
+// Invariant: numerator < denominator
+type quorum_threshold =
+  [@layout:comb]
+  { numerator : nat
+  ; denominator : nat
+  }
 
 type permit =
   { key : key
@@ -174,7 +182,6 @@ type unfreeze_param = nat
 type transfer_ownership_param = address
 
 type voting_period = nat
-type quorum_threshold = nat
 
 type custom_ep_param = (string * bytes)
 
@@ -279,8 +286,8 @@ type config =
 
   ; max_proposals : nat
   ; max_votes : nat
-  ; max_quorum_threshold : nat
-  ; min_quorum_threshold : nat
+  ; max_quorum_threshold : quorum_threshold
+  ; min_quorum_threshold : quorum_threshold
   ; max_voting_period : nat
   ; min_voting_period : nat
 

--- a/typescript/baseDAO/src/api.ts
+++ b/typescript/baseDAO/src/api.ts
@@ -200,7 +200,7 @@ export class BaseDAOContract {
 
   set_quorum_threshold(arg: Set_quorum_threshold): Promise<string|void> {
     return this.withContract(
-      contract => contract.methods.set_quorum_threshold(arg));
+      contract => contract.methods.set_quorum_threshold(arg.numerator, arg.denominator));
   }
 
   set_voting_period(arg: Set_voting_period): Promise<string|void> {

--- a/typescript/baseDAO/src/generated/Set_quorum_threshold.ts
+++ b/typescript/baseDAO/src/generated/Set_quorum_threshold.ts
@@ -1,2 +1,5 @@
 import {Lambda} from '../common';
-export type Set_quorum_threshold = number;
+export interface Set_quorum_threshold {
+  numerator: number;
+  denominator: number;
+};


### PR DESCRIPTION
## Description

Modifies the quorum threshold, as well as its settings, to be a fraction of the total supply of frozen tokens (instead of a fixed value).


## Related issue(s)

Resolves #175

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
