### PR TITLE
[#188] Store `contract_extra` as a `big_map`

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -35,9 +35,12 @@ These two parts are coupled into one smart contract because interaction between 
 BaseDAO is a concrete smart contract, but also a framework to implement various DAOs.
 It can be configured at origination for any specific needs.
 
-In order to do so the contract has two type synonyms for `(string, bytes) map`
-(or in Michelson: `map string bytes`), that can contain arbitrary data:
-`proposal_metadata` and `contract_extra`.
+In order to do so the contract has types that can contain arbitary data:
+- `proposal_metadata` which is a type synonym for `(string, bytes) map`
+  (or in Michelson: `map string bytes`)
+- `contract_extra` which is a type synonym for `(string, bytes) big_map`
+  (or in Michelson: `big_map string bytes`)
+
 
 The former contains fields that are required to submit a proposal.
 The latter keeps global information like information about accepted proposals.
@@ -230,7 +233,8 @@ The list of erros may be inaccurate and incomplete, it will be updated during th
 | `PROPOSAL_NOT_UNIQUE`           | Trying to propose a proposal that is already existed in the Storage.                                        |
 | `MISSIGNED`                     | Parameter signature does not match the expected one - for permits.                                          |
 | `ENTRYPOINT_NOT_FOUND`          | Throw when `CallCustom` is called with a non-existing entrypoint                                            |
-| `UNPACKING_FAILED`              | Throw when unpacking of a stored entrypoint or its parameter fails.                                         |
+| `UNPACKING_FAILED`              | Throw when unpacking of a stored entrypoint, its parameter or a required `extra` value fails.               |
+| `MISSING_VALUE`                 | Throw when trying to unpack a field that does not exist.                                                    |
 | `NOT_PROPOSING_PERIOD`          | Throw when `propose` call is made on a non-proposing period.                                                |
 | `NOT_ENOUGH_FROZEN_TOKENS`      | Throw when there is not enough frozen tokens for the operation.                                             |
 | `NOT_ENOUGH_STAKED_TOKENS`      | Throw when there is not enough staked tokens for the operation.                                             |

--- a/haskell/test/Test/Ligo/BaseDAO/Common.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Common.hs
@@ -235,7 +235,7 @@ originateLigoDaoWithConfigDesc extra config =
 
 originateLigoDao :: MonadNettest caps base m => OriginateFn m
 originateLigoDao =
-  originateLigoDaoWithConfig dynRecUnsafe defaultConfig
+  originateLigoDaoWithConfig dynRecBigMapUnsafe defaultConfig
 
 createSampleProposal
   :: (MonadNettest caps base m, HasCallStack)

--- a/haskell/test/Test/Ligo/BaseDAO/Integrational/Management.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Integrational/Management.hs
@@ -42,7 +42,7 @@ checkVotingPeriodTracking  = do
       ! #admin admin
       ! #votingPeriod 10
       ! #quorumThreshold (QuorumThreshold 10 100)
-      ! #extra dynRecUnsafe
+      ! #extra dynRecBigMapUnsafe
       ! #metadata mempty
       ! #now now
       ! #tokenAddress genesisAddress

--- a/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
@@ -48,7 +48,7 @@ checkFreezeHistoryTracking  = do
       ! #admin admin
       ! #votingPeriod 10
       ! #quorumThreshold (QuorumThreshold 10 100)
-      ! #extra dynRecUnsafe
+      ! #extra dynRecBigMapUnsafe
       ! #metadata mempty
       ! #now now
       ! #tokenAddress (unTAddress tokenContract)

--- a/haskell/test/Test/Ligo/BaseDAO/Management.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Management.hs
@@ -114,7 +114,7 @@ test_BaseDAO_Management =
 
     initialStorage now admin = mkFullStorage
       ! #admin admin
-      ! #extra dynRecUnsafe
+      ! #extra dynRecBigMapUnsafe
       ! #metadata mempty
       ! #now now
       ! #tokenAddress genesisAddress

--- a/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
@@ -33,7 +33,7 @@ offChainViewStorage :: Storage
 offChainViewStorage =
   (mkStorage
   ! #admin addr
-  ! #extra dynRecUnsafe
+  ! #extra dynRecBigMapUnsafe
   ! #metadata mempty
   ! #now (timestampFromSeconds 0)
   ! #tokenAddress genesisAddress

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -42,119 +42,119 @@ test_BaseDAO_Proposal =
   [ testGroup "Proposal creator:"
       [ nettestScenarioOnEmulator "BaseDAO - can propose a valid proposal" $
           \_emulated ->
-            uncapsNettest $ validProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ validProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "cannot propose an invalid proposal (rejected)" $
           \_emulated ->
-            uncapsNettest $ rejectProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ rejectProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "cannot propose a non-unique proposal" $
           \_emulated ->
-            uncapsNettest $ nonUniqueProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ nonUniqueProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "cannot propose in a non-proposal period" $
           \_emulated ->
-            uncapsNettest $ nonProposalPeriodProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ nonProposalPeriodProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       ]
 
   , testGroup "Voter:"
       [ nettestScenarioOnEmulator "can vote on a valid proposal" $
           \_emulated ->
-            uncapsNettest $ voteValidProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ voteValidProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "cannot vote non-existing proposal" $
           \_emulated ->
-            uncapsNettest $ voteNonExistingProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ voteNonExistingProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "can vote on multiple proposals" $
           \_emulated ->
-            uncapsNettest $ voteMultiProposals (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ voteMultiProposals (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "cannot vote on outdated proposal" $
           \_emulated ->
-            uncapsNettest $ voteOutdatedProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ voteOutdatedProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       ]
 
 
   , nettestScenarioOnEmulator "cannot vote if the vote amounts exceeds token balance" $
       \_emulated ->
-        uncapsNettest $ insufficientTokenVote (originateLigoDaoWithConfigDesc dynRecUnsafe)
+        uncapsNettest $ insufficientTokenVote (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
 
   , nettestScenario "cannot propose with insufficient tokens" $
-      uncapsNettest $ insufficientTokenProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+      uncapsNettest $ insufficientTokenProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
 
   , testGroup "Permit:"
       [ nettestScenarioOnEmulator "can vote from another user behalf" $
           \_emulated ->
-            uncapsNettest $ voteWithPermit (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ voteWithPermit (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "counter works properly in permits" $
           \_emulated ->
-            uncapsNettest $ voteWithPermitNonce (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ voteWithPermitNonce (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       ]
   , testGroup "Admin:"
       [ nettestScenario "can set voting period"  $
-          uncapsNettest $ setVotingPeriod (originateLigoDaoWithConfigDesc dynRecUnsafe)
+          uncapsNettest $ setVotingPeriod (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
 
       , nettestScenario "can set quorum threshold" $
-          uncapsNettest $ setQuorumThreshold (originateLigoDaoWithConfigDesc dynRecUnsafe)
+          uncapsNettest $ setQuorumThreshold (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
 
       , nettestScenarioOnEmulator "can flush proposals that got accepted" $
           \_emulated ->
-            uncapsNettest $ flushAcceptedProposals (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ flushAcceptedProposals (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "can flush 2 proposals that got accepted" $
           \_emulated ->
-            uncapsNettest $ flushAcceptedProposalsWithAnAmount (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ flushAcceptedProposalsWithAnAmount (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "can flush proposals that got rejected due to not meeting quorum_threshold" $
           \_emulated ->
-            uncapsNettest $ flushRejectProposalQuorum (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ flushRejectProposalQuorum (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "can flush proposals that got rejected due to negative votes" $
           \_emulated ->
-            uncapsNettest $ flushRejectProposalNegativeVotes (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ flushRejectProposalNegativeVotes (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "flush should not affecting ongoing proposals" $
           \_emulated ->
             uncapsNettest $ flushNotAffectOngoingProposals
-            (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "flush with bad cRejectedProposalReturnValue" $
           \_emulated ->
-            uncapsNettest $ flushWithBadConfig (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ flushWithBadConfig (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       -- TODO [#15]: admin burn proposer token and test "flush"
 
       -- TODO [#38]: Improve this when contract size is smaller
       , nettestScenarioOnEmulator "flush and run decision lambda" $
           \_emulated ->
-            uncapsNettest $ flushDecisionLambda (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ flushDecisionLambda (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "can drop proposals" $
           \_emulated ->
-            uncapsNettest $ dropProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ dropProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       ]
 
   , testGroup "Bounded Value"
       [ nettestScenarioOnEmulator "bounded value on proposals" $
           \_emulated ->
-            uncapsNettest $ proposalBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ proposalBoundedValue (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "bounded value on votes" $
           \_emulated ->
-            uncapsNettest $ votesBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ votesBoundedValue (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenario "bounded range on quorum_threshold" $
-          uncapsNettest $ quorumThresholdBound (originateLigoDaoWithConfigDesc dynRecUnsafe)
+          uncapsNettest $ quorumThresholdBound (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       , nettestScenarioOnEmulator "bounded range on voting_period" $
           \_emulated ->
-            uncapsNettest $ votingPeriodBound (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ votingPeriodBound (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       ]
 
   , testGroup "Freeze-Unfreeze"
       [ nettestScenario "can freeze tokens" $
-          uncapsNettest $ freezeTokens (originateLigoDaoWithConfigDesc dynRecUnsafe)
+          uncapsNettest $ freezeTokens (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
 
       , nettestScenarioOnEmulator "cannot unfreeze tokens from the same period" $
           \_emulated ->
-            uncapsNettest $ cannotUnfreezeFromSamePeriod (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ cannotUnfreezeFromSamePeriod (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
 
       , nettestScenarioOnEmulator "can unfreeze tokens from the previous period" $
           \_emulated ->
-            uncapsNettest $ canUnfreezeFromPreviousPeriod (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ canUnfreezeFromPreviousPeriod (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
 
       , nettestScenarioOnEmulator "handle voting period change" $
           \_emulated ->
-            uncapsNettest $ canHandleVotingPeriodChange (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ canHandleVotingPeriodChange (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
 
       , nettestScenarioOnEmulator "handle voting period change" $
           \_emulated ->
-            uncapsNettest $ votingPeriodChange (originateLigoDaoWithConfigDesc dynRecUnsafe)
+            uncapsNettest $ votingPeriodChange (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
       ]
 
  , testGroup "LIGO-specific proposal tests:"

--- a/haskell/test/Test/Ligo/BaseDAO/Token.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Token.hs
@@ -24,7 +24,7 @@ test_BaseDAO_Token :: TestTree
 test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
   [ nettestScenario "can burn tokens from any accounts"
       $ uncapsNettest $ burnScenario
-        $ originateLigoDaoWithBalance dynRecUnsafe defaultConfig
+        $ originateLigoDaoWithBalance dynRecBigMapUnsafe defaultConfig
           (\o1 o2 ->
               [ ((o1, frozenTokenId), 10)
               , ((o2, frozenTokenId), 10)-- for total supply
@@ -32,7 +32,7 @@ test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
           )
   , nettestScenario "can mint tokens to any accounts"
       $ uncapsNettest $ mintScenario
-        $ originateLigoDaoWithBalance dynRecUnsafe defaultConfig
+        $ originateLigoDaoWithBalance dynRecBigMapUnsafe defaultConfig
           (\o1 _ ->
               [ ((o1, frozenTokenId), 0)
               ]

--- a/haskell/test/Test/Ligo/BaseDAO/Token/FA2.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Token/FA2.hs
@@ -57,7 +57,7 @@ test_BaseDAO_FA2 = testGroup "BaseDAO FA2 tests:"
         $ uncapsNettest $ FA2.adminTransferScenario originateLigoDao
     , nettestScenario "transfer frozen tokens"
         $ uncapsNettest $ FA2.adminTransferFrozenScenario
-        $ originateLigoDaoWithBalance Ligo.dynRecUnsafe Ligo.defaultConfig
+        $ originateLigoDaoWithBalance Ligo.dynRecBigMapUnsafe Ligo.defaultConfig
             (\owner1 owner2 ->
                 [ ((owner1, Ligo.frozenTokenId), 100)
                 , ((owner2, Ligo.frozenTokenId), 100)

--- a/haskell/test/Test/Ligo/RegistryDAO.hs
+++ b/haskell/test/Test/Ligo/RegistryDAO.hs
@@ -456,13 +456,6 @@ test_RegistryDAO =
       setExtra @Natural [mt|max_xtz_amount|] 5 $
       setExtra @Natural [mt|max_proposal_size|] 100 (initialStorage admin wallets)
 
-    setExtra :: forall a. NicePackedValue a => MText -> a -> FullStorage -> FullStorage
-    setExtra key v (s@FullStorage {..}) = let
-     oldExtra = unDynamic $ sExtra fsStorage
-     newExtra = Map.insert key (lPackValueRaw v) oldExtra
-     newStorage = fsStorage { sExtra = DynamicRec newExtra }
-     in s { fsStorage = newStorage }
-
 
 expectFailProposalCheck
   :: (MonadNettest caps base m, ToAddress addr)

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -209,7 +209,7 @@ originateTreasuryDaoWithBalance
  => (Address -> Address -> [(LedgerKey, LedgerValue)]) -> OriginateFn m
 originateTreasuryDaoWithBalance bal =
   let fs = fromVal ($(fetchValue @FullStorage "haskell/test/treasuryDAO_storage.tz" "TREASURY_STORAGE_PATH"))
-      testExtra = (sExtra $ fsStorage fs)
+      FullStorage{..} = fs
         & setExtra @Natural [mt|frozen_scale_value|] 1
         & setExtra @Natural [mt|frozen_extra_value|] 0
         & setExtra @Natural [mt|slash_scale_value|] 1
@@ -218,8 +218,4 @@ originateTreasuryDaoWithBalance bal =
         & setExtra @Natural [mt|min_xtz_amount|] 2
         & setExtra @Natural [mt|max_xtz_amount|] 5
 
-  in originateLigoDaoWithBalance testExtra (fsConfig fs) bal
-  where
-    setExtra :: forall a n. NicePackedValue a => MText -> a -> DynamicRec n -> DynamicRec n
-    setExtra key v extra =
-      DynamicRec $ Map.insert key (lPackValueRaw v) (unDynamic extra)
+  in originateLigoDaoWithBalance (sExtra fsStorage) fsConfig bal

--- a/src/common/types.mligo
+++ b/src/common/types.mligo
@@ -25,4 +25,19 @@ type transfer_type =
   | Xtz_transfer_type of xtz_transfer
   | Token_transfer_type of token_transfer
 
+
+// -- Unpack Helpers (fail if the unpacked result is none) -- //
+
+let unpack_transfer_type_list (key_name, packed_b: string * bytes) : transfer_type list =
+  match ((Bytes.unpack packed_b) : (transfer_type list) option) with
+  | Some (v) -> v
+  | None -> ([%Michelson ({| { FAILWITH } |} : (string * string) -> transfer_type list)]
+              ("UNPACKING_FAILED", key_name) : transfer_type list)
+
+(* Non-failed unpack functions. Accepts an optional bytes, try to unpack if the bytes are not `None`. *)
+let unpack_transfer_type_list_safe (bytes_opt: bytes option) : (transfer_type list) option =
+  match bytes_opt with
+  | None -> (None : (transfer_type list) option)
+  | Some b -> (Bytes.unpack b : (transfer_type list) option)
+
 #endif

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -26,7 +26,7 @@ let default_storage (admin , governance_token, now_val, metadata : address * gov
     metadata = metadata;
     voting_period = 11n;
     quorum_threshold = {numerator = 1n; denominator = 10n}; // 10%
-    extra = (Map.empty : (string, bytes) map);
+    extra = (Big_map.empty : (string, bytes) big_map);
     proposals = (Big_map.empty : (proposal_key, proposal) big_map);
     proposal_key_list_sort_by_date = (Set.empty : (timestamp * proposal_key) set);
     permits_counter = 0n;

--- a/src/helper/unpack.mligo
+++ b/src/helper/unpack.mligo
@@ -6,25 +6,44 @@
 
 #include "../types.mligo"
 
-// ------------------------------
-// Unpack Helpers
-// ------------------------------
+(* Required version of `Map.find_opt`. Fail immediately if the required key does not exist  *)
+let find_map (key_name, ce : string * ((string, bytes) map)) : (string * bytes) =
+  match Map.find_opt key_name ce with
+  | Some (packed_b) -> (key_name, packed_b)
+  | None -> ([%Michelson ({| { FAILWITH } |} : (string * string) -> (string * bytes))]
+              ("MISSING_VALUE", key_name) : (string * bytes))
 
-let unpack_key (key_name, p : string * ((string, bytes) map)) : bytes =
-    match Map.find_opt key_name p with
-      Some (b) -> b
-    | None -> (failwith "UNPACK_KEY_NOT_FOUND" : bytes)
+(* Required version of `Big_map.find_opt`. Fail immediately if the required key does not exist  *)
+let find_big_map (key_name, ce : string * ((string, bytes) big_map)) : (string * bytes) =
+  match Big_map.find_opt key_name ce with
+  | Some (packed_b) -> (key_name, packed_b)
+  | None -> ([%Michelson ({| { FAILWITH } |} : (string * string) -> (string * bytes))]
+              ("MISSING_VALUE", key_name) : (string * bytes))
 
-let unpack_nat (key_name, p : string * ((string, bytes) map)) : nat =
-  let b = unpack_key (key_name, p)
-  in match ((Bytes.unpack b) : (nat option)) with
-    Some (v) -> v
-  | None -> (failwith "UNPACKING_NOT_NAT_TYPE" : nat)
 
-let unpack_tez (key_name, p : string * ((string, bytes) map)) : tez =
-  let b = unpack_key (key_name, p)
-  in match ((Bytes.unpack b) : tez option) with
-    Some (v) -> v
-  | None -> (failwith "UNPACKING_NOT_TEZ_TYPE" : tez)
+(*
+ * Unpack Helpers
+ *
+ * All the `unpack_<type>` functions are required version of `Bytes.unpack`.
+ * They each fail immediately if the unpacked result is `None`.
+ *)
+
+let unpack_tez(key_name, packed_b: string * bytes) : tez =
+  match ((Bytes.unpack packed_b) : (tez option)) with
+  | Some (v) -> v
+  | None -> ([%Michelson ({| { FAILWITH } |} : (string * string) -> tez)]
+              ("UNPACKING_FAILED", key_name) : tez)
+
+let unpack_nat(key_name, packed_b: string * bytes) : nat =
+  match ((Bytes.unpack packed_b) : (nat option)) with
+  | Some (v) -> v
+  | None -> ([%Michelson ({| { FAILWITH } |} : (string * string) -> nat)]
+              ("UNPACKING_FAILED", key_name) : nat)
+
+let unpack_nat_opt(key_name, packed_b: string * bytes) : nat option =
+  match ((Bytes.unpack packed_b) : (nat option) option) with
+  | Some (v) -> v
+  | None -> ([%Michelson ({| { FAILWITH } |} : (string * string) -> nat option)]
+              ("UNPACKING_FAILED", key_name) : nat option)
 
 #endif

--- a/src/registryDAO/types.mligo
+++ b/src/registryDAO/types.mligo
@@ -52,3 +52,31 @@ type lookup_registry_param =
   }
 
 type lookup_registry_view = (registry_key * (registry_value option)) contract
+
+
+
+// -- Unpack Helpers (fail if the unpacked result is none) -- //
+
+let unpack_registry (key_name, packed_b: string * bytes) : registry =
+  match ((Bytes.unpack packed_b) : (registry option)) with
+  | Some (v) -> v
+  | None -> ([%Michelson ({| { FAILWITH } |} : (string * string) -> registry)]
+              ("UNPACKING_FAILED", key_name) : registry)
+
+let unpack_registry_affected (key_name, packed_b: string * bytes) : registry_affected =
+  match ((Bytes.unpack packed_b) : (registry_affected option)) with
+  |  Some (v) -> v
+  | None -> ([%Michelson ({| { FAILWITH } |} : (string * string) -> registry_affected)]
+              ("UNPACKING_FAILED", key_name) : registry_affected)
+
+let unpack_proposal_receivers (key_name, packed_b: string * bytes) : proposal_receivers =
+  match ((Bytes.unpack packed_b) : (proposal_receivers option)) with
+  | Some (v) -> v
+  | None -> ([%Michelson ({| { FAILWITH } |} : (string * string) -> proposal_receivers)]
+              ("UNPACKING_FAILED", key_name) : proposal_receivers)
+
+let unpack_lookup_registry_param (key_name, packed_b: string * bytes) : lookup_registry_param =
+  match ((Bytes.unpack packed_b) : (lookup_registry_param option)) with
+  | Some (v) -> v
+  | None -> ([%Michelson ({| { FAILWITH } |} : (string * string) -> lookup_registry_param)]
+              ("UNPACKING_FAILED", key_name) : lookup_registry_param)

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -140,7 +140,7 @@ type permit =
   }
 
 type metadata_map = (string, bytes) big_map
-type contract_extra = (string, bytes) map
+type contract_extra = (string, bytes) big_map
 
 // Some information to track changes made to the voting period so that we can
 // calculate the current voting period even after many changes to the period length


### PR DESCRIPTION
## Description

Problem: The `extra` field of the storage is a `contract_extra`,
which is currently defined as a `(string, bytes) map`.
This however poses a limitation, as `map` is strict and so the cost
in case of many key is too high.

Solution: Make `contract_extra` as `big_map` instead of map, update
various unpack related functions.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #188 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
