### PR TITLE
[#215] Accept admin privilege without accept_owenership if new owner if contract itself

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -619,6 +619,8 @@ Parameter (in Michelson):
 
 - When pending administrator is not set, it is considered equal to the current owner, thus administrator can accept ownership of its own contract without a prior `transfer_ownership` call.
 
+- If the new owner is the BaseDAO contract itself, the admin is set right away, without the need for a call to 'accept_ownership' entrypoint.
+
 ## Proposal entrypoints
 
 ### **propose**

--- a/src/management.mligo
+++ b/src/management.mligo
@@ -13,7 +13,12 @@
 let transfer_ownership
     (param, store : transfer_ownership_param * storage) : return =
       let store = authorize_admin(store) in
-        (([] : operation list), { store with pending_owner = param ; })
+      let store =
+        if Tezos.self_address = param
+          then { store with admin = param ; } // If new admin is address of baseDAO,
+                                              // set as admin right away.
+          else { store with pending_owner = param ; }
+      in (([] : operation list), store)
 
 (*
  * Auth check for pending admin and copies the value in 'pending_owner' field


### PR DESCRIPTION
Problem: In this issue, we are required to modify the behavior of
transfer_ownership entrypoint such that the new admin is set without
having to call accept_ownership call, if the new owner is the address of
the contract itsef.

Soltution: Implement the behavior and update tests and docs.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
