### PR TITLE
[#170] Update build instructions to include governance_token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 	#
 
 $(OUT)/trivialDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
-$(OUT)/trivialDAO_storage.tz : governance_token_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
+$(OUT)/trivialDAO_storage.tz : governance_token_address = KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5
 $(OUT)/trivialDAO_storage.tz : governance_token_id = 0n
 $(OUT)/trivialDAO_storage.tz : now_val = Tezos.now
 $(OUT)/trivialDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
@@ -102,7 +102,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
 	#
 
 $(OUT)/registryDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
-$(OUT)/registryDAO_storage.tz : governance_token_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
+$(OUT)/registryDAO_storage.tz : governance_token_address = KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5
 $(OUT)/registryDAO_storage.tz : governance_token_id = 0n
 $(OUT)/registryDAO_storage.tz : frozen_scale_value = 1n
 $(OUT)/registryDAO_storage.tz : frozen_extra_value = 0n
@@ -154,7 +154,7 @@ $(OUT)/registryDAO_storage.tz: src/**
 	#
 
 $(OUT)/treasuryDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
-$(OUT)/treasuryDAO_storage.tz : governance_token_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
+$(OUT)/treasuryDAO_storage.tz : governance_token_address = KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5
 $(OUT)/treasuryDAO_storage.tz : governance_token_id = 0n
 $(OUT)/treasuryDAO_storage.tz : frozen_scale_value = 0n
 $(OUT)/treasuryDAO_storage.tz : frozen_extra_value = 0n

--- a/docs/building.md
+++ b/docs/building.md
@@ -45,7 +45,8 @@ This storage is the one based on the [default storage values](../src/defaults.ml
 ```sh
 make out/trivialDAO_storage.tz \
   admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" \
-  token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" \
+  governance_token_address="KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5" \
+  governance_token_id=0n \
   now_val=Tezos.now \
   metadata_map=(Big_map.empty : metadata_map)
   fixed_proposal_fee_in_token=0n \
@@ -68,7 +69,8 @@ compiled with `make`, as usual:
 ```sh
 make out/registryDAO_storage.tz \
   admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" \
-  token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" \
+  governance_token_address="KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5" \
+  governance_token_id=0n \
   max_proposal_size=100n \
   frozen_scale_value=1n \
   frozen_extra_value=0n \
@@ -94,7 +96,8 @@ can be compiled once again with `make`:
 ```sh
 make out/treasuryDAO_storage.tz \
   admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" \
-  token_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" \
+  governance_token_address="KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5" \
+  governance_token_id=0n \
   max_proposal_size=12n \
   frozen_scale_value=1n \
   frozen_extra_value=0n \

--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -95,6 +95,4 @@ metadataConfigParser :: Opt.Parser MetadataConfig
 metadataConfigParser = do
   mcFrozenTokenMetadata <-
     tokenMetadataParser "frozen" "frozen_token" "Frozen Token" 8
-  mcUnfrozenTokenMetadata <-
-    tokenMetadataParser "unfrozen" "unfrozen_token" "Unfrozen Token" 8
   return MetadataConfig{..}

--- a/haskell/src/Ligo/BaseDAO/TZIP16Metadata.hs
+++ b/haskell/src/Ligo/BaseDAO/TZIP16Metadata.hs
@@ -34,7 +34,6 @@ import qualified Paths_baseDAO_ligo_meta as Paths
 -- | Piece of metadata defined by user.
 data MetadataConfig = MetadataConfig
   { mcFrozenTokenMetadata :: FA2.TokenMetadata
-  , mcUnfrozenTokenMetadata :: FA2.TokenMetadata
   }
 
 -- | All the information for instantiating metadata.
@@ -54,8 +53,6 @@ defaultMetadataConfig =
   MetadataConfig
     { mcFrozenTokenMetadata =
         FA2.mkTokenMetadata "frozen_token" "Frozen Token" "8"
-    , mcUnfrozenTokenMetadata =
-        FA2.mkTokenMetadata "unfrozen_token" "Unfrozen Token" "8"
     }
 
 

--- a/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/Types.hs
@@ -756,18 +756,6 @@ instance CustomErrorHasDoc "fAIL_PROPOSAL_CHECK" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to propose a proposal that does not pass `proposalCheck`"
 
-type instance ErrorArg "pROPOSAL_INSUFFICIENT_BALANCE" = NoErrorArg
-
-instance CustomErrorHasDoc "pROPOSAL_INSUFFICIENT_BALANCE" where
-  customErrClass = ErrClassActionException
-  customErrDocMdCause = "Trying to propose a proposal without having enough unfrozen token"
-
-type instance ErrorArg "vOTING_INSUFFICIENT_BALANCE" = NoErrorArg
-
-instance CustomErrorHasDoc "vOTING_INSUFFICIENT_BALANCE" where
-  customErrClass = ErrClassActionException
-  customErrDocMdCause = "Trying to vote on a proposal without having enough unfrozen token"
-
 type instance ErrorArg "pROPOSAL_NOT_EXIST" = NoErrorArg
 
 instance CustomErrorHasDoc "pROPOSAL_NOT_EXIST" where


### PR DESCRIPTION
## Description

In the PR that implements BYO extension, we added Makefile
arguments `governance_token_address` and `governance_token_id`. But the
build instructions was not updated to reflect this. This PR updates
 `docs/building.md` file to include the new arguments in
`make` command samples. In addition the default token address was
changed to an address of the form `KT*` instead of `tz*`, to better
reflect the fact that it is an address of a smart contract. 

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #170

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-olicy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
