### PR TITLE
Fix stages cycle to match the specification

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -182,8 +182,14 @@ The contract constantly cycles between two stages, a proposing stage and a votin
 Both have the same same length, `voting_period` and alternate between each other,
 starting from "voting" for period number `0`.
 
+The voting period is specified for the whole smart contract and never changes.
+
 Tokens can be frozen in any period, but they can only be used for voting, proposing
 and unfreezing starting from the following one and onwards.
+
+For this reason the contract starts from a `voting` stage, because even tho there
+are no proposals to vote on yet, this allows token to be frozen in it and be
+usable in the first `proposing` stage, number `1`.
 
 For freezing, the address should have corresponding amount of tokens of proper
 token type (token_id of storage.governance_token.token_id) in the governance
@@ -216,7 +222,7 @@ One frozen token is required for one vote.
 A vote can only be cast in a voting stage period, meaning one that's even-numbered.
 Moreover the proposal to vote on must have been submitted in the proposing period immediately preceding
 and the voter must have frozen his tokens in one of the preceding periods.
-Voting period is specified for the whole smart contract and can be updated by the administrator; on update, the existing proposals are also affected.
+
 It's possible to vote positively or negatively.
 After the voting ends, the contract is "flushed" by calling a dedicated entrypoint.
 
@@ -666,7 +672,6 @@ have the same timestamp due to being in the same block, are processed in the ord
   - If proposal got accepted:
     - The return amount for the proposer is equal to or less than the sum of the proposer frozen tokens and the fee paid for the proposal.
     - The return amount for each voters is equal to or less than the voter's frozen tokens.
-- The lost of frozen tokens is due to the fact that the administrator has the right to `transfer` frozen tokens of any proposers or voters.
 - If proposal is accepted, decision lambda is called.
 
 ### **drop_proposal**

--- a/haskell/test/Test/Ligo/BaseDAO/Common.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Common.hs
@@ -40,7 +40,6 @@ import Lorentz.Test (contractConsumer)
 import Michelson.Typed.Convert (convertContract, untypeValue)
 import Morley.Nettest
 import Named ((!))
-import Time (sec)
 import Util.Named
 
 import qualified Data.Map as M
@@ -258,17 +257,12 @@ originateLigoDao =
 
 createSampleProposal
   :: (MonadNettest caps base m, HasCallStack)
-  => Int -> Int -> Address -> TAddress Parameter -> m ProposalKey
-createSampleProposal counter vp owner1 dao = do
+  => Int -> Address -> TAddress Parameter -> m ProposalKey
+createSampleProposal counter owner1 dao = do
   let params = ProposeParams
         { ppFrozenToken = 10
         , ppProposalMetadata = lPackValueRaw @Integer $ fromIntegral counter
         }
-
-  when (vp > 0) $ do
-    withSender (AddressResolved owner1) $
-      call dao (Call @"Freeze") (#amount .! 10)
-    advanceTime (sec (fromIntegral vp))
 
   withSender (AddressResolved owner1) $ call dao (Call @"Propose") params
   pure $ (makeProposalKey params owner1)

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -63,13 +63,11 @@ validProposal = uncapsNettest $ withFrozenCallStack do
         }
     proposalSize = metadataSize proposalMeta -- 115
 
-  -- Advance one voting period.
-  advanceTime (sec 10)
-
+  -- Freeze in voting stage.
   withSender (AddressResolved owner1) $
     call dao (Call @"Freeze") (#amount .! proposalSize)
 
-  -- Advance one voting period.
+  -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
 
   withSender (AddressResolved owner1) $
@@ -103,9 +101,8 @@ flushTokenTransfer = uncapsNettest $ withFrozenCallStack $ do
   withSender (AddressResolved owner2) $
     call dao (Call @"Freeze") (#amount .! 20)
 
-  -- Advance two voting periods so that we are in a
-  -- proposal period.
-  advanceTime (sec 20)
+  -- Advance one voting periods to a proposing stage.
+  advanceTime (sec 10)
 
   withSender (AddressResolved owner1) $
     call dao (Call @"Propose") proposeParams
@@ -120,8 +117,10 @@ flushTokenTransfer = uncapsNettest $ withFrozenCallStack $ do
         , vProposalKey = key1
         }
 
+  -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
   withSender (AddressResolved owner2) $ call dao (Call @"Vote") [upvote]
+  -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
   withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
 
@@ -144,13 +143,13 @@ flushXtzTransfer = uncapsNettest $ withFrozenCallStack $ do
         }
     proposeParams amt = ProposeParams (metadataSize $ proposalMeta amt) $ proposalMeta amt
 
-  advanceTime (sec 10)
+  -- Freeze in initial voting stage.
   withSender (AddressResolved owner1) $
     call dao (Call @"Freeze") (#amount .! (metadataSize $ proposalMeta 3))
 
   withSender (AddressResolved owner2) $
     call dao (Call @"Freeze") (#amount .! 10)
-  -- Advance one voting period.
+  -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
 
   withSender (AddressResolved owner1) $ do
@@ -174,8 +173,10 @@ flushXtzTransfer = uncapsNettest $ withFrozenCallStack $ do
         , vProposalKey = key1
         }
 
+  -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
   withSender (AddressResolved owner2) $ call dao (Call @"Vote") [upvote]
+  -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
   withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
 

--- a/src/proposal.mligo
+++ b/src/proposal.mligo
@@ -43,7 +43,7 @@ let ensure_proposal_voting_period (proposal, voting_period, store : proposal * v
 // Only odd period numbers are proposing periods, in which a proposal can be
 // submitted.
 let ensure_proposing_period(period_num, store : nat * storage): storage =
-  if (period_num mod 2n) = 0n
+  if (period_num mod 2n) = 1n
   then store
   else (failwith("NOT_PROPOSING_PERIOD") : storage)
 


### PR DESCRIPTION
## Description

Problem: there is a discrepancy between the specifiction and the
implementation (and tests) for the cycles: in the spec we say that
proposals stages are only odd and voting ones even, but the contract
behaves in the opposite way.

Solution: it seems to be more sensible to follow the specification,
although the current implementation is just as valid of an option, so
the contract code and tests are updated.
Additionally, tests have been commented more to show this more clearly.

## Related issue(s)

None

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
