### PR TITLE
[#92] Add `governance_token` off-chain view

### DIFF
--- a/haskell/src/Ligo/BaseDAO/TZIP16Metadata.hs
+++ b/haskell/src/Ligo/BaseDAO/TZIP16Metadata.hs
@@ -16,6 +16,7 @@ module Ligo.BaseDAO.TZIP16Metadata
   , tokenMetadataView
   , getTotalSupplyView
   , permitsCounterView
+  , governanceTokenView
   ) where
 
 import qualified Universum as U
@@ -86,6 +87,7 @@ baseDAOViews = U.sequence
   , isOperatorView
   , tokenMetadataView
   , getTotalSupplyView
+  , governanceTokenView
 
   , permitsCounterView
   ]
@@ -199,6 +201,20 @@ getTotalSupplyView MetadataSettings{ msConfig = MetadataConfig{} } = View
             unsafeCompileViewCode $ WithParam @FA2.TokenId $ do
               stGet #sTotalSupply
               ifSome nop $ failCustom_ #fA2_TOKEN_UNDEFINED
+      ]
+  }
+
+governanceTokenView :: DaoView
+governanceTokenView MetadataSettings{} = View
+  { vName = "governance_token"
+  , vDescription = Just
+      "Return the address and token_id of the associated FA2 contract."
+  , vPure = Just True
+  , vImplementations =
+      [ VIMichelsonStorageView $
+          mkMichelsonStorageView @Storage Nothing [] $
+            unsafeCompileViewCode $ WithoutParam $ do
+              stToField #sGovernanceToken
       ]
   }
 

--- a/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
@@ -111,4 +111,9 @@ mkFA2Tests storage mc = testGroup "FA2 off-chain views"
         checkTotalSupply storage frozenTokenId
           @?= Right 200
     ]
+  , testGroup "governance_token" $
+    [ testCase "Get the address and token_id of the associated FA2 contract" $
+        runView @GovernanceToken (governanceTokenView mc) storage NoParam
+        @?= (Right $ GovernanceToken genesisAddress FA2.theTokenId)
+    ]
   ]


### PR DESCRIPTION
## Description

Problem: We used to have a `token_address` entrypoint, but we removed
it in #85 because it's not very useful. We can instead make it an
off-chain view (according to TZIP-16).

Solution: Add off-chain view `token_address`, rename it to
`governance_token` view instead, add tests to cover this
view.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #92 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
