### PR TITLE
[#192] Change the `custom_entrypoints` type to `big_map`

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -78,7 +78,7 @@ type transfer_proposal =
 ```
 and an empty `contract_extra`.
 
-Lastly, there is one more `(string, bytes) map` type synonym: `custom_entrypoints`,
+Lastly, there is one more `(string, bytes) big_map` type synonym: `custom_entrypoints`,
 used to execute arbitrary logic on the contract, see [its section](#custom-entrypoints)
 for more information on its content and usage.
 

--- a/haskell/test/Test/Ligo/BaseDAO/Common.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Common.hs
@@ -235,7 +235,7 @@ originateLigoDaoWithConfigDesc extra config =
 
 originateLigoDao :: MonadNettest caps base m => OriginateFn m
 originateLigoDao =
-  originateLigoDaoWithConfig dynRecBigMapUnsafe defaultConfig
+  originateLigoDaoWithConfig dynRecUnsafe defaultConfig
 
 createSampleProposal
   :: (MonadNettest caps base m, HasCallStack)

--- a/haskell/test/Test/Ligo/BaseDAO/Integrational/Management.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Integrational/Management.hs
@@ -42,7 +42,7 @@ checkVotingPeriodTracking  = do
       ! #admin admin
       ! #votingPeriod 10
       ! #quorumThreshold (QuorumThreshold 10 100)
-      ! #extra dynRecBigMapUnsafe
+      ! #extra dynRecUnsafe
       ! #metadata mempty
       ! #now now
       ! #tokenAddress genesisAddress

--- a/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
@@ -48,7 +48,7 @@ checkFreezeHistoryTracking  = do
       ! #admin admin
       ! #votingPeriod 10
       ! #quorumThreshold (QuorumThreshold 10 100)
-      ! #extra dynRecBigMapUnsafe
+      ! #extra dynRecUnsafe
       ! #metadata mempty
       ! #now now
       ! #tokenAddress (unTAddress tokenContract)

--- a/haskell/test/Test/Ligo/BaseDAO/Management.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Management.hs
@@ -114,7 +114,7 @@ test_BaseDAO_Management =
 
     initialStorage now admin = mkFullStorage
       ! #admin admin
-      ! #extra dynRecBigMapUnsafe
+      ! #extra dynRecUnsafe
       ! #metadata mempty
       ! #now now
       ! #tokenAddress genesisAddress

--- a/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
@@ -33,7 +33,7 @@ offChainViewStorage :: Storage
 offChainViewStorage =
   (mkStorage
   ! #admin addr
-  ! #extra dynRecBigMapUnsafe
+  ! #extra dynRecUnsafe
   ! #metadata mempty
   ! #now (timestampFromSeconds 0)
   ! #tokenAddress genesisAddress

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -42,119 +42,119 @@ test_BaseDAO_Proposal =
   [ testGroup "Proposal creator:"
       [ nettestScenarioOnEmulator "BaseDAO - can propose a valid proposal" $
           \_emulated ->
-            uncapsNettest $ validProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ validProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "cannot propose an invalid proposal (rejected)" $
           \_emulated ->
-            uncapsNettest $ rejectProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ rejectProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "cannot propose a non-unique proposal" $
           \_emulated ->
-            uncapsNettest $ nonUniqueProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ nonUniqueProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "cannot propose in a non-proposal period" $
           \_emulated ->
-            uncapsNettest $ nonProposalPeriodProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ nonProposalPeriodProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
       ]
 
   , testGroup "Voter:"
       [ nettestScenarioOnEmulator "can vote on a valid proposal" $
           \_emulated ->
-            uncapsNettest $ voteValidProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ voteValidProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "cannot vote non-existing proposal" $
           \_emulated ->
-            uncapsNettest $ voteNonExistingProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ voteNonExistingProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "can vote on multiple proposals" $
           \_emulated ->
-            uncapsNettest $ voteMultiProposals (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ voteMultiProposals (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "cannot vote on outdated proposal" $
           \_emulated ->
-            uncapsNettest $ voteOutdatedProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ voteOutdatedProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
       ]
 
 
   , nettestScenarioOnEmulator "cannot vote if the vote amounts exceeds token balance" $
       \_emulated ->
-        uncapsNettest $ insufficientTokenVote (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+        uncapsNettest $ insufficientTokenVote (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
   , nettestScenario "cannot propose with insufficient tokens" $
-      uncapsNettest $ insufficientTokenProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+      uncapsNettest $ insufficientTokenProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
   , testGroup "Permit:"
       [ nettestScenarioOnEmulator "can vote from another user behalf" $
           \_emulated ->
-            uncapsNettest $ voteWithPermit (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ voteWithPermit (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "counter works properly in permits" $
           \_emulated ->
-            uncapsNettest $ voteWithPermitNonce (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ voteWithPermitNonce (originateLigoDaoWithConfigDesc dynRecUnsafe)
       ]
   , testGroup "Admin:"
       [ nettestScenario "can set voting period"  $
-          uncapsNettest $ setVotingPeriod (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+          uncapsNettest $ setVotingPeriod (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
       , nettestScenario "can set quorum threshold" $
-          uncapsNettest $ setQuorumThreshold (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+          uncapsNettest $ setQuorumThreshold (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
       , nettestScenarioOnEmulator "can flush proposals that got accepted" $
           \_emulated ->
-            uncapsNettest $ flushAcceptedProposals (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ flushAcceptedProposals (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "can flush 2 proposals that got accepted" $
           \_emulated ->
-            uncapsNettest $ flushAcceptedProposalsWithAnAmount (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ flushAcceptedProposalsWithAnAmount (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "can flush proposals that got rejected due to not meeting quorum_threshold" $
           \_emulated ->
-            uncapsNettest $ flushRejectProposalQuorum (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ flushRejectProposalQuorum (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "can flush proposals that got rejected due to negative votes" $
           \_emulated ->
-            uncapsNettest $ flushRejectProposalNegativeVotes (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ flushRejectProposalNegativeVotes (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "flush should not affecting ongoing proposals" $
           \_emulated ->
             uncapsNettest $ flushNotAffectOngoingProposals
-            (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "flush with bad cRejectedProposalReturnValue" $
           \_emulated ->
-            uncapsNettest $ flushWithBadConfig (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ flushWithBadConfig (originateLigoDaoWithConfigDesc dynRecUnsafe)
       -- TODO [#15]: admin burn proposer token and test "flush"
 
       -- TODO [#38]: Improve this when contract size is smaller
       , nettestScenarioOnEmulator "flush and run decision lambda" $
           \_emulated ->
-            uncapsNettest $ flushDecisionLambda (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ flushDecisionLambda (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "can drop proposals" $
           \_emulated ->
-            uncapsNettest $ dropProposal (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ dropProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
       ]
 
   , testGroup "Bounded Value"
       [ nettestScenarioOnEmulator "bounded value on proposals" $
           \_emulated ->
-            uncapsNettest $ proposalBoundedValue (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ proposalBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "bounded value on votes" $
           \_emulated ->
-            uncapsNettest $ votesBoundedValue (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ votesBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenario "bounded range on quorum_threshold" $
-          uncapsNettest $ quorumThresholdBound (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+          uncapsNettest $ quorumThresholdBound (originateLigoDaoWithConfigDesc dynRecUnsafe)
       , nettestScenarioOnEmulator "bounded range on voting_period" $
           \_emulated ->
-            uncapsNettest $ votingPeriodBound (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ votingPeriodBound (originateLigoDaoWithConfigDesc dynRecUnsafe)
       ]
 
   , testGroup "Freeze-Unfreeze"
       [ nettestScenario "can freeze tokens" $
-          uncapsNettest $ freezeTokens (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+          uncapsNettest $ freezeTokens (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
       , nettestScenarioOnEmulator "cannot unfreeze tokens from the same period" $
           \_emulated ->
-            uncapsNettest $ cannotUnfreezeFromSamePeriod (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ cannotUnfreezeFromSamePeriod (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
       , nettestScenarioOnEmulator "can unfreeze tokens from the previous period" $
           \_emulated ->
-            uncapsNettest $ canUnfreezeFromPreviousPeriod (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ canUnfreezeFromPreviousPeriod (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
       , nettestScenarioOnEmulator "handle voting period change" $
           \_emulated ->
-            uncapsNettest $ canHandleVotingPeriodChange (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ canHandleVotingPeriodChange (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
       , nettestScenarioOnEmulator "handle voting period change" $
           \_emulated ->
-            uncapsNettest $ votingPeriodChange (originateLigoDaoWithConfigDesc dynRecBigMapUnsafe)
+            uncapsNettest $ votingPeriodChange (originateLigoDaoWithConfigDesc dynRecUnsafe)
       ]
 
  , testGroup "LIGO-specific proposal tests:"

--- a/haskell/test/Test/Ligo/BaseDAO/Token.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Token.hs
@@ -24,7 +24,7 @@ test_BaseDAO_Token :: TestTree
 test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
   [ nettestScenario "can burn tokens from any accounts"
       $ uncapsNettest $ burnScenario
-        $ originateLigoDaoWithBalance dynRecBigMapUnsafe defaultConfig
+        $ originateLigoDaoWithBalance dynRecUnsafe defaultConfig
           (\o1 o2 ->
               [ ((o1, frozenTokenId), 10)
               , ((o2, frozenTokenId), 10)-- for total supply
@@ -32,14 +32,14 @@ test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
           )
   , nettestScenario "can mint tokens to any accounts"
       $ uncapsNettest $ mintScenario
-        $ originateLigoDaoWithBalance dynRecBigMapUnsafe defaultConfig
+        $ originateLigoDaoWithBalance dynRecUnsafe defaultConfig
           (\o1 _ ->
               [ ((o1, frozenTokenId), 0)
               ]
           )
   , nettestScenario "cannot mint unknown tokens"
       $ uncapsNettest $ unknownMintScenario
-        $ originateLigoDaoWithBalance dynRecBigMapUnsafe defaultConfig
+        $ originateLigoDaoWithBalance dynRecUnsafe defaultConfig
           (\o1 _ ->
               [ ((o1, frozenTokenId), 0)
               ]

--- a/haskell/test/Test/Ligo/BaseDAO/Token/Common.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Token/Common.hs
@@ -33,7 +33,7 @@ unknownTokens = FA2.TokenId 2
 
 originateWithCustomToken :: MonadNettest caps base m => OriginateFn m
 originateWithCustomToken =
-  originateLigoDaoWithBalance dynRecBigMapUnsafe defaultConfig
+  originateLigoDaoWithBalance dynRecUnsafe defaultConfig
       (\owner1 owner2 ->
           [ ((owner1, frozenTokens), 100)
           , ((owner2, frozenTokens), 100)

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -16,7 +16,7 @@ let default_config (data : initial_config_data) : config = {
   max_voting_period = data.max_period;
   min_voting_period = data.min_period;
 
-  custom_entrypoints = (Map.empty : custom_entrypoints);
+  custom_entrypoints = (Big_map.empty : custom_entrypoints);
 }
 
 let bound_vp (vp, min_vp, max_vp : voting_period * voting_period * voting_period)

--- a/src/registryDAO.mligo
+++ b/src/registryDAO.mligo
@@ -234,7 +234,7 @@ let default_registry_DAO_full_storage (data : initial_registryDAO_storage) : ful
     proposal_check = registry_DAO_proposal_check;
     rejected_proposal_return_value = registry_DAO_rejected_proposal_return_value;
     decision_lambda = registry_DAO_decision_lambda;
-    custom_entrypoints = Map.literal
+    custom_entrypoints = Big_map.literal
       [ "lookup_registry", Bytes.pack lookup_registry
       ; "receive_xtz", Bytes.pack receive_xtz_entrypoint
       ];

--- a/src/treasuryDAO.mligo
+++ b/src/treasuryDAO.mligo
@@ -108,6 +108,6 @@ let default_treasury_DAO_full_storage (data : initial_treasuryDAO_storage) : ful
     proposal_check = treasury_DAO_proposal_check;
     rejected_proposal_return_value = treasury_DAO_rejected_proposal_return_value;
     decision_lambda = treasury_DAO_decision_lambda;
-    custom_entrypoints = Map.literal [("receive_xtz", Bytes.pack (receive_xtz_entrypoint))];
+    custom_entrypoints = Big_map.literal [("receive_xtz", Bytes.pack (receive_xtz_entrypoint))];
     }
   in (new_storage, new_config)

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -272,7 +272,7 @@ type allow_xtz_params =
 type parameter =
   (allow_xtz_params, "", forbid_xtz_params, "") michelson_or
 
-type custom_entrypoints = (string, bytes) map
+type custom_entrypoints = (string, bytes) big_map
 
 type decision_lambda_input =
   { proposal : proposal


### PR DESCRIPTION
## Description

Problem: The `custom_entrypoints` is currently defined as a `(string, bytes) map`.
This however poses a limitation, as `map` is strict and so the cost
in case of many key is too high.

Solution: Make `custom_entrypoints` as `big_map` instead of map, make
`DynamicRec` using `BigMap` instead, remove `DynamicRecBigMap`.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #192 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
