### PR TITLE
[#198] Add more assets to the auto prerelease step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,8 +45,14 @@ steps:
     commands:
     - nix-build ci.nix -A build-ligo -o ./ligo-out/
     - nix run -f ci.nix morley -c morley optimize --contract ./ligo-out/baseDAO.tz --output baseDAO.tz
+    - cp ./ligo-out/trivialDAO_storage.tz trivialDAO_storage.tz
+    - cp ./ligo-out/registryDAO_storage.tz registryDAO_storage.tz
+    - cp ./ligo-out/treasuryDAO_storage.tz treasuryDAO_storage.tz
     artifact_paths:
       - baseDAO.tz
+      - trivialDAO_storage.tz
+      - registryDAO_storage.tz
+      - treasuryDAO_storage.tz
 
   - label: build-haskell
     key: build-haskell
@@ -83,6 +89,13 @@ steps:
     commands:
     - nix-build ci.nix -A packages.baseDAO-ligo-meta.tests.baseDAO-test
     - ./result/bin/baseDAO-test --nettest-no-run-network
+
+    # Get `known_metadata.json` artifact
+    - nix run -f ci.nix
+          packages.baseDAO-ligo-meta.exes.baseDAO-ligo-meta
+        -c baseDAO-ligo-meta print-metadata > known_metadata.json
+    artifact_paths:
+      - known_metadata.json
 
   # TODO #124 uncomment:
   # - label: ligo-test-local-chain-008
@@ -202,10 +215,14 @@ steps:
 
   - label: create auto prerelease
     if: build.branch == "master" && build.source != "schedule"
-    depends_on: build-ligo
+    depends_on: ligo-test
     commands:
       - mkdir assets
       - buildkite-agent artifact download baseDAO.tz assets --step "build-ligo"
+      - buildkite-agent artifact download trivialDAO_storage.tz assets --step "build-ligo"
+      - buildkite-agent artifact download treasuryDAO_storage.tz assets --step "build-ligo"
+      - buildkite-agent artifact download registryDAO_storage.tz assets --step "build-ligo"
+      - buildkite-agent artifact download known_metadata.json assets --step "ligo-test"
       - nix run -f ci.nix pkgs.gitAndTools.gh -c gh release delete auto-release --yes || true
       - nix run -f ci.nix pkgs.git -c git fetch && git tag -f auto-release && git push --force --tags
       - nix run -f ci.nix pkgs.gitAndTools.gh -c gh release create --prerelease auto-release --title auto-release --notes ""


### PR DESCRIPTION
## Description

Problem: In CI we have an auto prerelease step that creates a
prerelease based on master. Currently this only includes the
`baseDAO.tz` contract itself.

However, we can modify it to:
- compile all storage(s) with the default values
- generate the known metadata (for the ligo version only)

Solution: Add all trivialDAO, treasuryDAO, and registryDAO storages,
and add `known_metadata.json` to the pre-release step as assets.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #198

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
