### PR TITLE
[TM-546] Remove edo2net tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -98,9 +98,9 @@ steps:
       - known_metadata.json
 
   # TODO #124 uncomment:
-  # - label: ligo-test-local-chain-008
+  # - label: ligo-test-local-chain-009
   #   env:
-  #     TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8733"
+  #     TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8734"
   #   if: *not_scheduled
   #   depends_on:
   #     - build-ligo
@@ -114,19 +114,6 @@ steps:
   #   - nix run -f ci.nix tezos-client -c
   #     ./result/bin/baseDAO-test --nettest-run-network
   #       --pattern '\$1 == "On network" || \$NF == "On network" || \$0 ~ /.On network./'
-
-  # TODO #124 uncomment:
-  # - label: ligo-test-local-chain-009
-  #   env:
-  #     TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8734"
-  #   if: *not_scheduled
-  #   depends_on:
-  #     - build-ligo
-  #     - build-haskell
-  #     - ligo-test
-  #     # NOTE ^ this last dependency is not strictly necessary, but it saves us
-  #     # from building the tests twice and 'ligo-test' running time is mostly that.
-  #   commands: *ligo-nettest
 
   - label: check typescript api
     if: *not_scheduled
@@ -160,19 +147,6 @@ steps:
     depends_on: build-haskell
     commands:
     - nix-build ci.nix -A haddock --no-out-link
-
-  # TODO #124 uncomment:
-  # - label: scheduled edonet ligo test
-  #   if: build.source == "schedule"
-  #   env:
-  #     TASTY_NETTEST_NODE_ENDPOINT: "http://edo.testnet.tezos.serokell.team:8732"
-  #   depends_on:
-  #     - build-ligo
-  #     - build-haskell
-  #   commands: *ligo-nettest
-  #   retry:
-  #     automatic:
-  #       limit: 1
 
   # TODO #124 uncomment:
   # - label: scheduled florencenet ligo test


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

Problem: protocol 008 has become obsolete.

Solution: remove tests for 008 local chain and edo2net from the CI.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves part of TM-546

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).