### PR TITLE
[#208] Remove the `mint` entrypoint 

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -277,7 +277,6 @@ Full list:
 * [`transfer`](#transfer)
 * [`balance_of`](#balance_of)
 * [`update_operators`](#update_operators)
-* [`mint`](#mint)
 * [`burn`](#burn)
 * [`transfer_contract_tokens`](#transfer_contract_tokens)
 * [`transfer_ownership`](#transfer_ownership)
@@ -466,34 +465,6 @@ Parameter (in Michelson)
 ## Custom (non-FA2) token functions
 
 Functions related to token transfers, but not present in FA2.
-
-### **mint**
-
-```ocaml
-type mint_param =
-  [@layout:comb]
-  { to_ : address
-  ; token_id : token_id
-  ; amount : nat
-  }
-
-Mint of mint_param
-```
-
-Parameter (in Michelson):
-```
-(pair %mint
-  (address %to_)
-  (pair
-    (nat %token_id)
-    (nat %amount)
-  )
-)
-```
-
-- Produces the given amounts of tokens to the wallet associated with the given address.
-- Fails with `NOT_ADMIN` if the sender is not the administrator.
-- Fails with `FA2_TOKEN_UNDEFINED` if trying to mint an unsupported token.
 
 ### **burn**
 

--- a/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/Types.hs
@@ -32,7 +32,6 @@ module Ligo.BaseDAO.Types
 
     -- * Non FA2
   , BurnParam (..)
-  , MintParam (..)
   , TransferContractTokensParam (..)
 
     -- * Permissions
@@ -229,21 +228,6 @@ instance TypeHasDoc BurnParam where
 
 instance HasAnnotation BurnParam where
   annOptions = baseDaoAnnOptions
-
-data MintParam = MintParam
-  { mTo_     :: Address
-  , mTokenId :: FA2.TokenId
-  , mAmount  :: Natural
-  }
-  deriving stock (Generic, Show)
-  deriving anyclass IsoValue
-
-instance TypeHasDoc MintParam where
-  typeDocMdDescription = "Describes whose account, which token id and in what amount to mint"
-
-instance HasAnnotation MintParam where
-  annOptions = baseDaoAnnOptions
-
 data TransferContractTokensParam = TransferContractTokensParam
   { tcContractAddress :: Address
   , tcParams          :: FA2.TransferParams
@@ -429,7 +413,6 @@ data ForbidXTZParam
   | Freeze FreezeParam
   | Get_vote_permit_counter (Void_ () Nonce)
   | Get_total_supply (Void_ FA2.TokenId Natural)
-  | Mint MintParam
   | Set_fixed_fee_in_token Natural
   | Set_quorum_threshold QuorumThreshold
   | Set_voting_period VotingPeriod

--- a/haskell/test/Test/Ligo/BaseDAO/Token.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Token.hs
@@ -30,20 +30,6 @@ test_BaseDAO_Token = testGroup "BaseDAO non-FA2 token tests:"
               , ((o2, frozenTokenId), 10)-- for total supply
               ]
           )
-  , nettestScenario "can mint tokens to any accounts"
-      $ uncapsNettest $ mintScenario
-        $ originateLigoDaoWithBalance dynRecUnsafe defaultConfig
-          (\o1 _ ->
-              [ ((o1, frozenTokenId), 0)
-              ]
-          )
-  , nettestScenario "cannot mint unknown tokens"
-      $ uncapsNettest $ unknownMintScenario
-        $ originateLigoDaoWithBalance dynRecUnsafe defaultConfig
-          (\o1 _ ->
-              [ ((o1, frozenTokenId), 0)
-              ]
-          )
   , nettestScenario "can call transfer tokens entrypoint"
       $ uncapsNettest $ transferContractTokensScenario originateLigoDao
   ]
@@ -73,35 +59,6 @@ burnScenario originateFn = withFrozenCallStack $ do
   withSender (AddressResolved owner1) $
     call dao (Call @"Get_total_supply") (mkVoid frozenTokenId)
       & expectError dao (VoidResult (15 :: Natural)) -- initial = 20
-
-mintScenario
-  :: (MonadNettest caps base m, HasCallStack)
-  => OriginateFn m -> m ()
-mintScenario originateFn = withFrozenCallStack $ do
-  ((owner1, _), _, dao, _, admin) <- originateFn
-
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Mint") (MintParam owner1 frozenTokenId 10)
-    & expectCustomErrorNoArg #nOT_ADMIN dao
-
-  withSender (AddressResolved admin) $ do
-    call dao (Call @"Mint") (MintParam owner1 frozenTokenId 10)
-  checkTokenBalance frozenTokenId dao owner1 10
-
-  -- Check total supply
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Get_total_supply") (mkVoid frozenTokenId)
-      & expectError dao (VoidResult (10 :: Natural)) -- initial = 0
-
-unknownMintScenario
-  :: (MonadNettest caps base m, HasCallStack)
-  => OriginateFn m -> m ()
-unknownMintScenario originateFn = withFrozenCallStack $ do
-  ((owner1, _), _, dao, _, admin) <- originateFn
-
-  withSender (AddressResolved admin) $ do
-    call dao (Call @"Mint") (MintParam owner1 (FA2.TokenId 2) 10)
-    & expectCustomError_ #fA2_TOKEN_UNDEFINED dao
 
 transferContractTokensScenario
   :: MonadNettest caps base m

--- a/src/base_DAO.mligo
+++ b/src/base_DAO.mligo
@@ -30,7 +30,6 @@ let requiring_no_xtz (param, store, config : forbid_xtz_params * storage * confi
     | Set_quorum_threshold (p) -> set_quorum_threshold(p, config, store)
     | Flush (p) -> flush (p, config, store)
     | Burn (p) -> burn(p, store)
-    | Mint (p) -> mint(p, store)
     | Get_vote_permit_counter (p) -> get_vote_permit_counter(p, store)
     | Get_total_supply (p) -> get_total_supply(p, store)
     | Freeze p -> freeze(p, store)

--- a/src/token.mligo
+++ b/src/token.mligo
@@ -18,11 +18,6 @@ let burn(param, store : burn_param * storage) : return =
   let (ledger, total_supply) = debit_from (param.amount, param.from_, param.token_id, store.ledger, store.total_supply)
   in (([] : operation list), { store with ledger = ledger; total_supply = total_supply})
 
-let mint(param, store : mint_param * storage) : return =
-  let store = authorize_admin(store) in
-  let (ledger, total_supply) = credit_to (param.amount, param.to_, param.token_id, store.ledger, store.total_supply)
-  in (([] : operation list), {store with ledger = ledger; total_supply = total_supply})
-
 let make_transfer_on_token (tps, contract_addr : transfer_params * address) : operation =
   let token_contract =
     begin

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -250,7 +250,6 @@ type forbid_xtz_params =
   | Set_quorum_threshold of quorum_threshold
   | Flush of nat
   | Burn of burn_param
-  | Mint of mint_param
   | Get_vote_permit_counter of vote_permit_counter_param
   | Get_total_supply of get_total_supply_param
   | Freeze of freeze_param

--- a/typescript/baseDAO/README.md
+++ b/typescript/baseDAO/README.md
@@ -55,10 +55,6 @@ BaseDAO
   .catch(err => console.log(JSON.stringify(err), null, 2));
 
 BaseDAO
-  .mint({to_:  "tz1ZvZCqjaBLEyJLYHCfzq6B8MCFu2SRjzJG", "token_id" : 0, "amount" : 10})
-  .catch(err => console.log(JSON.stringify(err), null, 2));
-
-BaseDAO
   .propose({frozen_token: 10, proposal_metadata: new Map([["key", "FF"]])})
   .catch(err => console.log(JSON.stringify(err), null, 2));
 

--- a/typescript/baseDAO/etc/basedao-sdk.api.md
+++ b/typescript/baseDAO/etc/basedao-sdk.api.md
@@ -56,8 +56,6 @@ export class BaseDAOContract {
     // (undocumented)
     migrate(arg: Migrate): Promise<string | void>;
     // (undocumented)
-    mint(arg: Mint): Promise<string | void>;
-    // (undocumented)
     propose(arg: Propose): Promise<string | void>;
     // (undocumented)
     set_quorum_threshold(arg: Set_quorum_threshold): Promise<string | void>;
@@ -117,16 +115,6 @@ export interface GetVotePermitCounter {
 
 // @public (undocumented)
 export type Migrate = string;
-
-// @public (undocumented)
-export interface Mint {
-    // (undocumented)
-    amount: number;
-    // (undocumented)
-    to_: string;
-    // (undocumented)
-    token_id: number;
-}
 
 // @public (undocumented)
 export interface Propose {

--- a/typescript/baseDAO/src/api.ts
+++ b/typescript/baseDAO/src/api.ts
@@ -15,7 +15,6 @@ import { Balance_of } from './generated/Balance_of';
 import { Drop_proposal } from './generated/Drop_proposal';
 import { Flush } from './generated/Flush';
 import { Get_total_supply } from './generated/Get_total_supply';
-import { Mint } from './generated/Mint';
 import { Propose } from './generated/Propose';
 import { Set_quorum_threshold } from './generated/Set_quorum_threshold';
 import { Set_voting_period } from './generated/Set_voting_period';
@@ -181,11 +180,6 @@ export class BaseDAOContract {
   get_vote_permit_counter(arg: Get_vote_permit_counter): Promise<string|void> {
     return this.withContract(
       contract => contract.methods.get_vote_permit_counter(arg.voidParam, arg.voidResProxy));
-  }
-
-  mint(arg: Mint): Promise<string|void> {
-    return this.withContract(
-      contract => contract.methods.mint(arg.to_, arg.token_id, arg.amount));
   }
 
   propose(arg: Propose): Promise<string|void> {

--- a/typescript/baseDAO/src/generated/Mint.ts
+++ b/typescript/baseDAO/src/generated/Mint.ts
@@ -1,6 +1,0 @@
-import {Lambda} from '../common';
-export interface Mint {
-  to_: string;
-  token_id: number;
-  amount: number;
-};

--- a/typescript/baseDAO/src/generated/Parameter.ts
+++ b/typescript/baseDAO/src/generated/Parameter.ts
@@ -7,7 +7,6 @@ import {Flush} from  './Flush';
 import {Freeze} from  './Freeze';
 import {Get_total_supply} from  './Get_total_supply';
 import {Get_vote_permit_counter} from  './Get_vote_permit_counter';
-import {Mint} from  './Mint';
 import {Propose} from  './Propose';
 import {Set_fixed_fee_in_token} from  './Set_fixed_fee_in_token';
 import {Set_quorum_threshold} from  './Set_quorum_threshold';
@@ -28,7 +27,6 @@ export type Parameter =
   | Freeze
   | Get_total_supply
   | Get_vote_permit_counter
-  | Mint
   | Propose
   | Set_fixed_fee_in_token
   | Set_quorum_threshold

--- a/typescript/baseDAO/src/index.ts
+++ b/typescript/baseDAO/src/index.ts
@@ -21,7 +21,6 @@ export {Drop_proposal} from  './generated/Drop_proposal';
 export {Flush} from  './generated/Flush';
 export {Get_vote_permit_counter} from  './generated/Get_vote_permit_counter';
 export {Get_total_supply} from  './generated/Get_total_supply';
-export {Mint} from  './generated/Mint';
 export {Propose} from  './generated/Propose';
 export {Set_quorum_threshold} from  './generated/Set_quorum_threshold';
 export {Set_voting_period} from  './generated/Set_voting_period';


### PR DESCRIPTION
## Description

Problem: `mint` is an admin-only entrypoint that allow
generating tokens. This was intended to
be used mainly to set up the contract and then to not be used again.
However, it is possible to setup the ledger with correct initial value
at origination and we no longer need this entrypoint.

Solution: Remove `mint` entrypoint and remove all related
tests.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #208

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
