### PR TITLE
[#207] Dynamic quorum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,13 @@ $(OUT)/trivialDAO_storage.tz : now_val = `date +"%s"`
 $(OUT)/trivialDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/trivialDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/trivialDAO_storage.tz : ledger = ([] : ledger_list)
-$(OUT)/trivialDAO_storage.tz : quorum_threshold = {numerator = 1n; denominator = 10n}
+$(OUT)/trivialDAO_storage.tz : quorum_threshold = 10n
+$(OUT)/trivialDAO_storage.tz : min_quorum = 1n
+$(OUT)/trivialDAO_storage.tz : max_quorum = 99n
 $(OUT)/trivialDAO_storage.tz : voting_period = 950400n # 11 days
+$(OUT)/trivialDAO_storage.tz : quorum_change = 5n
+$(OUT)/trivialDAO_storage.tz : max_quorum_change = 19n
+$(OUT)/trivialDAO_storage.tz : governance_total_supply = 100n
 $(OUT)/trivialDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
 $(OUT)/trivialDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
 $(OUT)/trivialDAO_storage.tz: src/**
@@ -95,11 +100,16 @@ $(OUT)/trivialDAO_storage.tz: src/**
           ; ledger_lst = $(call escape_double_quote,$(ledger)) \
           } \
         ; config_data = \
-          { voting_period = { length = $(voting_period) } \
+          { max_quorum = { numerator = ($(max_quorum) * quorum_denominator)/100n } \
+          ; min_quorum = { numerator = ($(min_quorum) * quorum_denominator)/100n } \
+          ; voting_period = { length = $(voting_period) } \
           ; proposal_flush_time = $(proposal_flush_time) \
           ; proposal_expired_time = $(proposal_expired_time) \
-          ; quorum_threshold = $(quorum_threshold) \
+          ; quorum_threshold = { numerator = ($(quorum_threshold) * quorum_denominator)/100n } \
           ; fixed_proposal_fee_in_token = $(fixed_proposal_fee_in_token) \
+          ; quorum_change = { numerator = ($(quorum_change) * quorum_denominator)/100n } \
+          ; max_quorum_change = { numerator = ($(max_quorum_change) * quorum_denominator)/100n } \
+          ; governance_total_supply = $(governance_total_supply) \
           } \
         })"
 	# ================= Compilation successful ================= #
@@ -121,10 +131,16 @@ $(OUT)/registryDAO_storage.tz : now_val = `date +"%s"`
 $(OUT)/registryDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/registryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/registryDAO_storage.tz : ledger = ([] : ledger_list)
-$(OUT)/registryDAO_storage.tz : quorum_threshold = {numerator = 1n; denominator = 10n}
+$(OUT)/registryDAO_storage.tz : quorum_threshold = 10n
+$(OUT)/registryDAO_storage.tz : min_quorum = 1n
+$(OUT)/registryDAO_storage.tz : max_quorum = 99n
+
 $(OUT)/registryDAO_storage.tz : voting_period = 950400n # 11 days
+$(OUT)/registryDAO_storage.tz : quorum_change = 5n
+$(OUT)/registryDAO_storage.tz : max_quorum_change = 19n
 $(OUT)/registryDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
 $(OUT)/registryDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
+$(OUT)/registryDAO_storage.tz : governance_total_supply = 100n
 $(OUT)/registryDAO_storage.tz: src/**
 	# ============== Compiling RegistryDAO storage ============== #
 	mkdir -p $(OUT)
@@ -143,13 +159,17 @@ $(OUT)/registryDAO_storage.tz: src/**
             ; ledger_lst = $(call escape_double_quote,$(ledger)) \
             } \
           ; config_data = \
-            { quorum_threshold = $(quorum_threshold) \
+            { max_quorum = { numerator = ($(max_quorum) * quorum_denominator)/100n } \
+            ; min_quorum = { numerator = ($(min_quorum) * quorum_denominator)/100n } \
             ; voting_period = { length = $(voting_period) } \
             ; proposal_flush_time = $(proposal_flush_time) \
             ; proposal_expired_time = $(proposal_expired_time) \
             ; fixed_proposal_fee_in_token = $(fixed_proposal_fee_in_token) \
-            } \
-          } \
+            ; quorum_threshold = { numerator = ($(quorum_threshold) * quorum_denominator)/100n } \
+            ; quorum_change = { numerator = ($(quorum_change) * quorum_denominator)/100n } \
+            ; max_quorum_change = { numerator = ($(max_quorum_change) * quorum_denominator)/100n } \
+            ; governance_total_supply = $(governance_total_supply) \
+            }} \
           ; frozen_scale_value = $(frozen_scale_value) \
           ; frozen_extra_value = $(frozen_extra_value) \
           ; max_proposal_size = $(max_proposal_size) \
@@ -177,10 +197,15 @@ $(OUT)/treasuryDAO_storage.tz : now_val = `date +"%s"`
 $(OUT)/treasuryDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/treasuryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/treasuryDAO_storage.tz : ledger = ([] : ledger_list)
-$(OUT)/treasuryDAO_storage.tz : quorum_threshold = {numerator = 1n; denominator = 10n}
+$(OUT)/treasuryDAO_storage.tz : quorum_threshold = 10n
+$(OUT)/treasuryDAO_storage.tz : min_quorum = 1n
+$(OUT)/treasuryDAO_storage.tz : max_quorum = 99n
 $(OUT)/treasuryDAO_storage.tz : voting_period = 950400n # 11 days
+$(OUT)/treasuryDAO_storage.tz : quorum_change = 5n
+$(OUT)/treasuryDAO_storage.tz : max_quorum_change = 19n
 $(OUT)/treasuryDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
 $(OUT)/treasuryDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
+$(OUT)/treasuryDAO_storage.tz : governance_total_supply = 100n
 $(OUT)/treasuryDAO_storage.tz: src/**
 	# ============== Compiling TreasuryDAO storage ============== #
 	mkdir -p $(OUT)
@@ -199,13 +224,17 @@ $(OUT)/treasuryDAO_storage.tz: src/**
             ; ledger_lst = $(call escape_double_quote,$(ledger)) \
             } \
           ; config_data = \
-            { quorum_threshold = $(quorum_threshold) \
+            { max_quorum = { numerator = ($(max_quorum) * quorum_denominator)/100n } \
+            ; min_quorum = { numerator = ($(min_quorum) * quorum_denominator)/100n } \
             ; voting_period = { length = $(voting_period) } \
             ; proposal_flush_time = $(proposal_flush_time) \
             ; proposal_expired_time = $(proposal_expired_time) \
             ; fixed_proposal_fee_in_token = $(fixed_proposal_fee_in_token) \
-            } \
-          } \
+            ; quorum_threshold = { numerator = ($(quorum_threshold) * quorum_denominator)/100n } \
+            ; quorum_change = { numerator = ($(quorum_change) * quorum_denominator)/100n } \
+            ; max_quorum_change = { numerator = ($(max_quorum_change) * quorum_denominator)/100n } \
+            ; governance_total_supply = $(governance_total_supply) \
+            }} \
           ; frozen_scale_value = $(frozen_scale_value) \
           ; frozen_extra_value = $(frozen_extra_value) \
           ; max_proposal_size = $(max_proposal_size) \

--- a/docs/building.md
+++ b/docs/building.md
@@ -52,7 +52,12 @@ make out/trivialDAO_storage.tz \
   metadata_map=(Big_map.empty : metadata_map)
   fixed_proposal_fee_in_token=0n \
   ledger=([] : ledger_list) \
-  quorum_threshold={numerator=1n; denominator=10n} \
+  quorum_threshold = 10n \
+  min_quorum = 1 \
+  max_quorum = 99 \
+  change_percent = 5n \
+  max_change_percent = 19n \
+  governance_total_supply = 100n \
   voting_period=950400n \
   proposal_flush_time = 1900801n \
   proposal_expired_time = 2851200n \
@@ -86,7 +91,12 @@ make out/registryDAO_storage.tz \
   metadata_map=(Big_map.empty : metadata_map) \
   fixed_proposal_fee_in_token=0n \
   ledger=([] : ledger_list) \
-  quorum_threshold={numerator=1n; denominator=10n} \
+  quorum_threshold = 10n \
+  min_quorum = 1n \
+  max_quorum = 99n
+  change_percent = 5n \
+  max_change_percent = 19n \
+  governance_total_supply = 100n \
   voting_period=950400n \
   proposal_flush_time = 1900801n \
   proposal_expired_time = 2851200n
@@ -116,7 +126,12 @@ make out/treasuryDAO_storage.tz \
   metadata_map=(Big_map.empty : metadata_map)
   fixed_proposal_fee_in_token=0n \
   ledger=([] : ledger_list) \
-  quorum_threshold={numerator=1n; denominator=10n} \
+  quorum_threshold = 10n \
+  min_quorum = 1n \
+  max_quorum = 99n \
+  change_percent = 5n \
+  max_change_percent = 19n \
+  governance_total_supply = 100n \
   voting_period=950400n \
   proposal_flush_time = 1900801n \
   proposal_expired_time = 2851200n \

--- a/haskell/test/Ligo/BaseDAO/Contract.hs
+++ b/haskell/test/Ligo/BaseDAO/Contract.hs
@@ -13,4 +13,4 @@ import Ligo.Util
 
 baseDAOContractLigo :: Contract (ToT Parameter) (ToT FullStorage)
 baseDAOContractLigo =
-  $(fetchContract @(ToT Parameter) @(ToT FullStorage) "BASEDAO_LIGO_PATH")
+ $(fetchContract @(ToT Parameter) @(ToT FullStorage) "BASEDAO_LIGO_PATH")

--- a/haskell/test/Test/Ligo/BaseDAO/Common.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Common.hs
@@ -234,6 +234,7 @@ originateLigoDaoWithBalance extra config balFunc = do
               ! #metadata mempty
               ! #tokenAddress (unTAddress tokenContract)
               ! #now now
+              ! #quorumThreshold (cMinQuorumThreshold config)
             )
             { sLedger = bal
             , sOperators = operators

--- a/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
@@ -21,7 +21,7 @@ import Test.Tasty.HUnit (testCase)
 import Ligo.BaseDAO.Types
 import Michelson.Test.Integrational
 import Michelson.Untyped (unsafeBuildEpName)
-import Test.Ligo.BaseDAO.Common (dummyFA2Contract)
+import Test.Ligo.BaseDAO.Common (dummyFA2Contract, makeProposalKey)
 import Test.Ligo.BaseDAO.Integrational.Common
 import Util.Named
 
@@ -32,13 +32,21 @@ test_IntegrationalBaseDAOProposal = testGroup "BaseDAO Integrational Tests"
   [ testGroup "Integrational Tests for checking storage"
       [ testCase "contract correctly tracks freeze-unfreeze history" $
           integrationalTestExpectation $ checkFreezeHistoryTracking
+      , testCase "contract correctly updates quorum threshold and resets outdated staked token count" $
+          integrationalTestExpectation $ checkQuorumThresholdDynamicUpdate
+      , testCase "contract correctly updates quorum threshold within max bound" $
+          integrationalTestExpectation $ checkQuorumThresholdDynamicUpdateUpperBound
+      , testCase "contract correctly updates quorum threshold within min bound" $
+          integrationalTestExpectation $ checkQuorumThresholdDynamicUpdateLowerBound
+      , testCase "contract correctly stores quorum threshold within the proposal" $
+          integrationalTestExpectation $ checkProposalSavesQuorum
       ]
   ]
 
 checkFreezeHistoryTracking :: IntegrationalScenarioM ()
 checkFreezeHistoryTracking  = do
   let frozen_scale_value = 2
-  let frozen_extra_value = 0
+  let frozen_extra_value = 10
 
   now <- use isNow
 
@@ -47,11 +55,14 @@ checkFreezeHistoryTracking  = do
     pure $ mkFullStorage
       ! #admin admin
       ! #votingPeriod 10
-      ! #quorumThreshold (QuorumThreshold 10 100)
+      ! #quorumThreshold (mkQuorumThreshold 10 100)
       ! #extra dynRecUnsafe
       ! #metadata mempty
       ! #now now
       ! #tokenAddress (unTAddress dodTokenContract)
+      ! #maxChangePercent 19
+      ! #changePercent 5
+      ! #governanceTotalSupply 100
       ! #customEps mempty
     ) $ \(admin:wallet1:_) baseDao -> let
       proposalMeta1 = ""
@@ -93,3 +104,219 @@ checkFreezeHistoryTracking  = do
                   }
             when (fh /= (Just expected)) $
               Left $ CustomTestError "BaseDAO contract did not unstake tokens after voting period"
+
+calculateThreshold :: MaxChangePercent -> ChangePercent -> GovernanceTotalSupply -> Integer -> QuorumThreshold -> QuorumThreshold
+calculateThreshold (MaxChangePercent mcp) (ChangePercent cp) (GovernanceTotalSupply gts) staked oldQt =
+  let
+    changePercent = QuorumThreshold (percentageToFractionNumerator cp)
+    participation = fractionToNumerator staked (fromIntegral gts)
+    maxChangePercent = QuorumThreshold $ percentageToFractionNumerator mcp
+    possibeNewQuorum = addF (subF oldQt (mulF oldQt changePercent)) (mulF participation changePercent)
+    one' = mkQuorumThreshold 1 1
+    maxNewQuorum = mulF oldQt (addF one' maxChangePercent)
+    minNewQuorum = divF oldQt (addF one' maxChangePercent)
+    -- old_quorum - (old_quorum * changePercent) + participation * changePercent
+    configMinQuorum = QuorumThreshold $ percentageToFractionNumerator 1
+    configMaxQuorum = QuorumThreshold $ percentageToFractionNumerator 99
+  in boundQt configMinQuorum configMaxQuorum (boundQt minNewQuorum maxNewQuorum possibeNewQuorum)
+  where
+    boundQt (QuorumThreshold qmin) (QuorumThreshold qmax) (QuorumThreshold qt) = QuorumThreshold $ min qmax (max qmin qt)
+    mulF (QuorumThreshold n1) (QuorumThreshold n2) = QuorumThreshold (div (n1 * n2) (fromIntegral fractionDenominator))
+    divF (QuorumThreshold n1) (QuorumThreshold n2) = QuorumThreshold (div (n1 * (fromIntegral fractionDenominator)) n2)
+    addF (QuorumThreshold n1) (QuorumThreshold n2) = QuorumThreshold (n1 + n2)
+    subF (QuorumThreshold n1) (QuorumThreshold n2) = QuorumThreshold (n1 - n2)
+    fractionToNumerator = mkQuorumThreshold
+
+checkQuorumThresholdDynamicUpdate :: IntegrationalScenarioM ()
+checkQuorumThresholdDynamicUpdate  = do
+  now <- use isNow
+
+  withOriginated 2 (\(admin:_) -> do
+    tokenContract <- lOriginate dummyFA2Contract "TokenContract" [] (toMutez 0)
+    pure $ mkFullStorage
+      ! #admin admin
+      ! #votingPeriod 10
+      ! #quorumThreshold (mkQuorumThreshold 3 10)
+      ! #extra dynRecUnsafe
+      ! #metadata mempty
+      ! #now now
+      ! #tokenAddress (unTAddress tokenContract)
+      ! #maxChangePercent 19
+      ! #changePercent 5
+      ! #governanceTotalSupply 100
+      ! #customEps mempty
+    ) $ \(_:wallet1:_) baseDao -> do
+        let requiredFrozen = (10 :: Natural)
+
+        let proposalMeta1 = ""
+
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "freeze") (toVal (2 * requiredFrozen))
+
+        rewindTime 11
+        -- First proposal period, cycle 0
+
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "propose") (toVal (ProposeParams requiredFrozen proposalMeta1))
+
+        lExpectStorage @FullStorage baseDao $ \storage -> do
+            let qs = sQuorumThresholdAtCycle $ fsStorage storage
+            let expected = QuorumThresholdAtCycle 1 (mkQuorumThreshold 3 10) 10 -- We don't expect the inital quorum to have updated here
+            when (qs /= expected) $
+              Left $ CustomTestError ("BaseDAO contract updated quorum threshold unexpectedly" <> (show qs))
+
+        -- skip this proposal period and next voting period to be in next proposal period
+        rewindTime 21 -- cycle 2
+
+        let proposalMeta2 = "A"
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "propose") (toVal (ProposeParams requiredFrozen proposalMeta2))
+
+        lExpectStorage @FullStorage baseDao $ \storage -> do
+            let qs = sQuorumThresholdAtCycle $ fsStorage storage
+            -- We start with quorumThreshold of 3/10, with participation as 10 and governance total supply as 100
+            -- participation = 10/100 = 1/10
+            -- so possible_new_quorum = 3/10 * (1 - 0.05)  + (1/10 * 5/100)
+            -- so 3/10 * (19/20) + (5/1000) = 57/200 + 1/200 = 58/200 = 29/100
+            let expected = QuorumThresholdAtCycle 2 (calculateThreshold 19 5 100 10 $ mkQuorumThreshold 3 10) 10
+            when (qs /= expected) $
+              Left $ CustomTestError ("BaseDAO contract did not update quorum threshold as expected" <> (show qs))
+
+checkQuorumThresholdDynamicUpdateUpperBound :: IntegrationalScenarioM ()
+checkQuorumThresholdDynamicUpdateUpperBound  = do
+  now <- use isNow
+
+  withOriginated 2 (\(admin:_) -> do
+    tokenContract <- lOriginate dummyFA2Contract "TokenContract" [] (toMutez 0)
+    pure $ mkFullStorage
+      ! #admin admin
+      ! #votingPeriod 10
+      ! #quorumThreshold (mkQuorumThreshold 3 10)
+      ! #extra dynRecUnsafe
+      ! #metadata mempty
+      ! #now now
+      ! #tokenAddress (unTAddress tokenContract)
+      ! #maxChangePercent 7
+      ! #changePercent 5
+      ! #governanceTotalSupply 100
+      ! #customEps mempty
+    ) $ \(_:wallet1:_) baseDao -> do
+        let requiredFrozen = (100 :: Natural)
+
+        let proposalMeta1 = ""
+
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "freeze") (toVal (2 * requiredFrozen))
+
+        rewindTime 11
+
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "propose") (toVal (ProposeParams requiredFrozen proposalMeta1))
+
+        rewindTime 21
+        let proposalMeta2 = "A"
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "propose") (toVal (ProposeParams requiredFrozen proposalMeta2))
+
+        lExpectStorage @FullStorage baseDao $ \storage -> do
+            let qs = sQuorumThresholdAtCycle $ fsStorage storage
+            -- We start with quorumThreshold of 3/10, with participation as 100 and governance total supply as 100
+            -- participation = 100/100 = 1
+            -- so possible_new_quorum = 3/10 * (1 - 0.05)  + (1 * 5/100)
+            -- so 3/10 * (19/20) + (5/100) = 57/200 + 1/20 = 67/200 = (0.3350)
+            --
+            -- min_quorum = (3/10) / 1.07 = 0.28
+            -- max_quorum = (3/10) * (107/100) = 321/1000 = 0.321
+            let expected = QuorumThresholdAtCycle 2 (calculateThreshold 7 5 100 100 $ mkQuorumThreshold 3 10) 100
+            when (qs /= expected) $
+              Left $ CustomTestError ("BaseDAO contract did not update quorum threshold as expected")
+
+checkQuorumThresholdDynamicUpdateLowerBound :: IntegrationalScenarioM ()
+checkQuorumThresholdDynamicUpdateLowerBound  = do
+  now <- use isNow
+
+  withOriginated 2 (\(admin:_) -> do
+    tokenContract <- lOriginate dummyFA2Contract "TokenContract" [] (toMutez 0)
+    pure $ mkFullStorage
+      ! #admin admin
+      ! #votingPeriod 10
+      ! #quorumThreshold (mkQuorumThreshold 3 10)
+      ! #extra dynRecUnsafe
+      ! #metadata mempty
+      ! #now now
+      ! #tokenAddress (unTAddress tokenContract)
+      ! #maxChangePercent 19
+      ! #changePercent 25
+      ! #governanceTotalSupply 100
+      ! #customEps mempty
+    ) $ \(_:wallet1:_) baseDao -> do
+        let requiredFrozen = (100 :: Natural)
+
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "freeze") (toVal (2 * requiredFrozen))
+
+        -- We raise no proposals here, so participation for calculating next quorum would be zero.
+
+        rewindTime 31
+        let proposalMeta2 = "A"
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "propose") (toVal (ProposeParams requiredFrozen proposalMeta2))
+
+        lExpectStorage @FullStorage baseDao $ \storage -> do
+            let qs = sQuorumThresholdAtCycle $ fsStorage storage
+            -- We start with quorumThreshold of 3/10, with participation as 0 and governance total supply as 100
+            -- participation = 100/100 = 1
+            -- so possible_new_quorum = 3/10 * (1 - 0.25)  + (0 * 5/100)
+            -- so 3/10 * (15/20) = 45/200 = 0.2250
+            --
+            -- min_quorum = (3/10) / (119/100) = 300/1190 = 0.2521
+            -- let expected = QuorumThresholdAtCycle 2 (mkQuorumThreshold 300 1190) 100
+            let expected = QuorumThresholdAtCycle 2 (calculateThreshold 19 25 100 0 $ mkQuorumThreshold 3 10) 100
+            when (qs /= expected) $
+              Left $ CustomTestError ("BaseDAO contract did not update quorum threshold as expected")
+
+checkProposalSavesQuorum :: IntegrationalScenarioM ()
+checkProposalSavesQuorum  = do
+  now <- use isNow
+
+  withOriginated 2 (\(admin:_) -> do
+    tokenContract <- lOriginate dummyFA2Contract "TokenContract" [] (toMutez 0)
+    pure $ mkFullStorage
+      ! #admin admin
+      ! #votingPeriod 10
+      ! #quorumThreshold (mkQuorumThreshold 3 10)
+      ! #extra dynRecUnsafe
+      ! #metadata mempty
+      ! #now now
+      ! #tokenAddress (unTAddress tokenContract)
+      ! #maxChangePercent 19
+      ! #changePercent 5
+      ! #governanceTotalSupply 100
+      ! #customEps mempty
+    ) $ \(_:wallet1:_) baseDao -> do
+        let requiredFrozen = (10 :: Natural)
+
+        let proposalMeta1 = ""
+
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "freeze") (toVal (2 * requiredFrozen))
+
+        rewindTime 11
+        -- First proposal period, cycle 0
+
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "propose") (toVal (ProposeParams requiredFrozen proposalMeta1))
+
+        lExpectStorage @FullStorage baseDao $ \storage -> do
+            let qs = sQuorumThresholdAtCycle $ fsStorage storage
+            let expected = QuorumThresholdAtCycle 1 (mkQuorumThreshold 3 10) 10 -- We don't expect the inital quorum to have updated here
+            when (qs /= expected) $
+              Left $ CustomTestError ("BaseDAO contract updated quorum threshold unexpectedly")
+
+        -- skip this proposal period and next voting period to be in next proposal period
+        rewindTime 21 -- cycle 2
+
+        let proposalMeta2 = "A"
+        let proposeParams = ProposeParams requiredFrozen proposalMeta2
+        tTransfer  (#from .! wallet1) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "propose") (toVal proposeParams)
+
+        lExpectStorage @FullStorage baseDao $ \storage -> do
+            let proposalKey = makeProposalKey proposeParams wallet1
+            let proposal = fromMaybe (error "Proposal not found") $ Map.lookup proposalKey $ unBigMap $ sProposals $ fsStorage storage
+            -- We start with quorumThreshold of 3/10, with participation as 10 and governance total supply as 100
+            -- participation = 10/100 = 1/10
+            -- so possible_new_quorum = 3/10 * (1 - 0.05)  + (1/10 * 5/100)
+            -- so 3/10 * (19/20) + (5/1000) = 57/200 + 1/200 = 58/200 = 29/100
+            let expected = mkQuorumThreshold 290 1000
+            when ((plQuorumThreshold proposal) /= expected) $
+              Left $ CustomTestError ("BaseDAO contract did not update quorum threshold as expected")

--- a/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
@@ -37,6 +37,7 @@ offChainViewStorage =
   ! #metadata mempty
   ! #now (timestampFromSeconds 0)
   ! #tokenAddress genesisAddress
+  ! #quorumThreshold (mkQuorumThreshold 1 100)
   ! defaults
   ) { sLedger = bal
     , sTotalSupply = totalSupplyFromLedger bal

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
@@ -149,7 +149,7 @@ testConfig
 testConfig =
   ConfigDesc (proposalFrozenTokensMinBound 10) >>-
   ConfigDesc configConsts
-    { cmQuorumThreshold = Just (DAO.QuorumThreshold 1 100) }
+    { cmQuorumThreshold = Just (DAO.mkQuorumThreshold 1 100) }
 
 -- | Config with longer voting period and bigger quorum threshold
 -- Needed for vote related tests that do not call `flush`
@@ -159,7 +159,7 @@ voteConfig
 voteConfig = ConfigDesc $
   ConfigDesc (proposalFrozenTokensMinBound 10) >>-
   ConfigDesc configConsts
-    { cmQuorumThreshold = Just (DAO.QuorumThreshold 4 100) }
+    { cmQuorumThreshold = Just (DAO.mkQuorumThreshold 4 100) }
 
 configWithRejectedProposal
   :: AreConfigDescsExt config '[RejectedProposalReturnValue]
@@ -190,7 +190,9 @@ instance IsConfigDescExt DAO.Config ConfigConstants where
 
 instance IsConfigDescExt DAO.Config DAO.QuorumThreshold where
   fillConfig qt DAO.Config'{..} = DAO.Config'
-    { cQuorumThreshold = qt
+    -- We set min quorum threshold since we use it to initialize
+    -- the quorumThreshold in storage in tests.
+    { cMinQuorumThreshold = qt
     , ..
     }
 

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -223,7 +223,7 @@ originateTreasuryDaoWithBalance bal =
 
   in originateLigoDaoWithBalance (sExtra fsStorage)
       (fsConfig
-        { cQuorumThreshold = QuorumThreshold 1 100
+        { cMinQuorumThreshold = mkQuorumThreshold 1 100
         , cVotingPeriod = 10
         , cProposalFlushTime = 20
         , cProposalExpiredTime = 30

--- a/src/proposal.mligo
+++ b/src/proposal.mligo
@@ -54,24 +54,48 @@ let ensure_proposal_is_unique (propose_params, store : propose_params * storage)
     then (failwith("PROPOSAL_NOT_UNIQUE") : proposal_key)
     else proposal_key
 
-// Utility function for quorum_threshold comparison.
-// Returns two nats, which can be compared to check for the desired condition.
-// e.g. nat_1 > nat_2 implies that qt_1 > qt_2
-let cmp_qt(qt_1, qt_2 : quorum_threshold * quorum_threshold): (nat * nat) =
-  // Calculated this way because there is no support for floating point operations
-  (qt_1.numerator * qt_2.denominator, qt_1.denominator * qt_2.numerator)
+let quorum_denominator_int = int(quorum_denominator)
+  // Hopefuly this will be optimized by the compiler and does not actually
+  // call `int` for every access to this value
+
+// Multiply two quorum_fractions
+//
+// We store fractions by storing only the numerator and denominator is always
+// assumed to be quorum_denominator. So here qt_1, actually represents the
+// value qt_1.numerator/ quorum_denominator and qt_2 represents the value
+// qt_2.numerator/ quorum_denominator. So the product of the two is
+// qt_1.numerator * qt_2.numerator / (quorum_denominator *
+// quorum_denominator).  But since we store x as x * quorum_denominator,
+// the result here would be qt_1.numerator * qt_2.numerator /
+// quorum_denominator. This will also retain the required precision of
+// 1/quorum_denominator.
+[@inline]
+let fmul(qt_1, qt_2 : quorum_fraction * quorum_fraction): quorum_fraction =
+   { numerator = (qt_1.numerator * qt_2.numerator) / quorum_denominator_int }
+
+// Divide the first fraction by the second Here qt_1, actually represents the
+// value qt_1.numerator/ quorum_denominator and qt_2 represents the value
+// qt_2.numerator/ quorum_denominator. So the division can be expressed as
+// (qt_1.numerator * quorum_denominator) / (quorum_denominator *
+// qt_2.numerator) But since we store x as x * quorum_denominator, the result
+// here would be (qt_1.numerator * quorum_denominator_int) / qt_2.numerator
+[@inline]
+let fdiv(qt_1, qt_2 : quorum_fraction * quorum_fraction): quorum_fraction =
+  { numerator = (qt_1.numerator * quorum_denominator_int) / qt_2.numerator }
 
 [@inline]
-// Returns true iff the first quorum_threshold is strictly bigger than the second.
-let is_gt_qt(qt_1, qt_2 : quorum_threshold * quorum_threshold): bool =
-  let (nat_1, nat_2) = cmp_qt (qt_1, qt_2) in
-  nat_1 > nat_2
+let fadd(qt_1, qt_2 : quorum_fraction * quorum_fraction): quorum_fraction =
+  {numerator = qt_1.numerator + qt_2.numerator }
 
 [@inline]
-// Returns true iff the first quorum_threshold is bigger or equal than the second.
-let is_ge_qt(qt_1, qt_2 : quorum_threshold * quorum_threshold): bool =
-  let (nat_1, nat_2) = cmp_qt (qt_1, qt_2) in
-  nat_1 >= nat_2
+let fsub(qt_1, qt_2 : quorum_fraction * quorum_fraction): quorum_fraction =
+  { numerator = qt_1.numerator - qt_2.numerator }
+
+[@inline]
+let bound_qt (qt, min_qt, max_qt : quorum_fraction * quorum_fraction * quorum_fraction)
+    : quorum_fraction =
+  if (qt.numerator > max_qt.numerator) then max_qt else
+    if (qt.numerator < min_qt.numerator) then min_qt else qt
 
 // -----------------------------------------------------------------
 // Freeze history operations
@@ -101,7 +125,7 @@ let unstake_frozen_fh (amt, fh : nat * address_freeze_history)
       ([%Michelson ({| { FAILWITH } |} : (string * unit) -> address_freeze_history)]
         ("NOT_ENOUGH_STAKED_TOKENS", ()) : address_freeze_history)
   | Some new_amt ->
-      // Adding to past_unstaked should be fine since as of now, the staked tokens have to be from
+     // Adding to past_unstaked should be fine since as of now, the staked tokens have to be from
       // past periods.
       { fh with staked = new_amt; past_unstaked = fh.past_unstaked + amt }
 
@@ -144,8 +168,13 @@ let freeze_on_ledger (tokens, addr, ledger, total_supply, frozen_token_id, gover
   let (ledger, total_supply) = credit_to (tokens, addr, frozen_token_id, ledger, total_supply) in
   (operation, ledger, total_supply)
 
+[@inline]
+let period_to_cycle (p: nat): nat = (p + 1n) / 2n
+
 let stake_tk(token_amount, addr, voting_period, store : nat * address * voting_period * storage): storage =
   let current_period = get_current_period_num(store.start_time, voting_period) in
+  let current_cycle = period_to_cycle(current_period) in
+  let new_cycle_staked = store.quorum_threshold_at_cycle.staked + token_amount in
   let new_freeze_history = match Big_map.find_opt addr store.freeze_history with
     | Some fh ->
         let fh = update_fh(current_period, fh) in
@@ -156,7 +185,7 @@ let stake_tk(token_amount, addr, voting_period, store : nat * address * voting_p
       then store.freeze_history
       else ([%Michelson ({| { FAILWITH } |} : (string * unit) -> freeze_history)]
               ("NOT_ENOUGH_FROZEN_TOKENS", ()) : freeze_history)
-  in { store with freeze_history = new_freeze_history }
+  in { store with freeze_history = new_freeze_history; quorum_threshold_at_cycle = {store.quorum_threshold_at_cycle with staked = new_cycle_staked } }
 
 [@inline]
 let unfreeze_on_ledger (tokens, addr, ledger, total_supply, frozen_token_id, governance_token : nat * address * ledger * total_supply * token_id * governance_token): (operation * ledger * total_supply) =
@@ -184,6 +213,7 @@ let add_proposal (propose_params, voting_period, store : propose_params * voting
     ; proposer = Tezos.sender
     ; proposer_frozen_token = propose_params.frozen_token
     ; voters = ([] : voter list)
+    ; quorum_threshold = store.quorum_threshold_at_cycle.quorum_threshold
     } in
   { store with
     proposals =
@@ -191,16 +221,6 @@ let add_proposal (propose_params, voting_period, store : propose_params * voting
   ; proposal_key_list_sort_by_date =
       Set.add (timestamp, proposal_key) store.proposal_key_list_sort_by_date
   }
-
-let propose (param, config, store : propose_params * config * storage): return =
-  let store = check_is_proposal_valid (config, param, store) in
-  let store = check_proposal_limit_reached (config, store) in
-  let amount_to_freeze = param.frozen_token + config.fixed_proposal_fee_in_token in
-  let store = stake_tk(amount_to_freeze, Tezos.sender, config.voting_period, store) in
-  let store = add_proposal (param, config.voting_period, store) in
-  ( ([] : operation list)
-  , store
-  )
 
 // -----------------------------------------------------------------
 // Vote
@@ -320,18 +340,20 @@ let is_time_reached (proposal, sec : proposal * seconds): bool =
   Tezos.now > proposal.start_date + int(sec)
 
 [@inline]
-let do_total_vote_meet_quorum_threshold (proposal, store, quorum_threshold : proposal * storage * quorum_threshold): bool =
+let frozen_total_supply(store : storage): nat =
+    match Map.find_opt store.frozen_token_id store.total_supply with
+    | Some v -> v
+    | None -> ((failwith "BAD_STATE") : nat)
+
+[@inline]
+let do_total_vote_meet_quorum_threshold (proposal, store : proposal * storage): bool =
   let votes_placed = proposal.upvotes + proposal.downvotes in
-  let total_supply =
-        match Map.find_opt store.frozen_token_id store.total_supply with
-        | Some v -> v
-        | None -> 0n
-  in
+  let total_supply = frozen_total_supply(store) in
   // Note: this is equivalent to checking that the number of votes placed is
   // bigger or equal than the total supply of frozen tokens multiplied by the
   // quorum_threshold proportion.
-  let reached_quorum = {numerator = votes_placed; denominator = total_supply} in
-  is_ge_qt(reached_quorum, quorum_threshold)
+  let reached_quorum = (votes_placed * quorum_denominator) / total_supply in
+  (reached_quorum >= proposal.quorum_threshold.numerator)
 
 // Delete a proposal from 'sProposalKeyListSortByDate'
 [@inline]
@@ -340,6 +362,64 @@ let delete_proposal
   { store with proposal_key_list_sort_by_date =
     Set.remove (start_date, proposal_key) store.proposal_key_list_sort_by_date
   }
+
+[@inline]
+let fraction_to_quorum_fraction(n, d : nat * nat): unsigned_quorum_fraction
+  = { numerator = (n * quorum_denominator) / d }
+
+[@inline]
+let to_signed(n : unsigned_quorum_fraction): quorum_fraction
+  = { numerator = int(n.numerator) }
+
+[@inline]
+let to_unsigned(n : quorum_fraction): unsigned_quorum_fraction
+  = { numerator = match is_nat(n.numerator) with
+              | Some n -> n
+              | None -> (failwith("BAD_UNSIGNED_CONVERSION"):nat)
+    }
+
+let update_quorum(store, config : storage * config): storage =
+  let current_period = get_current_period_num(store.start_time, config.voting_period) in
+  let current_cycle = period_to_cycle(current_period) in
+  if store.quorum_threshold_at_cycle.last_updated_cycle = current_cycle
+    then store // Quorum has been updated in this period, so no change is required.
+    else
+      if current_cycle > store.quorum_threshold_at_cycle.last_updated_cycle
+          then
+              let previous_staked = store.quorum_threshold_at_cycle.staked in
+              let previous_participation = to_signed(fraction_to_quorum_fraction(previous_staked, config.governance_total_supply)) in
+              let old_quorum = to_signed(store.quorum_threshold_at_cycle.quorum_threshold) in
+              let quorum_change = to_signed(config.quorum_change) in
+              let possible_new_quorum =
+                // old_quorum + (previous_participation - old_quorum) * quorum_change
+                fadd(old_quorum, fmul(quorum_change, fsub(previous_participation, old_quorum))) in
+              let one_plus_max_change_percent = to_signed({ numerator = config.max_quorum_change.numerator + quorum_denominator }) in
+              let min_new_quorum =
+                fdiv(old_quorum, one_plus_max_change_percent) in
+              let max_new_quorum =
+                fmul(old_quorum, one_plus_max_change_percent) in
+
+              let config_min_qt = to_signed(config.min_quorum_threshold) in
+              let config_max_qt = to_signed(config.max_quorum_threshold) in
+              let new_quorum = bound_qt(bound_qt(possible_new_quorum, min_new_quorum, max_new_quorum), config_min_qt, config_max_qt)
+              in { store with quorum_threshold_at_cycle =
+                   { quorum_threshold = to_unsigned(new_quorum)
+                   ; last_updated_cycle = current_cycle
+                   ; staked = 0n;
+                   }
+                 }
+            else store
+
+let propose (param, config, store : propose_params * config * storage): return =
+  let store = check_is_proposal_valid (config, param, store) in
+  let store = check_proposal_limit_reached (config, store) in
+  let amount_to_freeze = param.frozen_token + config.fixed_proposal_fee_in_token in
+  let store = update_quorum(store, config) in
+  let store = stake_tk(amount_to_freeze, Tezos.sender, config.voting_period, store) in
+  let store = add_proposal (param, config.voting_period, store) in
+  ( ([] : operation list)
+  , store
+  )
 
 [@inline]
 let handle_proposal_is_over
@@ -356,7 +436,7 @@ let handle_proposal_is_over
       && counter.current < counter.total // not finished
     then
       let counter = { counter with current = counter.current + 1n } in
-      let cond =    do_total_vote_meet_quorum_threshold(proposal, store, config.quorum_threshold)
+      let cond =    do_total_vote_meet_quorum_threshold(proposal, store)
                 && proposal.upvotes > proposal.downvotes
       in
       let store = unfreeze_proposer_and_voter_token
@@ -417,7 +497,6 @@ let drop_proposal (proposal_key, config, store : proposal_key * config * storage
     (([] : operation list), store)
   else
     (failwith("DROP_PROPOSAL_CONDITION_NOT_MET") : return)
-
 
 let freeze (amt, config, store : freeze_param * config * storage) : return =
   let addr = Tezos.sender in


### PR DESCRIPTION
## Description

Problem: We should implement the dynamic update of the quorum threshold
based on the previous participation.

Solution: Introduce the concept of cycle, which is a proposing, voting
period pair. Then track the number of staked tokens in each cycle, and
use it to calculate the new value of quorum-threshold at the very first
propose call in each cycle. Since proposal can be flushed long after the
cycle in which it was proposed, we also store the quorum threshold for
the proposal cycle in the proposals. We use this stored quorum threshold
while evaluating the votes for this proposal.

Another main change in this PR is that we have stopped storing the
denominator for the fractions. This is to simplify the calculations,
mostly in update quorum procedure, and also to round off fractions to
the required precision.

Also updates documentation and specs.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #207 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
