### PR TITLE
Add escaping to metadata_map and ledger Makefile option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ ORIGINATE_STEPS ?= $(LARGE_ORIGINATOR) steps
 
 # Utility function to escape single quotes
 escape_quote = $(subst ','\'',$(1))
+# Utility function to escape double quotes
+escape_double_quote = $(subst $\",$\\",$(1))
 
 # Where to put build files
 OUT ?= out
@@ -85,7 +87,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
             ; token_id = $(governance_token_id) \
             } \
           ; now_val = $(now_val) \
-          ; metadata_map = $(metadata_map) \
+          ; metadata_map = $(call escape_double_quote,$(metadata_map)) \
           ; ledger_lst = $(ledger) \
           ; quorum_threshold = $(quorum_threshold) \
           ; voting_period = $(voting_period) \
@@ -130,7 +132,7 @@ $(OUT)/registryDAO_storage.tz: src/**
               ; token_id = $(governance_token_id) \
               } \
             ; now_val = $(now_val) \
-            ; metadata_map = $(metadata_map) \
+            ; metadata_map = $(call escape_double_quote,$(metadata_map)) \
             ; ledger_lst = $(ledger) \
             ; quorum_threshold = $(quorum_threshold) \
             ; voting_period = $(voting_period) \
@@ -182,7 +184,7 @@ $(OUT)/treasuryDAO_storage.tz: src/**
               ; token_id =  $(governance_token_id) \
               } \
             ; now_val = $(now_val) \
-            ; metadata_map = $(metadata_map) \
+            ; metadata_map = $(call escape_double_quote,$(metadata_map)) \
             ; ledger_lst = $(ledger) \
             ; quorum_threshold = $(quorum_threshold) \
             ; voting_period = $(voting_period) \

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
             } \
           ; now_val = $(now_val) \
           ; metadata_map = $(call escape_double_quote,$(metadata_map)) \
-          ; ledger_lst = $(ledger) \
+          ; ledger_lst = $(call escape_double_quote,$(ledger)) \
           ; quorum_threshold = $(quorum_threshold) \
           ; voting_period = $(voting_period) \
           } \
@@ -133,7 +133,7 @@ $(OUT)/registryDAO_storage.tz: src/**
               } \
             ; now_val = $(now_val) \
             ; metadata_map = $(call escape_double_quote,$(metadata_map)) \
-            ; ledger_lst = $(ledger) \
+            ; ledger_lst = $(call escape_double_quote,$(ledger)) \
             ; quorum_threshold = $(quorum_threshold) \
             ; voting_period = $(voting_period) \
             } \
@@ -185,7 +185,7 @@ $(OUT)/treasuryDAO_storage.tz: src/**
               } \
             ; now_val = $(now_val) \
             ; metadata_map = $(call escape_double_quote,$(metadata_map)) \
-            ; ledger_lst = $(ledger) \
+            ; ledger_lst = $(call escape_double_quote,$(ledger)) \
             ; quorum_threshold = $(quorum_threshold) \
             ; voting_period = $(voting_period) \
             } \


### PR DESCRIPTION
## Description

We recently changed the `Makefile` storage targets to contain the arguments inside double quotes instead of single ones.

This however causes previously valid calls containing double quotes in the `metadata_map` and `ledger` options to fail for lack of escaping.

Solution: add automatic escaping to the `metadata_map` and `ledger` options.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
