### PR TITLE
[#205] Update voting period in the Makefile from 11 seconds to 11 days

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(OUT)/trivialDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/trivialDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/trivialDAO_storage.tz : ledger = ([] : ledger_list)
 $(OUT)/trivialDAO_storage.tz : quorum_threshold = {numerator = 1n; denominator = 10n}
-$(OUT)/trivialDAO_storage.tz : voting_period = 11n
+$(OUT)/trivialDAO_storage.tz : voting_period = 950400n # 11 days
 $(OUT)/trivialDAO_storage.tz: src/**
 	# ============== Compiling TrivialDAO storage ============== #
 	mkdir -p $(OUT)
@@ -116,7 +116,7 @@ $(OUT)/registryDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/registryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/registryDAO_storage.tz : ledger = ([] : ledger_list)
 $(OUT)/registryDAO_storage.tz : quorum_threshold = {numerator = 1n; denominator = 10n}
-$(OUT)/registryDAO_storage.tz : voting_period = 11n
+$(OUT)/registryDAO_storage.tz : voting_period = 950400n # 11 days
 $(OUT)/registryDAO_storage.tz: src/**
 	# ============== Compiling RegistryDAO storage ============== #
 	mkdir -p $(OUT)
@@ -166,7 +166,7 @@ $(OUT)/treasuryDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/treasuryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/treasuryDAO_storage.tz : ledger = ([] : ledger_list)
 $(OUT)/treasuryDAO_storage.tz : quorum_threshold = {numerator = 1n; denominator = 10n}
-$(OUT)/treasuryDAO_storage.tz : voting_period = 11n
+$(OUT)/treasuryDAO_storage.tz : voting_period = 950400n # 11 days
 $(OUT)/treasuryDAO_storage.tz: src/**
 	# ============== Compiling TreasuryDAO storage ============== #
 	mkdir -p $(OUT)

--- a/docs/building.md
+++ b/docs/building.md
@@ -52,7 +52,7 @@ make out/trivialDAO_storage.tz \
   fixed_proposal_fee_in_token=0n \
   ledger=([] : ledger_list) \
   quorum_threshold={numerator=1n; denominator=10n} \
-  voting_period=11n \
+  voting_period=950400n \
   metadata_map=(Big_map.empty : metadata_map) \
 ```
 
@@ -83,7 +83,7 @@ make out/registryDAO_storage.tz \
   fixed_proposal_fee_in_token=0n \
   ledger=([] : ledger_list) \
   quorum_threshold={numerator=1n; denominator=10n} \
-  voting_period=11n
+  voting_period=950400n
 ```
 
 All its arguments are optional and will be equal to the values above if not
@@ -110,7 +110,7 @@ make out/treasuryDAO_storage.tz \
   fixed_proposal_fee_in_token=0n \
   ledger=([] : ledger_list) \
   quorum_threshold={numerator=1n; denominator=10n} \
-  voting_period=11n \
+  voting_period=950400n \
   metadata_map=(Big_map.empty : metadata_map) \
 ```
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -147,7 +147,7 @@ They must be provided on origination to construct the contract's initial storage
 These values are:
 1. `admin : address` is the address that can perform administrative actions.
 2. `governance_token` is the FA2 contract address/token id pair that will be used as the governance token.
-3. `voting_period : nat` specifies how long the voting period lasts.
+3. `voting_period : nat` specifies how long the voting period lasts in seconds.
 4. `quorum_threshold : quorum_threshold` specifies what fraction of the frozen
    tokens total supply of total votes are required for a successful proposal.
 5. `fixed_proposal_fee_in_token : nat` specifies the fee for submitting a proposal (in native DAO token).
@@ -608,9 +608,9 @@ Parameter (in Michelson):
 
 ```ocaml
 // Voting period in seconds
-type voting_period = nat
+type seconds = nat
 
-Set_voting_period of voting_period
+Set_voting_period of seconds
 ```
 
 Parameter (in Michelson):

--- a/haskell/test/Test/Ligo/RegistryDAO.hs
+++ b/haskell/test/Test/Ligo/RegistryDAO.hs
@@ -473,6 +473,7 @@ test_RegistryDAO =
         { sAdmin = admin
         , sLedger = ledger
         , sTotalSupply = totalSupplyFromLedger ledger
+        , sVotingPeriod = 11
         }
       in fs { fsStorage = newStorage }
 

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -18,8 +18,8 @@ let default_config (data : initial_config_data) : config = {
   custom_entrypoints = (Big_map.empty : custom_entrypoints);
 }
 
-let bound_vp (vp, min_vp, max_vp : voting_period * voting_period * voting_period)
-    : voting_period =
+let bound_vp (vp, min_vp, max_vp : seconds * seconds * seconds)
+    : seconds =
   if vp < min_vp
   then min_vp
   else

--- a/src/proposal.mligo
+++ b/src/proposal.mligo
@@ -262,7 +262,7 @@ let set_fixed_fee_in_token(new_fee, store : nat * storage): return =
 
 // Update voting period of all ongoing and new proposals.
 [@inline]
-let set_voting_period(new_period, config, store : voting_period * config * storage): return =
+let set_voting_period(new_period, config, store : seconds * config * storage): return =
   let store = authorize_admin store in
   let current_vp = get_current_period_num(store.last_period_change, store.voting_period) in
   let vp_log : last_period_change =

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -123,7 +123,8 @@ type proposal =
   ; voters : voter list
   }
 
-type voting_period = nat
+// Type `seconds` used with `voting_period`.
+type seconds = nat
 
 // Quorum threshold that a proposal needs to meet in order to be accepted,
 // expressed as a fraction of the total_supply of frozen tokens.
@@ -165,7 +166,7 @@ type storage =
   ; admin : address
   ; pending_owner : address
   ; metadata : metadata_map
-  ; voting_period : voting_period
+  ; voting_period : seconds
   ; extra : contract_extra
   ; proposals : (proposal_key, proposal) big_map
   ; proposal_key_list_sort_by_date : (timestamp * proposal_key) set
@@ -183,8 +184,6 @@ type freeze_param = nat
 type unfreeze_param = nat
 
 type transfer_ownership_param = address
-
-type voting_period = nat
 
 type custom_ep_param = (string * bytes)
 
@@ -245,7 +244,7 @@ type forbid_xtz_params =
   | Accept_ownership of unit
   | Vote of vote_param_permited list
   | Set_fixed_fee_in_token of nat
-  | Set_voting_period of voting_period
+  | Set_voting_period of seconds
   | Flush of nat
   | Get_vote_permit_counter of vote_permit_counter_param
   | Get_total_supply of get_total_supply_param
@@ -282,8 +281,8 @@ type initial_ledger_val = address * token_id * nat
 type ledger_list = (ledger_key * ledger_value) list
 
 type initial_config_data =
-  { max_period : voting_period
-  ; min_period : voting_period
+  { max_period : seconds
+  ; min_period : seconds
   ; quorum_threshold : quorum_threshold
   }
 
@@ -308,8 +307,8 @@ type config =
 
   ; max_proposals : nat
   ; max_votes : nat
-  ; max_voting_period : voting_period
-  ; min_voting_period : voting_period
+  ; max_voting_period : seconds
+  ; min_voting_period : seconds
   ; quorum_threshold : quorum_threshold
 
   ; custom_entrypoints : custom_entrypoints


### PR DESCRIPTION
## Description

Problem: In the `Makefile` we have a default voting period of `11n`,
since this value is in seconds, this is too low for a realistic use.

Solution: Update voting period in Makefile to 950400 seconds (11 days).


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #205 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
