### PR TITLE
[#230] Fix Makefile to use proper current timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ endif
 $(OUT)/trivialDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
 $(OUT)/trivialDAO_storage.tz : governance_token_address = KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5
 $(OUT)/trivialDAO_storage.tz : governance_token_id = 0n
-$(OUT)/trivialDAO_storage.tz : now_val = Tezos.now
+$(OUT)/trivialDAO_storage.tz : now_val = `date +"%s"`
 $(OUT)/trivialDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/trivialDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/trivialDAO_storage.tz : ledger = ([] : ledger_list)
@@ -86,7 +86,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
             { address = (\"$(governance_token_address)\" : address) \
             ; token_id = $(governance_token_id) \
             } \
-          ; now_val = $(now_val) \
+          ; now_val = ($(now_val) : timestamp)  \
           ; metadata_map = $(call escape_double_quote,$(metadata_map)) \
           ; ledger_lst = $(call escape_double_quote,$(ledger)) \
           } \
@@ -110,7 +110,7 @@ $(OUT)/registryDAO_storage.tz : slash_scale_value = 1n
 $(OUT)/registryDAO_storage.tz : slash_division_value = 0n
 $(OUT)/registryDAO_storage.tz : min_xtz_amount = 0mutez
 $(OUT)/registryDAO_storage.tz : max_xtz_amount = 100mutez
-$(OUT)/registryDAO_storage.tz : now_val = Tezos.now
+$(OUT)/registryDAO_storage.tz : now_val = `date +"%s"`
 $(OUT)/registryDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/registryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/registryDAO_storage.tz : ledger = ([] : ledger_list)
@@ -128,7 +128,7 @@ $(OUT)/registryDAO_storage.tz: src/**
               { address = (\"$(governance_token_address)\" : address) \
               ; token_id = $(governance_token_id) \
               } \
-            ; now_val = $(now_val) \
+            ; now_val = ($(now_val) : timestamp)  \
             ; metadata_map = $(call escape_double_quote,$(metadata_map)) \
             ; ledger_lst = $(call escape_double_quote,$(ledger)) \
             } \
@@ -160,7 +160,7 @@ $(OUT)/treasuryDAO_storage.tz : slash_scale_value = 0n
 $(OUT)/treasuryDAO_storage.tz : slash_division_value = 0n
 $(OUT)/treasuryDAO_storage.tz : min_xtz_amount = 0mutez
 $(OUT)/treasuryDAO_storage.tz : max_xtz_amount = 100mutez
-$(OUT)/treasuryDAO_storage.tz : now_val = Tezos.now
+$(OUT)/treasuryDAO_storage.tz : now_val = `date +"%s"`
 $(OUT)/treasuryDAO_storage.tz : metadata_map = (Big_map.empty : metadata_map)
 $(OUT)/treasuryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/treasuryDAO_storage.tz : ledger = ([] : ledger_list)
@@ -178,7 +178,7 @@ $(OUT)/treasuryDAO_storage.tz: src/**
               { address = (\"$(governance_token_address)\" : address) \
               ; token_id =  $(governance_token_id) \
               } \
-            ; now_val = $(now_val) \
+            ; now_val = ($(now_val) : timestamp)  \
             ; metadata_map = $(call escape_double_quote,$(metadata_map)) \
             ; ledger_lst = $(call escape_double_quote,$(ledger)) \
             } \

--- a/docs/building.md
+++ b/docs/building.md
@@ -47,7 +47,7 @@ make out/trivialDAO_storage.tz \
   admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" \
   governance_token_address="KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5" \
   governance_token_id=0n \
-  now_val=Tezos.now \
+  now_val = `date +"%s"` \
   metadata_map=(Big_map.empty : metadata_map)
   fixed_proposal_fee_in_token=0n \
   ledger=([] : ledger_list) \
@@ -78,7 +78,7 @@ make out/registryDAO_storage.tz \
   slash_division_value=-n \
   min_xtz_amount=0mutez \
   max_xtz_amount=100mutez \
-  now_val=Tezos.now \
+  now_val = `date +"%s"` \
   metadata_map=(Big_map.empty : metadata_map) \
   fixed_proposal_fee_in_token=0n \
   ledger=([] : ledger_list) \
@@ -105,7 +105,7 @@ make out/treasuryDAO_storage.tz \
   slash_division_value=1n \
   min_xtz_amount=0mutez \
   max_xtz_amount=100mutez \
-  now_val=Tezos.now \
+  now_val = `date +"%s"` \
   metadata_map=(Big_map.empty : metadata_map)
   fixed_proposal_fee_in_token=0n \
   ledger=([] : ledger_list) \


### PR DESCRIPTION
## Description

Problem: In the storage generation section of Makefile we use
'Tezos.now' to fetch the current timestamp. But it appears that the
'ligo compile' command is not able to fetch the current timestamp
properly.

Solution: Use the 'date' command from environment to fetch the unix
timestamp and use it as a timestamp during storage generation.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #230 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
