### PR TITLE
[#87] Improve handling of failed proposals (2nd Approach)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ endif
 	#
 
 $(OUT)/trivialDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
+$(OUT)/trivialDAO_storage.tz : guardian_address = KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh
 $(OUT)/trivialDAO_storage.tz : governance_token_address = KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5
 $(OUT)/trivialDAO_storage.tz : governance_token_id = 0n
 $(OUT)/trivialDAO_storage.tz : now_val = `date +"%s"`
@@ -75,6 +76,8 @@ $(OUT)/trivialDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/trivialDAO_storage.tz : ledger = ([] : ledger_list)
 $(OUT)/trivialDAO_storage.tz : quorum_threshold = {numerator = 1n; denominator = 10n}
 $(OUT)/trivialDAO_storage.tz : voting_period = 950400n # 11 days
+$(OUT)/trivialDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
+$(OUT)/trivialDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
 $(OUT)/trivialDAO_storage.tz: src/**
 	# ============== Compiling TrivialDAO storage ============== #
 	mkdir -p $(OUT)
@@ -82,6 +85,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
       src/base_DAO.mligo base_DAO_contract "default_full_storage( \
         { storage_data = \
           { admin = (\"$(admin_address)\" : address) \
+          ; guardian = (\"$(guardian_address)\" : address) \
           ; governance_token = \
             { address = (\"$(governance_token_address)\" : address) \
             ; token_id = $(governance_token_id) \
@@ -92,6 +96,8 @@ $(OUT)/trivialDAO_storage.tz: src/**
           } \
         ; config_data = \
           { voting_period = { length = $(voting_period) } \
+          ; proposal_flush_time = $(proposal_flush_time) \
+          ; proposal_expired_time = $(proposal_expired_time) \
           ; quorum_threshold = $(quorum_threshold) \
           ; fixed_proposal_fee_in_token = $(fixed_proposal_fee_in_token) \
           } \
@@ -101,6 +107,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
 	#
 
 $(OUT)/registryDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
+$(OUT)/registryDAO_storage.tz : guardian_address = KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh
 $(OUT)/registryDAO_storage.tz : governance_token_address = KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5
 $(OUT)/registryDAO_storage.tz : governance_token_id = 0n
 $(OUT)/registryDAO_storage.tz : frozen_scale_value = 1n
@@ -116,6 +123,8 @@ $(OUT)/registryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/registryDAO_storage.tz : ledger = ([] : ledger_list)
 $(OUT)/registryDAO_storage.tz : quorum_threshold = {numerator = 1n; denominator = 10n}
 $(OUT)/registryDAO_storage.tz : voting_period = 950400n # 11 days
+$(OUT)/registryDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
+$(OUT)/registryDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
 $(OUT)/registryDAO_storage.tz: src/**
 	# ============== Compiling RegistryDAO storage ============== #
 	mkdir -p $(OUT)
@@ -124,6 +133,7 @@ $(OUT)/registryDAO_storage.tz: src/**
         { base_data = \
           { storage_data = \
             { admin = (\"$(admin_address)\" : address) \
+            ; guardian = (\"$(guardian_address)\" : address) \
             ; governance_token = \
               { address = (\"$(governance_token_address)\" : address) \
               ; token_id = $(governance_token_id) \
@@ -135,6 +145,8 @@ $(OUT)/registryDAO_storage.tz: src/**
           ; config_data = \
             { quorum_threshold = $(quorum_threshold) \
             ; voting_period = { length = $(voting_period) } \
+            ; proposal_flush_time = $(proposal_flush_time) \
+            ; proposal_expired_time = $(proposal_expired_time) \
             ; fixed_proposal_fee_in_token = $(fixed_proposal_fee_in_token) \
             } \
           } \
@@ -151,6 +163,7 @@ $(OUT)/registryDAO_storage.tz: src/**
 	#
 
 $(OUT)/treasuryDAO_storage.tz : admin_address = tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af
+$(OUT)/treasuryDAO_storage.tz : guardian_address = KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh
 $(OUT)/treasuryDAO_storage.tz : governance_token_address = KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5
 $(OUT)/treasuryDAO_storage.tz : governance_token_id = 0n
 $(OUT)/treasuryDAO_storage.tz : frozen_scale_value = 0n
@@ -166,6 +179,8 @@ $(OUT)/treasuryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
 $(OUT)/treasuryDAO_storage.tz : ledger = ([] : ledger_list)
 $(OUT)/treasuryDAO_storage.tz : quorum_threshold = {numerator = 1n; denominator = 10n}
 $(OUT)/treasuryDAO_storage.tz : voting_period = 950400n # 11 days
+$(OUT)/treasuryDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
+$(OUT)/treasuryDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
 $(OUT)/treasuryDAO_storage.tz: src/**
 	# ============== Compiling TreasuryDAO storage ============== #
 	mkdir -p $(OUT)
@@ -174,6 +189,7 @@ $(OUT)/treasuryDAO_storage.tz: src/**
         { base_data = \
           { storage_data = \
             { admin = (\"$(admin_address)\" : address) \
+            ; guardian = (\"$(guardian_address)\" : address) \
             ; governance_token = \
               { address = (\"$(governance_token_address)\" : address) \
               ; token_id =  $(governance_token_id) \
@@ -185,6 +201,8 @@ $(OUT)/treasuryDAO_storage.tz: src/**
           ; config_data = \
             { quorum_threshold = $(quorum_threshold) \
             ; voting_period = { length = $(voting_period) } \
+            ; proposal_flush_time = $(proposal_flush_time) \
+            ; proposal_expired_time = $(proposal_expired_time) \
             ; fixed_proposal_fee_in_token = $(fixed_proposal_fee_in_token) \
             } \
           } \

--- a/docs/building.md
+++ b/docs/building.md
@@ -45,6 +45,7 @@ This storage is the one based on the [default storage values](../src/defaults.ml
 ```sh
 make out/trivialDAO_storage.tz \
   admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" \
+  guardian_address = "KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh" \
   governance_token_address="KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5" \
   governance_token_id=0n \
   now_val = `date +"%s"` \
@@ -53,6 +54,8 @@ make out/trivialDAO_storage.tz \
   ledger=([] : ledger_list) \
   quorum_threshold={numerator=1n; denominator=10n} \
   voting_period=950400n \
+  proposal_flush_time = 1900801n \
+  proposal_expired_time = 2851200n \
   metadata_map=(Big_map.empty : metadata_map) \
 ```
 
@@ -69,6 +72,7 @@ compiled with `make`, as usual:
 ```sh
 make out/registryDAO_storage.tz \
   admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" \
+  guardian_address = "KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh" \
   governance_token_address="KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5" \
   governance_token_id=0n \
   max_proposal_size=100n \
@@ -83,7 +87,9 @@ make out/registryDAO_storage.tz \
   fixed_proposal_fee_in_token=0n \
   ledger=([] : ledger_list) \
   quorum_threshold={numerator=1n; denominator=10n} \
-  voting_period=950400n
+  voting_period=950400n \
+  proposal_flush_time = 1900801n \
+  proposal_expired_time = 2851200n
 ```
 
 All its arguments are optional and will be equal to the values above if not
@@ -96,6 +102,7 @@ can be compiled once again with `make`:
 ```sh
 make out/treasuryDAO_storage.tz \
   admin_address="tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af" \
+  guardian_address = "KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh" \
   governance_token_address="KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5" \
   governance_token_id=0n \
   max_proposal_size=12n \
@@ -111,6 +118,8 @@ make out/treasuryDAO_storage.tz \
   ledger=([] : ledger_list) \
   quorum_threshold={numerator=1n; denominator=10n} \
   voting_period=950400n \
+  proposal_flush_time = 1900801n \
+  proposal_expired_time = 2851200n \
   metadata_map=(Big_map.empty : metadata_map) \
 ```
 

--- a/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/Types.hs
@@ -822,7 +822,14 @@ type instance ErrorArg "dROP_PROPOSAL_CONDITION_NOT_MET" = NoErrorArg
 instance CustomErrorHasDoc "dROP_PROPOSAL_CONDITION_NOT_MET" where
   customErrClass = ErrClassActionException
   customErrDocMdCause =
-    "Throw when trying to call `drop_proposal` when the sender is not proposer or guardian or proposal is not expired."
+    "Throw when calling `drop_proposal` when the sender is not proposer or guardian and proposal is not expired."
+
+type instance ErrorArg "eXPIRED_PROPOSAL" = NoErrorArg
+
+instance CustomErrorHasDoc "eXPIRED_PROPOSAL" where
+  customErrClass = ErrClassActionException
+  customErrDocMdCause =
+    "Throw when trying to `flush` expired proposals."
 
 type instance ErrorArg "nEGATIVE_TOTAL_SUPPLY" = ()
 

--- a/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
@@ -43,7 +43,7 @@ checkFreezeHistoryTracking  = do
   now <- use isNow
 
   withOriginated 2 (\(admin:_) -> do
-    tokenContract <- lOriginate dummyFA2Contract "TokenContract" [] (toMutez 0)
+    dodTokenContract <- lOriginate dummyFA2Contract "TokenContract" [] (toMutez 0)
     pure $ mkFullStorage
       ! #admin admin
       ! #votingPeriod 10
@@ -51,7 +51,7 @@ checkFreezeHistoryTracking  = do
       ! #extra dynRecUnsafe
       ! #metadata mempty
       ! #now now
-      ! #tokenAddress (unTAddress tokenContract)
+      ! #tokenAddress (unTAddress dodTokenContract)
       ! #customEps mempty
     ) $ \(admin:wallet1:_) baseDao -> let
       proposalMeta1 = ""

--- a/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Integrational/Proposal.hs
@@ -78,7 +78,7 @@ checkFreezeHistoryTracking  = do
             when (fh /= (Just expected)) $ Left $ CustomTestError "BaseDAO contract did not stake tokens as expected"
 
         -- Advance two voting periods to another proposing stage.
-        rewindTime 20
+        rewindTime 21
 
         tTransfer  (#from .! admin) (#to .! (unTAddress baseDao)) zeroMutez (unsafeBuildEpName "flush") (toVal (1 :: Natural))
 

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -105,7 +105,7 @@ test_BaseDAO_Proposal =
       , nettestScenarioOnEmulator "flush with bad cRejectedProposalReturnValue" $
           \_emulated ->
             uncapsNettest $ flushWithBadConfig (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      -- TODO [#15]: admin burn proposer token and test "flush"
+      -- TODO [#15]: dodAdmin burn proposer token and test "flush"
 
       -- TODO [#38]: Improve this when contract size is smaller
       , nettestScenarioOnEmulator "flush and run decision lambda" $
@@ -140,31 +140,33 @@ test_BaseDAO_Proposal =
 
  , testGroup "LIGO-specific proposal tests:"
     [ nettestScenarioOnEmulatorCaps "can propose a valid proposal with a fixed fee" $ do
-        ((proposer, _), _, dao, _, _) <-
+        DaoOriginateData{..} <-
           originateLigoDaoWithConfigDesc dynRecUnsafe (ConfigDesc (FixedFee 42))
         let params = ProposeParams
               { ppFrozenToken = 10
               , ppProposalMetadata = lPackValueRaw @Integer 1
               }
+        let proposer = dodOwner1
 
         withSender (AddressResolved proposer) $
-          call dao (Call @"Freeze") (#amount .! 52)
+          call dodDao (Call @"Freeze") (#amount .! 52)
         -- Advance one voting period to a proposing stage.
         advanceTime (sec 10)
 
-        withSender (AddressResolved proposer) $ call dao (Call @"Propose") params
-        checkTokenBalance frozenTokenId dao proposer 152
+        withSender (AddressResolved proposer) $ call dodDao (Call @"Propose") params
+        checkTokenBalance frozenTokenId dodDao proposer 152
 
-        totalSupply <- getTotalSupplyEmulator (AddressResolved $ unTAddress dao) frozenTokenId
+        totalSupply <- getTotalSupplyEmulator (AddressResolved $ unTAddress dodDao) frozenTokenId
         totalSupply @== 252 -- initial = 0
 
     , nettestScenarioOnEmulator "cannot propose with insufficient tokens to pay the fee" $
         \_emulated -> uncapsNettest $ do
-          ((proposer, _), _, dao, _, _) <-
+          DaoOriginateData{..} <-
             originateLigoDaoWithConfigDesc dynRecUnsafe (ConfigDesc (FixedFee 100))
+          let proposer = dodOwner1
 
           withSender (AddressResolved proposer) $
-            call dao (Call @"Freeze") (#amount .! 52)
+            call dodDao (Call @"Freeze") (#amount .! 52)
           -- Advance one voting period to a proposing stage.
           advanceTime (sec 10)
 
@@ -172,31 +174,33 @@ test_BaseDAO_Proposal =
                 { ppFrozenToken = 1
                 , ppProposalMetadata = lPackValueRaw @Integer 1
                 }
-          withSender (AddressResolved proposer) $ call dao (Call @"Propose") params
-            & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dao
+          withSender (AddressResolved proposer) $ call dodDao (Call @"Propose") params
+            & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dodDao
 
     , nettestScenarioOnEmulator "a proposer is returned a fee after the proposal succeeds" $
         \_emulated -> uncapsNettest $ do
-          ((proposer, _), (voter, _), dao, _, admin) <-
+          DaoOriginateData{..} <-
             originateLigoDaoWithConfigDesc dynRecUnsafe
               (   (ConfigDesc $ VotingPeriod 60)
               >>- (ConfigDesc configConsts{ cmProposalFlushTime = Just 120 })
               >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 180 })
               >>- (ConfigDesc (FixedFee 42))
               )
+          let proposer = dodOwner1
+          let voter = dodOwner2
 
           withSender (AddressResolved voter) $
-            call dao (Call @"Freeze") (#amount .! 20)
+            call dodDao (Call @"Freeze") (#amount .! 20)
 
           withSender (AddressResolved proposer) $
-            call dao (Call @"Freeze") (#amount .! 42)
+            call dodDao (Call @"Freeze") (#amount .! 42)
 
           withSender (AddressResolved proposer) $
-            call dao (Call @"Freeze") (#amount .! 10)
+            call dodDao (Call @"Freeze") (#amount .! 10)
 
           -- Advance one voting period to a proposing stage.
           advanceTime (sec 60)
-          key1 <- createSampleProposal 1 proposer dao
+          key1 <- createSampleProposal 1 proposer dodDao
           -- Advance one voting period to a voting stage.
           advanceTime (sec 60)
           let vote_ =
@@ -206,16 +210,16 @@ test_BaseDAO_Proposal =
                   , vProposalKey = key1
                   }
           withSender (AddressResolved voter) $
-            call dao (Call @"Vote") [vote_]
+            call dodDao (Call @"Vote") [vote_]
 
           let expectedFrozen = 100 + 42 + 10
-          checkTokenBalance frozenTokenId dao proposer expectedFrozen
+          checkTokenBalance frozenTokenId dodDao proposer expectedFrozen
 
           -- Advance one voting period to a proposing stage.
           advanceTime (sec 60)
-          withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
+          withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
 
-          checkTokenBalance frozenTokenId dao proposer 152
+          checkTokenBalance frozenTokenId dodDao proposer 152
 
     , nettestScenarioOnEmulator "the fee is burned if the proposal fails" $
         \_emulated -> uncapsNettest $ burnsFeeOnFailure Downvoted
@@ -229,10 +233,10 @@ nonProposalPeriodProposal
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 nonProposalPeriodProposal originateFn = do
-  ((owner1, _), _, dao, _, _) <- originateFn testConfig
+  DaoOriginateData{..} <- originateFn testConfig
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance two voting periods to another voting stage.
   advanceTime (sec 20)
@@ -242,140 +246,142 @@ nonProposalPeriodProposal originateFn = do
         , ppProposalMetadata = lPackValueRaw @Integer 1
         }
 
-  withSender (AddressResolved owner1) $ call dao (Call @"Propose") params
-    & expectCustomErrorNoArg #nOT_PROPOSING_PERIOD dao
+  withSender (AddressResolved dodOwner1) $ call dodDao (Call @"Propose") params
+    & expectCustomErrorNoArg #nOT_PROPOSING_PERIOD dodDao
 
 freezeTokens
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 freezeTokens originateFn = do
-  ((owner1, _), _, dao, tokenContract, _) <- originateFn testConfig
+  DaoOriginateData{..} <- originateFn testConfig
 
-  withSender (AddressResolved owner1) $ call dao (Call @"Freeze") (#amount .! 10)
-  checkTokenBalance frozenTokenId dao owner1 110
+  withSender (AddressResolved dodOwner1) $ call dodDao (Call @"Freeze") (#amount .! 10)
+  checkTokenBalance frozenTokenId dodDao dodOwner1 110
   -- Check that the FA2 token got a transfer call as expected.
-  checkStorage (AddressResolved $ unTAddress tokenContract)
+  checkStorage (AddressResolved $ unTAddress dodTokenContract)
     (toVal [[FA2.TransferItem
-      { tiFrom = owner1
-      , tiTxs = [FA2.TransferDestination { tdTo = unTAddress dao, tdTokenId = FA2.theTokenId, tdAmount = 10 }]
+      { tiFrom = dodOwner1
+      , tiTxs = [FA2.TransferDestination { tdTo = unTAddress dodDao, tdTokenId = FA2.theTokenId, tdAmount = 10 }]
       }]])
 
 burnsFeeOnFailure
   :: forall caps base m. (MonadNettest caps base m)
   => FailureReason -> m ()
 burnsFeeOnFailure reason = do
-  ((proposer, _), (voter, _), dao, _, admin) <-
+  DaoOriginateData{..} <-
       originateLigoDaoWithConfigDesc dynRecUnsafe
         (   (ConfigDesc $ VotingPeriod 60)
         >>- (ConfigDesc configConsts{ cmProposalFlushTime = Just 120 })
         >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 180 })
         >>- (ConfigDesc $ FixedFee 42)
         )
+  let proposer = dodOwner1
+  let voter = dodOwner2
 
   withSender (AddressResolved proposer) $
-    call dao (Call @"Freeze") (#amount .! 42)
+    call dodDao (Call @"Freeze") (#amount .! 42)
 
   withSender (AddressResolved voter) $
-    call dao (Call @"Freeze") (#amount .! 1)
+    call dodDao (Call @"Freeze") (#amount .! 1)
 
   withSender (AddressResolved proposer) $
-    call dao (Call @"Freeze") (#amount .! 10)
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 61)
-  key1 <- createSampleProposal 1 proposer dao
+  key1 <- createSampleProposal 1 proposer dodDao
 
   -- Advance one voting period to a voting stage.
   advanceTime (sec 60)
   case reason of
     Downvoted -> do
       withSender (AddressResolved voter) $
-        call dao (Call @"Vote") [downvote key1]
+        call dodDao (Call @"Vote") [downvote key1]
     QuorumNotMet -> return ()
 
   let expectedFrozen = 100 + 42 + 10
-  checkTokenBalance frozenTokenId dao proposer expectedFrozen
+  checkTokenBalance frozenTokenId dodDao proposer expectedFrozen
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 61)
-  withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
 
   -- Tokens frozen with the proposal are returned as unstaked (but still
   -- frozen), except for the fee and slash amount. The latter is zero in this
   -- case, so we expect 42 tokens to be burnt
   let expectedBurn = 42
-  checkTokenBalance frozenTokenId dao proposer (100 + (52 - expectedBurn))
+  checkTokenBalance frozenTokenId dodDao proposer (100 + (52 - expectedBurn))
 
 cannotUnfreezeFromSamePeriod
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 cannotUnfreezeFromSamePeriod originateFn = do
-  ((owner1, _), _, dao, _, _) <- originateFn testConfig
+  DaoOriginateData{..} <- originateFn testConfig
 
-  withSender (AddressResolved owner1) $ call dao (Call @"Freeze") (#amount .! 10)
-  checkTokenBalance frozenTokenId dao owner1 110
+  withSender (AddressResolved dodOwner1) $ call dodDao (Call @"Freeze") (#amount .! 10)
+  checkTokenBalance frozenTokenId dodDao dodOwner1 110
 
   -- Cannot unfreeze in the same period
-  withSender (AddressResolved owner1) $ call dao (Call @"Unfreeze") (#amount .! 10)
-    & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dao
+  withSender (AddressResolved dodOwner1) $ call dodDao (Call @"Unfreeze") (#amount .! 10)
+    & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dodDao
 
 canUnfreezeFromPreviousPeriod
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 canUnfreezeFromPreviousPeriod originateFn = do
-  ((owner1, _), _, dao, tokenContract, _) <- originateFn testConfig
+  DaoOriginateData{..} <- originateFn testConfig
 
-  withSender (AddressResolved owner1) $ call dao (Call @"Freeze") (#amount .! 10)
-  checkTokenBalance frozenTokenId dao owner1 110
+  withSender (AddressResolved dodOwner1) $ call dodDao (Call @"Freeze") (#amount .! 10)
+  checkTokenBalance frozenTokenId dodDao dodOwner1 110
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 15)
 
-  withSender (AddressResolved owner1) $ call dao (Call @"Unfreeze") (#amount .! 10)
-  checkTokenBalance frozenTokenId dao owner1 100
+  withSender (AddressResolved dodOwner1) $ call dodDao (Call @"Unfreeze") (#amount .! 10)
+  checkTokenBalance frozenTokenId dodDao dodOwner1 100
   -- Check that the FA2 token got a transfer call as expected.
-  checkStorage (AddressResolved $ unTAddress tokenContract)
+  checkStorage (AddressResolved $ unTAddress dodTokenContract)
     (toVal
       [ [ FA2.TransferItem
-        { tiFrom = unTAddress dao
-        , tiTxs = [FA2.TransferDestination { tdTo = owner1, tdTokenId = FA2.theTokenId, tdAmount = 10 }]
+        { tiFrom = unTAddress dodDao
+        , tiTxs = [FA2.TransferDestination { tdTo = dodOwner1, tdTokenId = FA2.theTokenId, tdAmount = 10 }]
         }]
       , [FA2.TransferItem
-        { tiFrom = owner1
-        , tiTxs = [FA2.TransferDestination { tdTo = unTAddress dao, tdTokenId = FA2.theTokenId, tdAmount = 10 }]
+        { tiFrom = dodOwner1
+        , tiTxs = [FA2.TransferDestination { tdTo = unTAddress dodDao, tdTokenId = FA2.theTokenId, tdAmount = 10 }]
       }]])
 
 insufficientTokenProposal
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> (AddressOrAlias -> m Int) -> m ()
 insufficientTokenProposal originateFn getProposalAmountFn = do
-  ((owner1, _), _, dao, _, _) <- originateFn testConfig
+  DaoOriginateData{..} <- originateFn testConfig
   let params = ProposeParams
         { ppFrozenToken = 101
         , ppProposalMetadata = lPackValueRaw @Integer 1
         }
 
-  withSender (AddressResolved owner1) $ call dao (Call @"Propose") params
-    & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dao
-  amt <- getProposalAmountFn (AddressResolved $ unTAddress dao)
+  withSender (AddressResolved dodOwner1) $ call dodDao (Call @"Propose") params
+    & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dodDao
+  amt <- getProposalAmountFn (AddressResolved $ unTAddress dodDao)
   amt @== 0
 
 insufficientTokenVote
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 insufficientTokenVote originateFn = do
-  ((owner1, _), (owner2, _), dao, _, _) <- originateFn voteConfig
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 100)
+  DaoOriginateData{..} <- originateFn voteConfig
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 100)
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
 
   -- Create sample proposal
-  key1 <- createSampleProposal 1 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
   let params = fmap NoPermit
         [ VoteParam
             { vVoteType = True
@@ -391,24 +397,24 @@ insufficientTokenVote originateFn = do
   -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
 
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") params
-    & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dao
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") params
+    & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dodDao
 
 voteWithPermit
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 voteWithPermit originateFn = do
-  ((owner1, _), (owner2, _), dao, _, _) <- originateFn voteConfig
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 12)
+  DaoOriginateData{..} <- originateFn voteConfig
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 12)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
 
   -- Create sample proposal
-  key1 <- createSampleProposal 1 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
 
-  params <- permitProtect (AddressResolved owner1) =<< addDataToSign dao (Nonce 0)
+  params <- permitProtect (AddressResolved dodOwner1) =<< addDataToSign dodDao (Nonce 0)
         VoteParam
         { vVoteType = True
         , vVoteAmount = 2
@@ -418,27 +424,27 @@ voteWithPermit originateFn = do
   -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
 
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") [params]
-  checkTokenBalance frozenTokenId dao owner1 112
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") [params]
+  checkTokenBalance frozenTokenId dodDao dodOwner1 112
 
 voteWithPermitNonce
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> GetVotePermitsCounterFn m -> m ()
 voteWithPermitNonce originateFn getVotePermitsCounterFn = do
 
-  ((owner1, _), (owner2, _), dao, _, _) <- originateFn voteConfig
+  DaoOriginateData{..} <- originateFn voteConfig
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 60)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 60)
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 50)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 50)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
 
   -- Create sample proposal
-  key1 <- createSampleProposal 1 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   let voteParam = VoteParam
         { vVoteType = True
@@ -449,63 +455,63 @@ voteWithPermitNonce originateFn getVotePermitsCounterFn = do
   -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
   -- Going to try calls with different nonces
-  signed1@(_          , _) <- addDataToSign dao (Nonce 0) voteParam
-  signed2@(dataToSign2, _) <- addDataToSign dao (Nonce 1) voteParam
-  signed3@(_          , _) <- addDataToSign dao (Nonce 2) voteParam
+  signed1@(_          , _) <- addDataToSign dodDao (Nonce 0) voteParam
+  signed2@(dataToSign2, _) <- addDataToSign dodDao (Nonce 1) voteParam
+  signed3@(_          , _) <- addDataToSign dodDao (Nonce 2) voteParam
 
-  params1 <- permitProtect (AddressResolved owner1) signed1
-  params2 <- permitProtect (AddressResolved owner1) signed2
-  params3 <- permitProtect (AddressResolved owner1) signed3
+  params1 <- permitProtect (AddressResolved dodOwner1) signed1
+  params2 <- permitProtect (AddressResolved dodOwner1) signed2
+  params3 <- permitProtect (AddressResolved dodOwner1) signed3
 
-  withSender (AddressResolved owner2) $ do
+  withSender (AddressResolved dodOwner2) $ do
     -- Good nonce
-    call dao (Call @"Vote") [params1]
+    call dodDao (Call @"Vote") [params1]
 
     -- Outdated nonce
-    call dao (Call @"Vote") [params1]
-      & expectCustomError #mISSIGNED dao (checkedCoerce $ lPackValue dataToSign2)
+    call dodDao (Call @"Vote") [params1]
+      & expectCustomError #mISSIGNED dodDao (checkedCoerce $ lPackValue dataToSign2)
 
     -- Nonce from future
-    call dao (Call @"Vote") [params3]
-      & expectCustomError #mISSIGNED dao (checkedCoerce $ lPackValue dataToSign2)
+    call dodDao (Call @"Vote") [params3]
+      & expectCustomError #mISSIGNED dodDao (checkedCoerce $ lPackValue dataToSign2)
 
     -- Good nonce after the previous successful entrypoint call
-    call dao (Call @"Vote") [params2]
+    call dodDao (Call @"Vote") [params2]
 
   -- Check counter
-  (Nonce counter) <- getVotePermitsCounterFn (AddressResolved $ unTAddress dao)
+  (Nonce counter) <- getVotePermitsCounterFn (AddressResolved $ unTAddress dodDao)
   counter @== 2
 
 flushProposalFlushTimeNotReach
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 flushProposalFlushTimeNotReach originateFn = do
-  ((owner1, _), _, dao, _, admin) <-
+  DaoOriginateData{..} <-
     originateFn (configWithRejectedProposal
         >>- (ConfigDesc $ VotingPeriod 20)
         >>- (ConfigDesc configConsts{ cmProposalFlushTime = Just 40 })
         >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 60 })
         )
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 30)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 30)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 20)
 
-  _key1 <- createSampleProposal 1 owner1 dao
-  _key2 <- createSampleProposal 2 owner1 dao
+  _key1 <- createSampleProposal 1 dodOwner1 dodDao
+  _key2 <- createSampleProposal 2 dodOwner1 dodDao
   -- Advance two voting period to another proposing stage.
   advanceTime (sec 20) -- skip voting period
   advanceTime (sec 21)
-  _key3 <- createSampleProposal 3 owner1 dao
+  _key3 <- createSampleProposal 3 dodOwner1 dodDao
 
-  withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
-  checkTokenBalance (frozenTokenId) dao owner1 (100 + 5 + 5 + 10) -- first 2 proposals got flushed then slashed by 5, the last one is not affected.
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
+  checkTokenBalance (frozenTokenId) dodDao dodOwner1 (100 + 5 + 5 + 10) -- first 2 proposals got flushed then slashed by 5, the last one is not affected.
 
   -- TODO: [#31]
-  -- checkIfAProposalExist (key1 :: ByteString) dao
-  -- checkIfAProposalExist (key2 :: ByteString) dao
+  -- checkIfAProposalExist (key1 :: ByteString) dodDao
+  -- checkIfAProposalExist (key2 :: ByteString) dodDao
 
 flushAcceptedProposals
   :: (MonadNettest caps base m, HasCallStack)
@@ -513,23 +519,23 @@ flushAcceptedProposals
 flushAcceptedProposals originateFn getTotalSupplyFn = do
 -- Use 60s for voting period, since in real network by the time we call
   -- vote entrypoint 30s is already passed.
-  ((owner1, _), (owner2, _), dao, _, admin) <- originateFn (testConfig
+  DaoOriginateData{..} <- originateFn (testConfig
       >>- (ConfigDesc $ VotingPeriod 60)
       >>- (ConfigDesc configConsts{ cmProposalFlushTime = Just 120 })
       >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 180 })
       )
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 3)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 3)
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 60)
 
   -- Accepted Proposals
-  key1 <- createSampleProposal 1 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
   -- Advance one voting period to a voting stage.
   advanceTime (sec 65)
 
@@ -543,47 +549,47 @@ flushAcceptedProposals originateFn getTotalSupplyFn = do
         , vVoteAmount = 1
         , vProposalKey = key1
         }
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Vote") [upvote', downvote']
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Vote") [upvote', downvote']
 
   -- Checking balance of proposer and voters
-  checkTokenBalance (frozenTokenId) dao owner1 110
-  checkTokenBalance (frozenTokenId) dao owner2 103
+  checkTokenBalance (frozenTokenId) dodDao dodOwner1 110
+  checkTokenBalance (frozenTokenId) dodDao dodOwner2 103
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 61)
-  withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
-  -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dao
+  -- checkIfAProposalExist (key1 :: ByteString) dodDao
+  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dodDao
 
-  checkTokenBalance (frozenTokenId) dao owner1 110
+  checkTokenBalance (frozenTokenId) dodDao dodOwner1 110
 
-  checkTokenBalance (frozenTokenId) dao owner2 103
+  checkTokenBalance (frozenTokenId) dodDao dodOwner2 103
 
-  totalSupply <- getTotalSupplyFn (AddressResolved $ unTAddress dao) frozenTokenId
+  totalSupply <- getTotalSupplyFn (AddressResolved $ unTAddress dodDao) frozenTokenId
   totalSupply @== 213 -- initial = 0
 
 flushAcceptedProposalsWithAnAmount
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 flushAcceptedProposalsWithAnAmount originateFn = do
-  ((owner1, _), (owner2, _), dao, _, admin) <- originateFn testConfig
+  DaoOriginateData{..} <- originateFn testConfig
 
   -- Accepted Proposals
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 40)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 40)
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 2)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 2)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 15)
-  key1 <- createSampleProposal 1 owner1 dao
-  key2 <- createSampleProposal 2 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
+  key2 <- createSampleProposal 2 dodOwner1 dodDao
   advanceTime (sec 1)
-  key3 <- createSampleProposal 3 owner1 dao
+  key3 <- createSampleProposal 3 dodOwner1 dodDao
 
   let vote' key = NoPermit VoteParam
         { vVoteType = True
@@ -594,51 +600,51 @@ flushAcceptedProposalsWithAnAmount originateFn = do
   -- Advance two voting period to another proposing stage.
   advanceTime (sec 21)
 
-  key4 <- createSampleProposal 4 owner1 dao
+  key4 <- createSampleProposal 4 dodOwner1 dodDao
 
-  checkTokenBalance frozenTokenId dao owner1 140
+  checkTokenBalance frozenTokenId dodDao dodOwner1 140
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
-  withSender (AddressResolved admin) $ call dao (Call @"Flush") 2
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 2
 
   -- Proposals are flushed
-  withSender (AddressResolved owner2) $ do
-    call dao (Call @"Vote") [vote' key1]
-      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dao
-    call dao (Call @"Vote") [vote' key2]
-      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dao
+  withSender (AddressResolved dodOwner2) $ do
+    call dodDao (Call @"Vote") [vote' key1]
+      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dodDao
+    call dodDao (Call @"Vote") [vote' key2]
+      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dodDao
 
     -- Proposal is over but not affected
-    call dao (Call @"Vote") [vote' key3]
-      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dao
+    call dodDao (Call @"Vote") [vote' key3]
+      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dodDao
 
     -- Proposal is not yet over
-    call dao (Call @"Vote") [vote' key4]
+    call dodDao (Call @"Vote") [vote' key4]
 
   -- Only 2 proposals are flush, so only 20 tokens are unfrozen back.
-  checkTokenBalance frozenTokenId dao owner1 140
+  checkTokenBalance frozenTokenId dodDao dodOwner1 140
 
 flushRejectProposalQuorum
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 flushRejectProposalQuorum originateFn = do
-  ((owner1, _), (owner2, _), dao, _, admin)
+  DaoOriginateData{..}
     <- originateFn (configWithRejectedProposal
         >>- (ConfigDesc (QuorumThreshold 3 5))
         >>- (ConfigDesc $ VotingPeriod 60))
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 5)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 5)
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 60)
 
   -- Rejected Proposal
-  key1 <- createSampleProposal 1 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   let votes = fmap NoPermit
         [ VoteParam
@@ -649,24 +655,24 @@ flushRejectProposalQuorum originateFn = do
         ]
   -- Advance one voting period to a voting stage.
   advanceTime (sec 60)
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") votes
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") votes
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 61)
-  withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
-  -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dao
+  -- checkIfAProposalExist (key1 :: ByteString) dodDao
+  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dodDao
 
-  checkTokenBalance frozenTokenId dao owner1 105
-  checkTokenBalance frozenTokenId dao owner2 105 -- Since voter tokens are not burned
+  checkTokenBalance frozenTokenId dodDao dodOwner1 105
+  checkTokenBalance frozenTokenId dodDao dodOwner2 105 -- Since voter tokens are not burned
 
 flushRejectProposalNegativeVotes
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 flushRejectProposalNegativeVotes originateFn = do
-  ((owner1, _), (owner2, _), dao, _, admin)
+  DaoOriginateData{..}
     <- originateFn (configWithRejectedProposal
           >>- (ConfigDesc (QuorumThreshold 3 100))
           >>- (ConfigDesc (VotingPeriod 20))
@@ -674,17 +680,17 @@ flushRejectProposalNegativeVotes originateFn = do
           >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 60 })
           )
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 3)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 3)
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 20)
 
   -- Rejected Proposal
-  key1 <- createSampleProposal 1 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   let votes = fmap NoPermit
         [ VoteParam
@@ -705,27 +711,27 @@ flushRejectProposalNegativeVotes originateFn = do
         ]
   -- Advance one voting period to a voting stage.
   advanceTime (sec 20)
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") votes
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") votes
 
   -- Check proposer balance
-  checkTokenBalance frozenTokenId dao owner1 110
+  checkTokenBalance frozenTokenId dodDao dodOwner1 110
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 21)
-  withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
-  -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dao
+  -- checkIfAProposalExist (key1 :: ByteString) dodDao
+  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dodDao
 
-  checkTokenBalance frozenTokenId dao owner1 105
-  checkTokenBalance frozenTokenId dao owner2 103
+  checkTokenBalance frozenTokenId dodDao dodOwner1 105
+  checkTokenBalance frozenTokenId dodDao dodOwner2 103
 
 flushWithBadConfig
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 flushWithBadConfig originateFn = do
-  ((owner1, _), (owner2, _), dao, _, admin) <-
+  DaoOriginateData{..} <-
     originateFn (badRejectedValueConfig
       >>- (ConfigDesc (QuorumThreshold 1 2))
       >>- (ConfigDesc (VotingPeriod 20))
@@ -733,15 +739,15 @@ flushWithBadConfig originateFn = do
       >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 60 })
       )
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 3)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 3)
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 20)
-  key1 <- createSampleProposal 1 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   let upvote' = NoPermit VoteParam
         { vVoteType = True
@@ -750,39 +756,39 @@ flushWithBadConfig originateFn = do
         }
   -- Advance one voting period to a voting stage.
   advanceTime (sec 20)
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") [upvote']
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") [upvote']
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 21)
-  withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
-  -- checkIfAProposalExist (key1 :: ByteString) dao
-  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dao
+  -- checkIfAProposalExist (key1 :: ByteString) dodDao
+  --   & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dodDao
 
-  checkTokenBalance frozenTokenId dao owner1 100
-  checkTokenBalance frozenTokenId dao owner2 103
+  checkTokenBalance frozenTokenId dodDao dodOwner1 100
+  checkTokenBalance frozenTokenId dodDao dodOwner2 103
 
 flushDecisionLambda
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 flushDecisionLambda originateFn = do
   consumer <- originateSimple "consumer" [] (contractConsumer)
-  ((owner1, _), (owner2, _), dao, _, admin) <-
+  DaoOriginateData{..} <-
     originateFn ((decisionLambdaConfig consumer)
       >>- (ConfigDesc $ VotingPeriod 60)
       >>- (ConfigDesc configConsts{ cmProposalFlushTime = Just 120 })
       >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 180 })
       )
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 10)
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 60)
-  key1 <- createSampleProposal 1 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   let upvote' = NoPermit VoteParam
         { vVoteType = True
@@ -791,21 +797,21 @@ flushDecisionLambda originateFn = do
         }
   -- Advance one voting period to a voting stage.
   advanceTime (sec 60)
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") [upvote']
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") [upvote']
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 61)
-  withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
 
   results <- fromVal <$> getStorage (AddressResolved $ toAddress consumer)
-  assert (results == (#proposer <.!> [owner1]))
+  assert (results == (#proposer <.!> [dodOwner1]))
     "Unexpected accepted proposals list"
 
 dropProposal
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 dropProposal originateFn = withFrozenCallStack $ do
-  ((owner1, _), (owner2, _), dao, _, _admin) <-
+  DaoOriginateData{..} <-
     originateFn
      (configWithRejectedProposal
        >>- (ConfigDesc (QuorumThreshold 1 50))
@@ -814,17 +820,17 @@ dropProposal originateFn = withFrozenCallStack $ do
        >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 60 })
       )
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 30)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 30)
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 20)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 20)
 
-  key1 <- createSampleProposal 1 owner1 dao
-  key2 <- createSampleProposal 2 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
+  key2 <- createSampleProposal 2 dodOwner1 dodDao
 
   -- Advance one voting period to a voting stage.
   advanceTime (sec 20)
@@ -833,49 +839,49 @@ dropProposal originateFn = withFrozenCallStack $ do
         , vVoteAmount = 20
         , vProposalKey = key
         }
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") [params key1]
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") [params key1]
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 20)
 
-  key3 <- createSampleProposal 3 owner1 dao
+  key3 <- createSampleProposal 3 dodOwner1 dodDao
 
   -- -- TODO: Change to `guardian`, but currently it is not working may be due to sender <> source
-  withSender (AddressResolved owner1) $ do
-    call dao (Call @"Drop_proposal") key1
+  withSender (AddressResolved dodOwner1) $ do
+    call dodDao (Call @"Drop_proposal") key1
 
   -- `key2` is not yet expired since it has to be more than 60 seconds
-  withSender (AddressResolved owner2) $ do
-    call dao (Call @"Drop_proposal") key2
-      & expectCustomErrorNoArg #dROP_PROPOSAL_CONDITION_NOT_MET dao
+  withSender (AddressResolved dodOwner2) $ do
+    call dodDao (Call @"Drop_proposal") key2
+      & expectCustomErrorNoArg #dROP_PROPOSAL_CONDITION_NOT_MET dodDao
 
   advanceTime (sec 21)
   -- `key2` is expired, so it is possible to `drop_proposal`
-  withSender (AddressResolved owner2) $ do
-    call dao (Call @"Drop_proposal") key2
+  withSender (AddressResolved dodOwner2) $ do
+    call dodDao (Call @"Drop_proposal") key2
 
   -- `key3` is not yet expired
-  withSender (AddressResolved owner2) $ do
-    call dao (Call @"Drop_proposal") key3
-      & expectCustomErrorNoArg #dROP_PROPOSAL_CONDITION_NOT_MET dao
+  withSender (AddressResolved dodOwner2) $ do
+    call dodDao (Call @"Drop_proposal") key3
+      & expectCustomErrorNoArg #dROP_PROPOSAL_CONDITION_NOT_MET dodDao
 
   -- proposers can delete their proposal
-  withSender (AddressResolved owner1) $ do
-    call dao (Call @"Drop_proposal") key3
+  withSender (AddressResolved dodOwner1) $ do
+    call dodDao (Call @"Drop_proposal") key3
 
   -- 30 tokens are frozen in total, but only 15 tokens are returned after drop_proposal
-  checkTokenBalance frozenTokenId dao owner1 115
+  checkTokenBalance frozenTokenId dodDao dodOwner1 115
 
 proposalBoundedValue
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 proposalBoundedValue originateFn = do
-  ((owner1, _), _, dao, _, _) <- originateFn
+  DaoOriginateData{..} <- originateFn
     ( testConfig >>-
       ConfigDesc configConsts{ cmMaxProposals = Just 1 }
     )
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 20)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
@@ -885,28 +891,28 @@ proposalBoundedValue originateFn = do
         , ppProposalMetadata = lPackValueRaw @Integer 1
         }
 
-  withSender (AddressResolved owner1) $ do
-    call dao (Call @"Propose") params
-    call dao (Call @"Propose") params
-      & expectCustomErrorNoArg #mAX_PROPOSALS_REACHED dao
+  withSender (AddressResolved dodOwner1) $ do
+    call dodDao (Call @"Propose") params
+    call dodDao (Call @"Propose") params
+      & expectCustomErrorNoArg #mAX_PROPOSALS_REACHED dodDao
 
 votesBoundedValue
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 votesBoundedValue originateFn = do
-  ((owner1, _), (owner2, _), dao, _, _) <- originateFn
+  DaoOriginateData{..} <- originateFn
     ( voteConfig >>-
       ConfigDesc configConsts{ cmMaxVotes = Just 1 }
     )
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 2)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 2)
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
-  key1 <- createSampleProposal 1 owner2 dao
+  key1 <- createSampleProposal 1 dodOwner2 dodDao
   let upvote' = NoPermit VoteParam
         { vVoteType = False
         , vVoteAmount = 1
@@ -919,7 +925,7 @@ votesBoundedValue originateFn = do
         }
   -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
-  withSender (AddressResolved owner1) $ do
-    call dao (Call @"Vote") [downvote']
-    call dao (Call @"Vote") [upvote']
-      & expectCustomErrorNoArg #mAX_VOTES_REACHED dao
+  withSender (AddressResolved dodOwner1) $ do
+    call dodDao (Call @"Vote") [downvote']
+    call dodDao (Call @"Vote") [upvote']
+      & expectCustomErrorNoArg #mAX_VOTES_REACHED dodDao

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -12,7 +12,7 @@ import Time (sec)
 
 import Lorentz.Test (contractConsumer)
 import Morley.Nettest
-import Morley.Nettest.Tasty (nettestScenario, nettestScenarioOnEmulator, nettestScenarioOnEmulatorCaps, nettestScenarioOnNetworkCaps)
+import Morley.Nettest.Tasty (nettestScenario, nettestScenarioOnEmulatorCaps, nettestScenarioOnNetworkCaps)
 import Test.Tasty (TestTree, testGroup)
 import Util.Named
 
@@ -42,100 +42,104 @@ test_BaseDAO_Proposal =
       [ nettestScenarioOnEmulatorCaps "BaseDAO - can propose a valid proposal (emulator)" $
           validProposal (originateLigoDaoWithConfigDesc dynRecUnsafe) getTotalSupplyEmulator
 
-      , nettestScenarioOnEmulator "cannot propose an invalid proposal (rejected)" $
-          \_emulated ->
-            uncapsNettest $ rejectProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "cannot propose a non-unique proposal" $
-          \_emulated ->
-            uncapsNettest $ nonUniqueProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "cannot propose in a non-proposal period" $
-          \_emulated ->
-            uncapsNettest $ nonProposalPeriodProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+      , nettestScenarioOnEmulatorCaps "cannot propose an invalid proposal (rejected)" $
+          rejectProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "cannot propose a non-unique proposal" $
+          nonUniqueProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "cannot propose in a non-proposal period" $
+          nonProposalPeriodProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
       ]
 
   , testGroup "Voter:"
-      [ nettestScenarioOnEmulator "can vote on a valid proposal" $
-          \_emulated ->
-            uncapsNettest $ voteValidProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "cannot vote non-existing proposal" $
-          \_emulated ->
-            uncapsNettest $ voteNonExistingProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "can vote on multiple proposals" $
-          \_emulated ->
-            uncapsNettest $ voteMultiProposals (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "cannot vote on outdated proposal" $
-          \_emulated ->
-            uncapsNettest $ voteOutdatedProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+      [ nettestScenarioOnEmulatorCaps "can vote on a valid proposal" $
+          voteValidProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "cannot vote non-existing proposal" $
+          voteNonExistingProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "can vote on multiple proposals" $
+          voteMultiProposals (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "cannot vote on outdated proposal" $
+          voteOutdatedProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
       ]
 
 
-  , nettestScenarioOnEmulator "cannot vote if the vote amounts exceeds token balance" $
-      \_emulated ->
-        uncapsNettest $ insufficientTokenVote (originateLigoDaoWithConfigDesc dynRecUnsafe)
+  , nettestScenarioOnEmulatorCaps "cannot vote if the vote amounts exceeds token balance" $
+      insufficientTokenVote (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
   -- Note: When checking storage, we need to split the test into 2 (emulator and network) as demonstrated below:
   , nettestScenarioOnEmulatorCaps "cannot propose with insufficient tokens (emulator) " $
       insufficientTokenProposal (originateLigoDaoWithConfigDesc dynRecUnsafe) (\addr -> (length . sProposalKeyListSortByDate . fsStorage) <$> getFullStorage addr)
+
   , nettestScenarioOnNetworkCaps "cannot propose with insufficient tokens (network) " $
       insufficientTokenProposal (originateLigoDaoWithConfigDesc dynRecUnsafe) (\addr -> (length . sProposalKeyListSortByDate . fsStorage) <$> getFullStorageView addr)
 
   , testGroup "Permit:"
-      [ nettestScenarioOnEmulator "can vote from another user behalf" $
-          \_emulated ->
-            uncapsNettest $ voteWithPermit (originateLigoDaoWithConfigDesc dynRecUnsafe)
+      [ nettestScenarioOnEmulatorCaps "can vote from another user behalf" $
+          voteWithPermit (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
       , nettestScenarioOnEmulatorCaps "counter works properly in permits" $
-            voteWithPermitNonce (originateLigoDaoWithConfigDesc dynRecUnsafe) getVotePermitsCounterEmulator
+          voteWithPermitNonce (originateLigoDaoWithConfigDesc dynRecUnsafe) getVotePermitsCounterEmulator
+
       ]
   , testGroup "Admin:"
       [ nettestScenarioOnEmulatorCaps "can flush proposals that got accepted" $
           flushAcceptedProposals (originateLigoDaoWithConfigDesc dynRecUnsafe) getTotalSupplyEmulator
-      , nettestScenarioOnEmulator "can flush 2 proposals that got accepted" $
-          \_emulated ->
-            uncapsNettest $ flushAcceptedProposalsWithAnAmount (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "can flush proposals that got rejected due to not meeting quorum_threshold" $
-          \_emulated ->
-            uncapsNettest $ flushRejectProposalQuorum (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "can flush proposals that got rejected due to negative votes" $
-          \_emulated ->
-            uncapsNettest $ flushRejectProposalNegativeVotes (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "flush should not affecting proposals that cannot be flushed yet" $
-          \_emulated ->
-            uncapsNettest $ flushProposalFlushTimeNotReach
-            (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "flush with bad cRejectedProposalReturnValue" $
-          \_emulated ->
-            uncapsNettest $ flushWithBadConfig (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "can flush 2 proposals that got accepted" $
+          flushAcceptedProposalsWithAnAmount (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "can flush proposals that got rejected due to not meeting quorum_threshold" $
+          flushRejectProposalQuorum (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "can flush proposals that got rejected due to negative votes" $
+          flushRejectProposalNegativeVotes (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "flush should not affect proposals that cannot be flushed yet" $
+          flushProposalFlushTimeNotReach (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "flush should fail on expired proposals" $
+          flushFailOnExpiredProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "flush with bad cRejectedProposalReturnValue" $
+          flushWithBadConfig (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
       -- TODO [#15]: dodAdmin burn proposer token and test "flush"
 
       -- TODO [#38]: Improve this when contract size is smaller
-      , nettestScenarioOnEmulator "flush and run decision lambda" $
-          \_emulated ->
-            uncapsNettest $ flushDecisionLambda (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "can drop proposals" $
-          \_emulated ->
-            uncapsNettest $ dropProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+      , nettestScenarioOnEmulatorCaps "flush and run decision lambda" $
+          flushDecisionLambda (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "can drop proposals, only when allowed" $
+          dropProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
       ]
 
   , testGroup "Bounded Value"
-      [ nettestScenarioOnEmulator "bounded value on proposals" $
-          \_emulated ->
-            uncapsNettest $ proposalBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
-      , nettestScenarioOnEmulator "bounded value on votes" $
-          \_emulated ->
-            uncapsNettest $ votesBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
+      [ nettestScenarioOnEmulatorCaps "bounded value on proposals" $
+          proposalBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "bounded value on votes" $
+          votesBoundedValue (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
       ]
 
   , testGroup "Freeze-Unfreeze"
       [ nettestScenario "can freeze tokens" $
           uncapsNettest $ freezeTokens (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
-      , nettestScenarioOnEmulator "cannot unfreeze tokens from the same period" $
-          \_emulated ->
-            uncapsNettest $ cannotUnfreezeFromSamePeriod (originateLigoDaoWithConfigDesc dynRecUnsafe)
+      , nettestScenarioOnEmulatorCaps "cannot unfreeze tokens from the same period" $
+          cannotUnfreezeFromSamePeriod (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
-      , nettestScenarioOnEmulator "can unfreeze tokens from the previous period" $
-          \_emulated ->
-            uncapsNettest $ canUnfreezeFromPreviousPeriod (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
+      , nettestScenarioOnEmulatorCaps "can unfreeze tokens from the previous period" $
+          canUnfreezeFromPreviousPeriod (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
       ]
 
  , testGroup "LIGO-specific proposal tests:"
@@ -159,26 +163,24 @@ test_BaseDAO_Proposal =
         totalSupply <- getTotalSupplyEmulator (AddressResolved $ unTAddress dodDao) frozenTokenId
         totalSupply @== 252 -- initial = 0
 
-    , nettestScenarioOnEmulator "cannot propose with insufficient tokens to pay the fee" $
-        \_emulated -> uncapsNettest $ do
-          DaoOriginateData{..} <-
-            originateLigoDaoWithConfigDesc dynRecUnsafe (ConfigDesc (FixedFee 100))
-          let proposer = dodOwner1
+    , nettestScenarioOnEmulatorCaps "cannot propose with insufficient tokens to pay the fee" $ do
+        DaoOriginateData{..} <-
+          originateLigoDaoWithConfigDesc dynRecUnsafe (ConfigDesc (FixedFee 100))
+        let proposer = dodOwner1
 
-          withSender (AddressResolved proposer) $
-            call dodDao (Call @"Freeze") (#amount .! 52)
-          -- Advance one voting period to a proposing stage.
-          advanceTime (sec 10)
+        withSender (AddressResolved proposer) $
+          call dodDao (Call @"Freeze") (#amount .! 52)
+        -- Advance one voting period to a proposing stage.
+        advanceTime (sec 10)
 
-          let params = ProposeParams
-                { ppFrozenToken = 1
-                , ppProposalMetadata = lPackValueRaw @Integer 1
-                }
-          withSender (AddressResolved proposer) $ call dodDao (Call @"Propose") params
-            & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dodDao
+        let params = ProposeParams
+              { ppFrozenToken = 1
+              , ppProposalMetadata = lPackValueRaw @Integer 1
+              }
+        withSender (AddressResolved proposer) $ call dodDao (Call @"Propose") params
+          & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dodDao
 
-    , nettestScenarioOnEmulator "a proposer is returned a fee after the proposal succeeds" $
-        \_emulated -> uncapsNettest $ do
+    , nettestScenarioOnEmulatorCaps "a proposer is returned a fee after the proposal succeeds" $ do
           DaoOriginateData{..} <-
             originateLigoDaoWithConfigDesc dynRecUnsafe
               (   (ConfigDesc $ VotingPeriod 60)
@@ -221,11 +223,10 @@ test_BaseDAO_Proposal =
 
           checkTokenBalance frozenTokenId dodDao proposer 152
 
-    , nettestScenarioOnEmulator "the fee is burned if the proposal fails" $
-        \_emulated -> uncapsNettest $ burnsFeeOnFailure Downvoted
-
-    , nettestScenarioOnEmulator "the fee is burned if the proposal doesn't meet the quorum" $
-        \_emulated -> uncapsNettest $ burnsFeeOnFailure QuorumNotMet
+    , nettestScenarioOnEmulatorCaps "the fee is burned if the proposal fails" $
+        burnsFeeOnFailure Downvoted
+    , nettestScenarioOnEmulatorCaps "the fee is burned if the proposal doesn't meet the quorum" $
+        burnsFeeOnFailure QuorumNotMet
     ]
   ]
 
@@ -575,55 +576,54 @@ flushAcceptedProposalsWithAnAmount
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 flushAcceptedProposalsWithAnAmount originateFn = do
-  DaoOriginateData{..} <- originateFn testConfig
+  DaoOriginateData{..}
+    <- originateFn (configWithRejectedProposal
+        >>- (ConfigDesc $ VotingPeriod 20)
+        >>- (ConfigDesc configConsts{ cmProposalFlushTime = Just 40 })
+        >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 60 })
+        )
 
-  -- Accepted Proposals
+  -- [Voting]
   withSender (AddressResolved dodOwner1) $
-    call dodDao (Call @"Freeze") (#amount .! 40)
+    call dodDao (Call @"Freeze") (#amount .! 30)
 
   withSender (AddressResolved dodOwner2) $
-    call dodDao (Call @"Freeze") (#amount .! 2)
+    call dodDao (Call @"Freeze") (#amount .! 6)
 
-  -- Advance one voting period to a proposing stage.
-  advanceTime (sec 15)
+  advanceTime (sec 20)
+
+  -- [Proposing]
   key1 <- createSampleProposal 1 dodOwner1 dodDao
   key2 <- createSampleProposal 2 dodOwner1 dodDao
   advanceTime (sec 1)
-  key3 <- createSampleProposal 3 dodOwner1 dodDao
+  _key3 <- createSampleProposal 3 dodOwner1 dodDao
 
   let vote' key = NoPermit VoteParam
         { vVoteType = True
-        , vVoteAmount = 2
+        , vVoteAmount = 3
         , vProposalKey = key
         }
 
-  -- Advance two voting period to another proposing stage.
-  advanceTime (sec 21)
+  advanceTime (sec 20)
 
-  key4 <- createSampleProposal 4 dodOwner1 dodDao
-
-  checkTokenBalance frozenTokenId dodDao dodOwner1 140
-
-  -- Advance one voting period to a proposing stage.
-  advanceTime (sec 10)
-  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 2
-
-  -- Proposals are flushed
+  -- [Voting]
   withSender (AddressResolved dodOwner2) $ do
     call dodDao (Call @"Vote") [vote' key1]
-      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dodDao
     call dodDao (Call @"Vote") [vote' key2]
-      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dodDao
 
-    -- Proposal is over but not affected
-    call dodDao (Call @"Vote") [vote' key3]
-      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dodDao
+  advanceTime (sec 22)
 
-    -- Proposal is not yet over
-    call dodDao (Call @"Vote") [vote' key4]
+  -- [Proposing]
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 2
 
-  -- Only 2 proposals are flush, so only 20 tokens are unfrozen back.
-  checkTokenBalance frozenTokenId dodDao dodOwner1 140
+  -- key1 and key2 are flushed. (Tokens remain the same, because they are all passed)
+  checkTokenBalance frozenTokenId dodDao dodOwner1 130
+
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 1
+
+  -- key3 is rejected
+  checkTokenBalance frozenTokenId dodDao dodOwner1 125
+
 
 flushRejectProposalQuorum
   :: (MonadNettest caps base m, HasCallStack)
@@ -632,7 +632,10 @@ flushRejectProposalQuorum originateFn = do
   DaoOriginateData{..}
     <- originateFn (configWithRejectedProposal
         >>- (ConfigDesc (QuorumThreshold 3 5))
-        >>- (ConfigDesc $ VotingPeriod 60))
+        >>- (ConfigDesc $ VotingPeriod 20)
+        >>- (ConfigDesc configConsts{ cmProposalFlushTime = Just 40 })
+        >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 60 })
+        )
 
   withSender (AddressResolved dodOwner2) $
     call dodDao (Call @"Freeze") (#amount .! 5)
@@ -641,7 +644,7 @@ flushRejectProposalQuorum originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime (sec 60)
+  advanceTime (sec 20)
 
   -- Rejected Proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -654,11 +657,11 @@ flushRejectProposalQuorum originateFn = do
           }
         ]
   -- Advance one voting period to a voting stage.
-  advanceTime (sec 60)
+  advanceTime (sec 20)
   withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") votes
 
   -- Advance one voting period to a proposing stage.
-  advanceTime (sec 61)
+  advanceTime (sec 21)
   withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
@@ -807,6 +810,54 @@ flushDecisionLambda originateFn = do
   assert (results == (#proposer <.!> [dodOwner1]))
     "Unexpected accepted proposals list"
 
+flushFailOnExpiredProposal
+  :: (MonadNettest caps base m, HasCallStack)
+  => (ConfigDesc Config -> OriginateFn m) -> m ()
+flushFailOnExpiredProposal originateFn = withFrozenCallStack $ do
+  DaoOriginateData{..} <-
+    originateFn
+     (configWithRejectedProposal
+       >>- (ConfigDesc (QuorumThreshold 1 50))
+       >>- (ConfigDesc (VotingPeriod 20))
+       >>- (ConfigDesc configConsts{ cmProposalFlushTime = Just 40 })
+       >>- (ConfigDesc configConsts{ cmProposalExpiredTime = Just 60 })
+      )
+
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 20)
+
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 20)
+
+  -- Advance one voting period to a proposing stage.
+  advanceTime (sec 20)
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
+
+  -- Advance one voting period to a voting stage.
+  advanceTime (sec 20)
+  let params key = NoPermit VoteParam
+        { vVoteType = True
+        , vVoteAmount = 20
+        , vProposalKey = key
+        }
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") [params key1]
+  -- Advance one voting period to a proposing stage.
+  advanceTime (sec 20)
+  _key2 <- createSampleProposal 2 dodOwner1 dodDao
+
+  advanceTime (sec 41)
+  -- `key1` is now expired, and `key2` is not yet expired.
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 2
+    & expectCustomErrorNoArg #eXPIRED_PROPOSAL dodDao
+
+  -- `key1` is expired, so it is possible to `drop_proposal`
+  withSender (AddressResolved dodOwner2) $ do
+    call dodDao (Call @"Drop_proposal") key1
+
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 1
+  checkTokenBalance frozenTokenId dodDao dodOwner1 110
+
+
 dropProposal
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
@@ -845,9 +896,9 @@ dropProposal originateFn = withFrozenCallStack $ do
 
   key3 <- createSampleProposal 3 dodOwner1 dodDao
 
-  -- -- TODO: Change to `guardian`, but currently it is not working may be due to sender <> source
-  withSender (AddressResolved dodOwner1) $ do
-    call dodDao (Call @"Drop_proposal") key1
+  -- `guardian` contract can drop any proposal.
+  withSender (AddressResolved dodOwner2) $ do
+    call dodGuardian CallDefault (unTAddress dodDao, key1)
 
   -- `key2` is not yet expired since it has to be more than 60 seconds
   withSender (AddressResolved dodOwner2) $ do

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
@@ -84,13 +84,15 @@ data ConfigConstants = ConfigConstants
   , cmMaxVotes :: Maybe Natural
   , cmQuorumThreshold :: Maybe DAO.QuorumThreshold
   , cmVotingPeriod :: Maybe DAO.VotingPeriod
+  , cmProposalFlushTime :: Maybe Natural
+  , cmProposalExpiredTime :: Maybe Natural
   }
 
 -- | Constructor for config descriptor that overrides config constants.
 --
 -- Example: @configConsts{ cmMinVotingPeriod = 10 }@
 configConsts :: ConfigConstants
-configConsts = ConfigConstants Nothing Nothing Nothing Nothing
+configConsts = ConfigConstants Nothing Nothing Nothing Nothing Nothing Nothing
 
 data ProposalFrozenTokensCheck =
   ProposalFrozenTokensCheck (Lambda ("ppFrozenToken" :! Natural) Bool)
@@ -181,6 +183,8 @@ instance IsConfigDescExt DAO.Config ConfigConstants where
   fillConfig ConfigConstants{..} DAO.Config'{..} = DAO.Config'
     { cMaxProposals = cmMaxProposals ?: cMaxProposals
     , cMaxVotes = cmMaxVotes ?: cMaxVotes
+    , cProposalFlushTime = cmProposalFlushTime ?: cProposalFlushTime
+    , cProposalExpiredTime = cmProposalExpiredTime ?: cProposalExpiredTime
     , ..
     }
 

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
@@ -25,18 +25,18 @@ voteNonExistingProposal
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 voteNonExistingProposal originateFn = do
-  ((owner1, _), (owner2, _), dao, _, _) <- originateFn testConfig
+  DaoOriginateData{..} <- originateFn testConfig
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 2)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 2)
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
   -- Create sample proposal
-  _ <- createSampleProposal 1 owner1 dao
+  _ <- createSampleProposal 1 dodOwner1 dodDao
   let params = NoPermit VoteParam
         { vVoteType = True
         , vVoteAmount = 2
@@ -45,27 +45,27 @@ voteNonExistingProposal originateFn = do
   -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
 
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") [params]
-    & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dao
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") [params]
+    & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dodDao
 
 voteMultiProposals
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 voteMultiProposals originateFn = do
-  ((owner1, _), (owner2, _), dao, _, _) <- originateFn voteConfig
+  DaoOriginateData{..} <- originateFn voteConfig
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 20)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 20)
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 5)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 5)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
 
   -- Create sample proposal
-  key1 <- createSampleProposal 1 owner1 dao
-  key2 <- createSampleProposal 2 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
+  key2 <- createSampleProposal 2 dodOwner1 dodDao
   let params = fmap NoPermit
         [ VoteParam
             { vVoteType = True
@@ -81,27 +81,27 @@ voteMultiProposals originateFn = do
 
   -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") params
-  checkTokenBalance (frozenTokenId) dao owner2 105
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") params
+  checkTokenBalance (frozenTokenId) dodDao dodOwner2 105
   -- TODO [#31]: check storage if the vote update the proposal properly
 
 voteOutdatedProposal
   :: (MonadNettest caps base m, HasCallStack)
   => (ConfigDesc Config -> OriginateFn m) -> m ()
 voteOutdatedProposal originateFn = do
-  ((owner1, _), (owner2, _), dao, _, _) <- originateFn testConfig
+  DaoOriginateData{..} <- originateFn testConfig
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 2)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 2)
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
 
   -- Create sample proposal
-  key1 <- createSampleProposal 1 owner1 dao
+  key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   let params = NoPermit VoteParam
         { vVoteType = True
@@ -112,9 +112,9 @@ voteOutdatedProposal originateFn = do
   -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
 
-  withSender (AddressResolved owner2) $ do
-    call dao (Call @"Vote") [params]
+  withSender (AddressResolved dodOwner2) $ do
+    call dodDao (Call @"Vote") [params]
     -- Advance two voting period to another voting stage.
     advanceTime (sec 25)
-    call dao (Call @"Vote") [params]
-      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dao
+    call dodDao (Call @"Vote") [params]
+      & expectCustomErrorNoArg #vOTING_PERIOD_OVER dodDao

--- a/haskell/test/Test/Ligo/BaseDAO/Token.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Token.hs
@@ -29,7 +29,7 @@ transferContractTokensScenario
   :: MonadNettest caps base m
   => OriginateFn m -> m ()
 transferContractTokensScenario originateFn = do
-  ((owner1, _), _, dao, fa2Contract, admin) <- originateFn
+  DaoOriginateData{..} <- originateFn
   let target_owner1 = genesisAddress1
   let target_owner2 = genesisAddress2
 
@@ -42,18 +42,18 @@ transferContractTokensScenario originateFn = do
                 } ]
             } ]
       param = TransferContractTokensParam
-        { tcContractAddress = toAddress fa2Contract
+        { tcContractAddress = toAddress dodTokenContract
         , tcParams = transferParams
         }
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Transfer_contract_tokens") param
-    & expectCustomErrorNoArg #nOT_ADMIN dao
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Transfer_contract_tokens") param
+    & expectCustomErrorNoArg #nOT_ADMIN dodDao
 
-  withSender (AddressResolved admin) $
-    call dao (Call @"Transfer_contract_tokens") param
+  withSender (AddressResolved dodAdmin) $
+    call dodDao (Call @"Transfer_contract_tokens") param
 
-  checkStorage (AddressResolved $ unTAddress fa2Contract)
+  checkStorage (AddressResolved $ unTAddress dodTokenContract)
     (toVal
       [ [ FA2.TransferItem { tiFrom = target_owner1, tiTxs = [FA2.TransferDestination { tdTo = target_owner2, tdTokenId = FA2.theTokenId, tdAmount = 10 }] } ]
       ])

--- a/haskell/test/Test/Ligo/BaseDAO/Token/Common.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Token/Common.hs
@@ -8,6 +8,7 @@ module Test.Ligo.BaseDAO.Token.Common
   , assertBalanceOf
 
   -- * Re-exports
+  , DaoOriginateData(..)
   , frozenTokens
   , unfrozenTokens
   , unfrozenTokens1
@@ -27,12 +28,12 @@ import Test.Ligo.BaseDAO.Common
 originateWithCustomToken :: MonadNettest caps base m => OriginateFn m
 originateWithCustomToken =
   originateLigoDaoWithBalance dynRecUnsafe defaultConfig
-      (\owner1 owner2 ->
-          [ ((owner1, frozenTokens), 100)
-          , ((owner2, frozenTokens), 100)
-          , ((owner1, unfrozenTokens), 1000)
-          , ((owner2, unfrozenTokens), 1000)
-          , ((owner1, unfrozenTokens1), 1000)
+      (\dodOwner1 dodOwner2 ->
+          [ ((dodOwner1, frozenTokens), 100)
+          , ((dodOwner2, frozenTokens), 100)
+          , ((dodOwner1, unfrozenTokens), 1000)
+          , ((dodOwner2, unfrozenTokens), 1000)
+          , ((dodOwner1, unfrozenTokens1), 1000)
           ]
       )
 

--- a/haskell/test/Test/Ligo/BaseDAO/Token/Transfer.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Token/Transfer.hs
@@ -20,124 +20,124 @@ transferTests :: TestTree
 transferTests = testGroup "Transfer:"
   [ testGroup "Transfers by operators:"
       [ nettestScenarioCaps "allows valid transfer and check balance" $ do
-          ((owner1, op1), (owner2, _), dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved op1) $
-            transfer 10 unfrozenTokens owner1 owner2 dao
+          withSender (AddressResolved dodOperator1) $
+            transfer 10 unfrozenTokens dodOwner1 dodOwner2 dodDao
           -- 1000 initially + 10 received
-          assertBalanceOf owner2 1010 unfrozenTokens dao
+          assertBalanceOf dodOwner2 1010 unfrozenTokens dodDao
 
       , nettestScenarioCaps "aborts if there is a failure (due to low balance)" $ do
-          ((owner1, op1), (owner2, _), dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved op1) $
-            transfer 1001 unfrozenTokens owner1 owner2 dao
+          withSender (AddressResolved dodOperator1) $
+            transfer 1001 unfrozenTokens dodOwner1 dodOwner2 dodDao
               & expectCustomError
-                  #fA2_INSUFFICIENT_BALANCE dao
+                  #fA2_INSUFFICIENT_BALANCE dodDao
                   (#required .! 1001, #present .! 1000)
 
       , nettestScenarioCaps "aborts if there is a failure (due to bad operator)" $ do
           op3 :: Address <- newAddress "operator3"
-          ((owner1, op1), (owner2, _), dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved op1) $
-            transfer 10 unfrozenTokens owner2 owner1 dao
-              & expectCustomError_ #fA2_NOT_OPERATOR dao
+          withSender (AddressResolved dodOperator1) $
+            transfer 10 unfrozenTokens dodOwner2 dodOwner1 dodDao
+              & expectCustomError_ #fA2_NOT_OPERATOR dodDao
 
           withSender (AddressResolved op3) $
-            transfer 10 unfrozenTokens owner2 owner1 dao
-              & expectCustomError_ #fA2_NOT_OPERATOR dao
+            transfer 10 unfrozenTokens dodOwner2 dodOwner1 dodDao
+              & expectCustomError_ #fA2_NOT_OPERATOR dodDao
 
       , nettestScenarioCaps "cannot transfer frozen tokens" $ do
-          ((owner1, op1), (owner2, _), dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved op1) $
-            transfer 10 frozenTokens owner1 owner2 dao
-              & expectCustomErrorNoArg #fROZEN_TOKEN_NOT_TRANSFERABLE dao
+          withSender (AddressResolved dodOperator1) $
+            transfer 10 frozenTokens dodOwner1 dodOwner2 dodDao
+              & expectCustomErrorNoArg #fROZEN_TOKEN_NOT_TRANSFERABLE dodDao
 
       , nettestScenarioCaps "fails if trying to transfer unknown tokens" $ do
-          ((owner1, op1), (owner2, _), dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved op1) $
-            transfer 0 unknownTokens owner1 owner2 dao
-              & expectCustomError_ #fA2_NOT_OPERATOR dao
+          withSender (AddressResolved dodOperator1) $
+            transfer 0 unknownTokens dodOwner1 dodOwner2 dodDao
+              & expectCustomError_ #fA2_NOT_OPERATOR dodDao
       ]
 
   , testGroup "Transfers by token owners:"
       [ nettestScenarioCaps "accepts an empty list of transfers" $ do
           someone :: Address <- newAddress "someone"
-          (_, _, dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
           withSender (AddressResolved someone) $
-            call dao (Call @"Transfer") []
+            call dodDao (Call @"Transfer") []
 
       , nettestScenarioCaps "allows zero transfer from non-existent owner" $ do
           nonexistent :: Address <- newAddress "nonexistent"
-          ((owner1, _), _, dao, _,  _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
           withSender (AddressResolved nonexistent) $
-            transfer 0 unfrozenTokens nonexistent owner1 dao
+            transfer 0 unfrozenTokens nonexistent dodOwner1 dodDao
 
       , nettestScenarioCaps "allows valid transfer and check balance" $ do
-            ((owner1, _), (owner2, _), dao, _, _) <- originateWithCustomToken
+            DaoOriginateData{..} <- originateWithCustomToken
 
-            withSender (AddressResolved owner1) $
-              transfer 10 unfrozenTokens owner1 owner2 dao
+            withSender (AddressResolved dodOwner1) $
+              transfer 10 unfrozenTokens dodOwner1 dodOwner2 dodDao
             -- 1000 initially + 10 received
-            assertBalanceOf owner2 1010 unfrozenTokens dao
+            assertBalanceOf dodOwner2 1010 unfrozenTokens dodDao
 
       , nettestScenarioCaps "aborts if there is a failure (due to low balance)" $ do
-          ((owner1, _), (owner2, _), dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved owner1) $
-            transfer 1001 unfrozenTokens owner1 owner2 dao
+          withSender (AddressResolved dodOwner1) $
+            transfer 1001 unfrozenTokens dodOwner1 dodOwner2 dodDao
               & expectCustomError
-                  #fA2_INSUFFICIENT_BALANCE dao
+                  #fA2_INSUFFICIENT_BALANCE dodDao
                   (#required .! 1001, #present .! 1000)
 
       , nettestScenarioCaps "cannot transfer someone else's money" $ do
-          ((owner1, _), (owner2, _), dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved owner1) $
-            transfer 10 unfrozenTokens owner2 owner1 dao
-              & expectCustomError_ #fA2_NOT_OPERATOR dao
+          withSender (AddressResolved dodOwner1) $
+            transfer 10 unfrozenTokens dodOwner2 dodOwner1 dodDao
+              & expectCustomError_ #fA2_NOT_OPERATOR dodDao
 
       , nettestScenarioCaps "aborts if there is a failure (due to non existent source account)" $ do
           nonexistent :: Address <- newAddress "nonexistent"
-          ((owner1, _), _, dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
           -- Failed with 'fA2_INSUFFICIENT_BALANCE' due to nonexistent account is treated
           -- as an existing account with 0 balance.
           withSender (AddressResolved nonexistent) $
-            transfer 1 unfrozenTokens nonexistent owner1 dao
-              & expectCustomError #fA2_INSUFFICIENT_BALANCE dao (#required .! 1, #present .! 0)
+            transfer 1 unfrozenTokens nonexistent dodOwner1 dodDao
+              & expectCustomError #fA2_INSUFFICIENT_BALANCE dodDao (#required .! 1, #present .! 0)
 
       , nettestScenarioCaps "cannot transfer frozen tokens" $ do
-          ((owner1, _), (owner2, _), dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved owner1) $
-            transfer 10 frozenTokens owner1 owner2 dao
-              & expectCustomErrorNoArg #fROZEN_TOKEN_NOT_TRANSFERABLE dao
+          withSender (AddressResolved dodOwner1) $
+            transfer 10 frozenTokens dodOwner1 dodOwner2 dodDao
+              & expectCustomErrorNoArg #fROZEN_TOKEN_NOT_TRANSFERABLE dodDao
 
       , nettestScenarioCaps "fails if trying to transfer unknown tokens" $ do
-          ((owner1, _), (owner2, _), dao, _, _) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved owner1) $
-            transfer 0 unknownTokens owner1 owner2 dao
-              & expectCustomError_ #fA2_TOKEN_UNDEFINED dao
+          withSender (AddressResolved dodOwner1) $
+            transfer 0 unknownTokens dodOwner1 dodOwner2 dodDao
+              & expectCustomError_ #fA2_TOKEN_UNDEFINED dodDao
       ]
 
   , testGroup "Transfers by the administrator"
       [ nettestScenarioCaps "admin cannot transfer unfrozen tokens that don't belong to them" $ do
-          ((owner1, _), (owner2, _), dao, _, admin) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved admin) $
-            transfer 10 unfrozenTokens owner2 owner1 dao
-              & expectCustomError_ #fA2_NOT_OPERATOR dao
+          withSender (AddressResolved dodAdmin) $
+            transfer 10 unfrozenTokens dodOwner2 dodOwner1 dodDao
+              & expectCustomError_ #fA2_NOT_OPERATOR dodDao
 
       , nettestScenarioCaps "admin cannot transfer frozen tokens from any address to any address" $ do
-          ((owner1, _), (owner2, _), dao, _, admin) <- originateWithCustomToken
+          DaoOriginateData{..} <- originateWithCustomToken
 
-          withSender (AddressResolved admin) $
-            transfer 10 frozenTokens owner1 owner2 dao
-              & expectCustomErrorNoArg #fROZEN_TOKEN_NOT_TRANSFERABLE dao
+          withSender (AddressResolved dodAdmin) $
+            transfer 10 frozenTokens dodOwner1 dodOwner2 dodDao
+              & expectCustomErrorNoArg #fROZEN_TOKEN_NOT_TRANSFERABLE dodDao
       ]
   ]

--- a/haskell/test/Test/Ligo/BaseDAO/Token/UpdateOperators.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Token/UpdateOperators.hs
@@ -35,94 +35,94 @@ updateOperatorsTests =
 addOperator :: MonadNettest caps base m => m ()
 addOperator = do
   operator :: Address <- newAddress "operator"
-  ((owner1, _), (owner2, _), dao, _, _) <- originateWithCustomToken
+  DaoOriginateData{..} <- originateWithCustomToken
   let params = FA2.OperatorParam
-        { opOwner = owner1
+        { opOwner = dodOwner1
         , opOperator = operator
         , opTokenId = unfrozenTokens
         }
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Update_operators") [FA2.AddOperator params]
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Update_operators") [FA2.AddOperator params]
   withSender (AddressResolved operator) $
-    transfer 10 unfrozenTokens owner1 owner2 dao
+    transfer 10 unfrozenTokens dodOwner1 dodOwner2 dodDao
 
 addOperatorSingleToken :: MonadNettest caps base m => m ()
 addOperatorSingleToken = do
   operator :: Address <- newAddress "operator"
-  ((owner1, _), (owner2, _), dao, _, _) <- originateWithCustomToken
+  DaoOriginateData{..} <- originateWithCustomToken
   let params = FA2.OperatorParam
-        { opOwner = owner1
+        { opOwner = dodOwner1
         , opOperator = operator
         , opTokenId = unfrozenTokens1
         }
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Update_operators") [FA2.AddOperator params]
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Update_operators") [FA2.AddOperator params]
   withSender (AddressResolved operator) $
-    transfer 10 unfrozenTokens owner1 owner2 dao
-      & expectCustomError_ #fA2_NOT_OPERATOR dao
+    transfer 10 unfrozenTokens dodOwner1 dodOwner2 dodDao
+      & expectCustomError_ #fA2_NOT_OPERATOR dodDao
 
 removeOperator :: MonadNettest caps base m => m ()
 removeOperator = do
-  ((owner1, op1), (owner2, _), dao, _, _) <- originateWithCustomToken
+  DaoOriginateData{..} <- originateWithCustomToken
   let params = FA2.OperatorParam
-        { opOwner = owner1
-        , opOperator = op1
+        { opOwner = dodOwner1
+        , opOperator = dodOperator1
         , opTokenId = unfrozenTokens
         }
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Update_operators") [FA2.RemoveOperator params]
-  withSender (AddressResolved op1) $
-    transfer 10 unfrozenTokens owner1 owner2 dao
-      & expectCustomError_ #fA2_NOT_OPERATOR dao
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Update_operators") [FA2.RemoveOperator params]
+  withSender (AddressResolved dodOperator1) $
+    transfer 10 unfrozenTokens dodOwner1 dodOwner2 dodDao
+      & expectCustomError_ #fA2_NOT_OPERATOR dodDao
 
 notOwnerUpdatesOperator :: MonadNettest caps base m => m ()
 notOwnerUpdatesOperator = do
-  ((owner1, _), (owner2, _), dao, _, _) <- originateWithCustomToken
+  DaoOriginateData{..} <- originateWithCustomToken
   let notOwnerParams = FA2.OperatorParam
-        { opOwner = owner2
-        , opOperator = owner1
+        { opOwner = dodOwner2
+        , opOperator = dodOwner1
         , opTokenId = unfrozenTokens
         }
 
-  withSender (AddressResolved owner1) $ do
-    call dao (Call @"Update_operators") ([FA2.AddOperator notOwnerParams])
-      & expectCustomErrorNoArg #nOT_OWNER dao
-    call dao (Call @"Update_operators") [FA2.RemoveOperator notOwnerParams]
-      & expectCustomErrorNoArg #nOT_OWNER dao
+  withSender (AddressResolved dodOwner1) $ do
+    call dodDao (Call @"Update_operators") ([FA2.AddOperator notOwnerParams])
+      & expectCustomErrorNoArg #nOT_OWNER dodDao
+    call dodDao (Call @"Update_operators") [FA2.RemoveOperator notOwnerParams]
+      & expectCustomErrorNoArg #nOT_OWNER dodDao
 
 adminUnfrozenOperator :: MonadNettest caps base m => m ()
 adminUnfrozenOperator = do
-  ((owner1, _), (owner2, _), dao, _, admin) <- originateWithCustomToken
+  DaoOriginateData{..} <- originateWithCustomToken
   let params = FA2.OperatorParam
-        { opOwner = owner1
-        , opOperator = admin
+        { opOwner = dodOwner1
+        , opOperator = dodAdmin
         , opTokenId = unfrozenTokens
         }
 
-  withSender (AddressResolved owner1) $ do
-    call dao (Call @"Update_operators") [FA2.AddOperator params]
-    transfer 10 unfrozenTokens owner1 owner2 dao
+  withSender (AddressResolved dodOwner1) $ do
+    call dodDao (Call @"Update_operators") [FA2.AddOperator params]
+    transfer 10 unfrozenTokens dodOwner1 dodOwner2 dodDao
 
 frozenOperator :: MonadNettest caps base m => m ()
 frozenOperator = do
-  ((owner1, _), (owner2, _), dao, _, admin) <- originateWithCustomToken
+  DaoOriginateData{..} <- originateWithCustomToken
   let params op = FA2.OperatorParam
-        { opOwner = owner1
+        { opOwner = dodOwner1
         , opOperator = op
         , opTokenId = frozenTokens
         }
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Update_operators") [FA2.AddOperator (params admin)]
-      & expectCustomErrorNoArg #oPERATION_PROHIBITED dao
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Update_operators") [FA2.AddOperator (params dodAdmin)]
+      & expectCustomErrorNoArg #oPERATION_PROHIBITED dodDao
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Update_operators") [FA2.AddOperator (params owner2)]
-      & expectCustomErrorNoArg #oPERATION_PROHIBITED dao
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Update_operators") [FA2.AddOperator (params dodOwner2)]
+      & expectCustomErrorNoArg #oPERATION_PROHIBITED dodDao
 
-  withSender (AddressResolved admin) $
-    call dao (Call @"Update_operators") [FA2.AddOperator (params admin)]
-      & expectCustomErrorNoArg #oPERATION_PROHIBITED dao
+  withSender (AddressResolved dodAdmin) $
+    call dodDao (Call @"Update_operators") [FA2.AddOperator (params dodAdmin)]
+      & expectCustomErrorNoArg #oPERATION_PROHIBITED dodDao

--- a/haskell/test/Test/Ligo/RegistryDAO.hs
+++ b/haskell/test/Test/Ligo/RegistryDAO.hs
@@ -206,7 +206,7 @@ test_RegistryDAO =
                 call baseDao (Call @"Propose") (ProposeParams requiredFrozen proposalMeta1)
 
               -- Advance two voting periods to another proposing stage.
-              advanceTime (sec 22)
+              advanceTime (sec $ 22 + 1) -- 22 is `proposal_flush_time`
               withSender (AddressResolved admin) $
                 call baseDao (Call @"Flush") (1 :: Natural)
 
@@ -284,7 +284,7 @@ test_RegistryDAO =
                 call baseDao (Call @"Vote") [PermitProtected (VoteParam proposalKey True 60) Nothing]
 
               -- Advance one voting period to a proposing stage.
-              advanceTime (sec 11)
+              advanceTime (sec $ 11 + 1)
               withSender (AddressResolved admin) $
                 call baseDao (Call @"Flush") (1 :: Natural)
 
@@ -493,7 +493,13 @@ test_RegistryDAO =
         , sLedger = ledger
         , sTotalSupply = totalSupplyFromLedger ledger
         }
-      in fs { fsStorage = newStorage, fsConfig = oldConfig { cVotingPeriod = 11} }
+      in fs { fsStorage = newStorage
+            , fsConfig = oldConfig
+                { cVotingPeriod = 11
+                , cProposalFlushTime = 22
+                , cProposalExpiredTime = 33
+                }
+            }
 
     initialStorageWithExplictRegistryDAOConfig :: Address -> [Address] -> FullStorage
     initialStorageWithExplictRegistryDAOConfig admin wallets =

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -20,7 +20,7 @@ import Util.Named
 import Ligo.BaseDAO.Common.Types
 import Ligo.BaseDAO.Types
 import Ligo.Util
-import Test.Ligo.BaseDAO.Common 
+import Test.Ligo.BaseDAO.Common
   ( DaoOriginateData(..), OriginateFn, TransferProposal(..)
   , checkTokenBalance, makeProposalKey, originateLigoDaoWithBalance, sendXtz )
 

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -220,4 +220,11 @@ originateTreasuryDaoWithBalance bal =
         & setExtra @Natural [mt|min_xtz_amount|] 2
         & setExtra @Natural [mt|max_xtz_amount|] 5
 
-  in originateLigoDaoWithBalance (sExtra fsStorage) (fsConfig { cQuorumThreshold = QuorumThreshold 1 100, cVotingPeriod = 10 }) bal
+  in originateLigoDaoWithBalance (sExtra fsStorage)
+      (fsConfig
+        { cQuorumThreshold = QuorumThreshold 1 100
+        , cVotingPeriod = 10
+        , cProposalFlushTime = 20
+        , cProposalExpiredTime = 30
+        }
+      ) bal

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -20,8 +20,9 @@ import Util.Named
 import Ligo.BaseDAO.Common.Types
 import Ligo.BaseDAO.Types
 import Ligo.Util
-import Test.Ligo.BaseDAO.Common
-  (OriginateFn, TransferProposal(..), checkTokenBalance, makeProposalKey, originateLigoDaoWithBalance, sendXtz)
+import Test.Ligo.BaseDAO.Common 
+  ( DaoOriginateData(..), OriginateFn, TransferProposal(..)
+  , checkTokenBalance, makeProposalKey, originateLigoDaoWithBalance, sendXtz )
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
@@ -50,7 +51,7 @@ metadataSize md = fromIntegral $ BS.length md
 
 validProposal :: (Monad m, HasCallStack) => NettestImpl m -> m ()
 validProposal = uncapsNettest $ withFrozenCallStack do
-  ((owner1, _), (owner2, _), dao, _, _) <-
+  DaoOriginateData{..} <-
     originateTreasuryDaoWithBalance $ \owner1_ owner2_ ->
       [ ((owner1_, frozenTokenId), 200)
       , ((owner2_, frozenTokenId), 200)
@@ -59,29 +60,29 @@ validProposal = uncapsNettest $ withFrozenCallStack do
     proposalMeta = lPackValueRaw @TreasuryDaoProposalMetadata $
       TransferProposal
         { tpAgoraPostId = 1
-        , tpTransfers = [ tokenTransferType (toAddress dao) owner1 owner2 ]
+        , tpTransfers = [ tokenTransferType (toAddress dodDao) dodOwner1 dodOwner2 ]
         }
     proposalSize = metadataSize proposalMeta -- 115
 
   -- Freeze in voting stage.
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! proposalSize)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! proposalSize)
 
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Propose") (ProposeParams (proposalSize + 1) proposalMeta)
-    & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK dao
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Propose") (ProposeParams (proposalSize + 1) proposalMeta)
+    & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK dodDao
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Propose") (ProposeParams proposalSize proposalMeta)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Propose") (ProposeParams proposalSize proposalMeta)
 
-  checkTokenBalance frozenTokenId dao owner1 315
+  checkTokenBalance frozenTokenId dodDao dodOwner1 315
 
 flushTokenTransfer :: (Monad m, HasCallStack) => NettestImpl m -> m ()
 flushTokenTransfer = uncapsNettest $ withFrozenCallStack $ do
-  ((owner1, _), (owner2, _), dao, fa2Contract, admin) <-
+  DaoOriginateData{..} <-
     originateTreasuryDaoWithBalance $ \_ owner2_ ->
       [ ((owner2_, frozenTokenId), 100)
       ]
@@ -90,25 +91,25 @@ flushTokenTransfer = uncapsNettest $ withFrozenCallStack $ do
     proposalMeta = lPackValueRaw @TreasuryDaoProposalMetadata $
       TransferProposal
         { tpAgoraPostId = 1
-        , tpTransfers = [ tokenTransferType (toAddress fa2Contract) owner2 owner1 ]
+        , tpTransfers = [ tokenTransferType (toAddress dodTokenContract) dodOwner2 dodOwner1 ]
         }
     proposalSize = metadataSize proposalMeta
     proposeParams = ProposeParams proposalSize proposalMeta
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! proposalSize)
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! proposalSize)
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 20)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting periods to a proposing stage.
   advanceTime (sec 10)
 
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Propose") proposeParams
-  let key1 = makeProposalKey proposeParams owner1
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Propose") proposeParams
+  let key1 = makeProposalKey proposeParams dodOwner1
 
-  checkTokenBalance frozenTokenId dao owner1 115
+  checkTokenBalance frozenTokenId dodDao dodOwner1 115
 
   let
     upvote = NoPermit VoteParam
@@ -119,52 +120,52 @@ flushTokenTransfer = uncapsNettest $ withFrozenCallStack $ do
 
   -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") [upvote]
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") [upvote]
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
-  withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
 
-  checkTokenBalance frozenTokenId dao owner1 proposalSize
-  checkTokenBalance frozenTokenId dao owner2 120
+  checkTokenBalance frozenTokenId dodDao dodOwner1 proposalSize
+  checkTokenBalance frozenTokenId dodDao dodOwner2 120
 
 flushXtzTransfer :: (Monad m, HasCallStack) => NettestImpl m -> m ()
 flushXtzTransfer = uncapsNettest $ withFrozenCallStack $ do
-  ((owner1, _), (owner2, _), dao, _, admin) <-
+  DaoOriginateData{..} <-
     originateTreasuryDaoWithBalance $ \_ _ ->
       []
 
-  sendXtz (toAddress dao) (unsafeBuildEpName "callCustom") ([mt|receive_xtz|], lPackValueRaw ())
+  sendXtz (toAddress dodDao) (unsafeBuildEpName "callCustom") ([mt|receive_xtz|], lPackValueRaw ())
 
   let
     proposalMeta amt = lPackValueRaw @TreasuryDaoProposalMetadata $
       TransferProposal
         { tpAgoraPostId = 1
-        , tpTransfers = [ xtzTransferType amt owner2 ]
+        , tpTransfers = [ xtzTransferType amt dodOwner2 ]
         }
     proposeParams amt = ProposeParams (metadataSize $ proposalMeta amt) $ proposalMeta amt
 
   -- Freeze in initial voting stage.
-  withSender (AddressResolved owner1) $
-    call dao (Call @"Freeze") (#amount .! (metadataSize $ proposalMeta 3))
+  withSender (AddressResolved dodOwner1) $
+    call dodDao (Call @"Freeze") (#amount .! (metadataSize $ proposalMeta 3))
 
-  withSender (AddressResolved owner2) $
-    call dao (Call @"Freeze") (#amount .! 10)
+  withSender (AddressResolved dodOwner2) $
+    call dodDao (Call @"Freeze") (#amount .! 10)
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
 
-  withSender (AddressResolved owner1) $ do
+  withSender (AddressResolved dodOwner1) $ do
   -- due to smaller than min_xtz_amount
-    call dao (Call @"Propose") (proposeParams 1)
-      & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK dao
+    call dodDao (Call @"Propose") (proposeParams 1)
+      & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK dodDao
 
   -- due to bigger than max_xtz_amount
-    call dao (Call @"Propose") (proposeParams 6)
-      & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK dao
+    call dodDao (Call @"Propose") (proposeParams 6)
+      & expectCustomErrorNoArg #fAIL_PROPOSAL_CHECK dodDao
 
-    call dao (Call @"Propose") (proposeParams 3)
-  let key1 = makeProposalKey (proposeParams 3) owner1
+    call dodDao (Call @"Propose") (proposeParams 3)
+  let key1 = makeProposalKey (proposeParams 3) dodOwner1
 
-  checkTokenBalance (frozenTokenId) dao owner1 43
+  checkTokenBalance (frozenTokenId) dodDao dodOwner1 43
 
   let
     upvote = NoPermit VoteParam
@@ -175,10 +176,10 @@ flushXtzTransfer = uncapsNettest $ withFrozenCallStack $ do
 
   -- Advance one voting period to a voting stage.
   advanceTime (sec 10)
-  withSender (AddressResolved owner2) $ call dao (Call @"Vote") [upvote]
+  withSender (AddressResolved dodOwner2) $ call dodDao (Call @"Vote") [upvote]
   -- Advance one voting period to a proposing stage.
   advanceTime (sec 10)
-  withSender (AddressResolved admin) $ call dao (Call @"Flush") 100
+  withSender (AddressResolved dodAdmin) $ call dodDao (Call @"Flush") 100
 
 --   -- TODO: check xtz balance
 

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -4,19 +4,27 @@
 #include "types.mligo"
 #include "proposal.mligo"
 
-let default_config (data : initial_config_data) : config = {
-  proposal_check = (fun (params, extras : propose_params * contract_extra) -> true);
-  rejected_proposal_return_value = (fun (proposal, extras : proposal * contract_extra) -> 0n);
-  decision_lambda = (fun (proposal, extras : proposal * contract_extra) -> (([] : (operation list)), extras));
+let validate_default_config (data : initial_config_data) : unit =
+  if data.proposal_expired_time <= data.proposal_flush_time then
+    failwith("proposal_expired_time needs to be bigger than proposal_flush_time")
+  else if data.proposal_flush_time <= (data.voting_period.length * 2n) then
+    failwith("proposal_flush_time needs to be more than twice the voting_period length")
+  else unit
 
-  quorum_threshold = data.quorum_threshold;
-  fixed_proposal_fee_in_token = data.fixed_proposal_fee_in_token;
-  voting_period = data.voting_period;
-  max_proposals = 500n;
-  max_votes = 1000n;
-
-  custom_entrypoints = (Big_map.empty : custom_entrypoints);
-}
+let default_config (data : initial_config_data) : config =
+  let u : unit = validate_default_config(data) in {
+    proposal_check = (fun (params, extras : propose_params * contract_extra) -> true);
+    rejected_proposal_return_value = (fun (proposal, extras : proposal * contract_extra) -> 0n);
+    decision_lambda = (fun (proposal, extras : proposal * contract_extra) -> (([] : (operation list)), extras));
+    quorum_threshold = data.quorum_threshold;
+    fixed_proposal_fee_in_token = data.fixed_proposal_fee_in_token;
+    voting_period = data.voting_period;
+    max_proposals = 500n;
+    max_votes = 1000n;
+    proposal_flush_time = data.proposal_flush_time;
+    proposal_expired_time = data.proposal_expired_time;
+    custom_entrypoints = (Big_map.empty : custom_entrypoints);
+  }
 
 let ledger_constructor (ledger, param : ledger * (ledger_key * ledger_value)) : ledger =
   let (key, value) = param in
@@ -36,6 +44,7 @@ let default_storage (data, config_data : initial_storage_data * initial_config_d
     operators = (Big_map.empty : operators);
     governance_token = data.governance_token;
     admin = data.admin;
+    guardian = data.guardian;
     pending_owner = data.admin;
     metadata = data.metadata_map;
     extra = (Big_map.empty : (string, bytes) big_map);

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -151,6 +151,7 @@ type storage =
   ; operators : operators
   ; governance_token : governance_token
   ; admin : address
+  ; guardian : address // A special role that can drop any proposals at anytime
   ; pending_owner : address
   ; metadata : metadata_map
   ; extra : contract_extra
@@ -252,11 +253,14 @@ type ledger_list = (ledger_key * ledger_value) list
 type initial_config_data =
   { quorum_threshold : quorum_threshold
   ; voting_period : voting_period
+  ; proposal_flush_time: seconds
+  ; proposal_expired_time: seconds
   ; fixed_proposal_fee_in_token: nat
   }
 
 type initial_storage_data =
   { admin : address
+  ; guardian : address
   ; governance_token : governance_token
   ; now_val : timestamp
   ; metadata_map : metadata_map
@@ -278,6 +282,8 @@ type config =
   ; quorum_threshold : quorum_threshold
   ; voting_period : voting_period
   ; fixed_proposal_fee_in_token : nat
+  ; proposal_flush_time: seconds // Number of seconds until a proposal can be flushed
+  ; proposal_expired_time: seconds // Number of seconds until a proposal is expired
 
   ; custom_entrypoints : custom_entrypoints
   }


### PR DESCRIPTION
## Description

Problem: Problem: Basically, in a case when a proposal get accepted but it containsoperation that fails, we have the `drop_proposal` entrypoint to remove this proposal.This entrypoint can only be call by the `admin` currently. We no longer want this, andwe want it to be called by anyone. As a result, we need to update to the current `flush`
process, add expiry process, and update `drop_proposal` logic.

Original gist/discussion: https://gist.github.com/gromakovsky/cd03f73f1f5dcc9640def18d0eee642d

Solution: Add `proposal_flush_time_reached` and `proposal_expired_time` to
config, add `guardian` to `storage`, update `flush` and `drop_proposal`
logic.

Detail: https://github.com/tqtezos/baseDAO/issues/87#issuecomment-839716850


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #87

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
