### PR TITLE
[#242] modify RegistryDAO proposals to transfer with registry updates

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -22,10 +22,7 @@ There is additional data to implement configuration lambdas, it's an implementat
 
 Proposals can be of different type and include (`proposal_metadata`) different data:
 
-1. Standard proposals contain:
-   - `nat %agoraPostID` is used to refer to an Agora post explaining the proposed changes and motivation for them.
-   - a list of `update` items parameterized by `k` and `v` types. Each `update` item contains a key of the type `k` and a new value of the type `option v`.
-2. Proposals to update the parameters specified below taking
+1. Proposals to update the parameters specified below taking
    - 5 `option nat` values:
       - `max_proposal_size`
       - `frozen_scale_value`
@@ -35,11 +32,15 @@ Proposals can be of different type and include (`proposal_metadata`) different d
    - 2 `option tez` values
       - `min_xtz_amount`
       - `max_xtz_amount`
-3. Proposal to update the set of successful-proposal receiver contract addresses.
+2. Proposal to update the set of successful-proposal receiver contract addresses.
 This proposal takes a parameter that has two constructors. The proposal can add to,
 or remove from the set of addresses.
-4. Transfer proposals, that can transfer XTZ or tokens.
-Modeled just the same way as [treasuryDAO proposals](./treasury.md).
+3. Transfer proposals, that can transfer XTZ or tokens as well as update the
+registry. This includes:
+   - a list of `update` items parameterized by `k` and `v` types. Each `update` item contains a key of the type `k` and a new value of the type `option v`.
+   - a list of items where each item contains:
+   `or %transfers (pair (mutez %amount) (address %recipient)) (pair (address %fa2) (list (pair (address %from_) (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount)))))))` specifies what transfer to make. The left part is used for XTZ transfers, the right part is used for FA2 transfers.
+   - `nat %agoraPostID` is used to refer to an Agora post explaining the proposed transfer and/or changes and motivation for them.
 
 ## Configuration lambdas
 

--- a/docs/treasury.md
+++ b/docs/treasury.md
@@ -9,8 +9,9 @@ Treasury is a DAO that holds XTZ and FA2 tokens and lets its users decide how to
 spend its XTZ and tokens. Its extra storage data is empty.
 
 Its `proposal_metadata` contains a proposal type:
-- Transfer proposal that includes a list of items where each item contains:
-   - `or %transfers (pair (mutez %amount) (address %recipient)) (pair (address %fa2) (list (pair (address %from_) (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount)))))))` specifies what transfer to make. The left part is used for XTZ transfers, the right part is used for FA2 transfers.
+- Transfer proposal that includes:
+   - a list of items where each item contains:
+   `or %transfers (pair (mutez %amount) (address %recipient)) (pair (address %fa2) (list (pair (address %from_) (list %txs (pair (address %to_) (pair (nat %token_id) (nat %amount)))))))` specifies what transfer to make. The left part is used for XTZ transfers, the right part is used for FA2 transfers.
    - `nat %agoraPostID` is used to refer to an Agora post explaining the proposed transfer and motivation for it.
 
 ## Configuration lambdas

--- a/haskell/test/Test/Ligo/BaseDAO/Common.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Common.hs
@@ -8,7 +8,6 @@
 module Test.Ligo.BaseDAO.Common
   ( DaoOriginateData(..)
   , OriginateFn
-  , TransferProposal(..)
   , totalSupplyFromLedger
 
   , frozenTokens
@@ -45,7 +44,6 @@ import Util.Named
 
 import qualified Data.Map as M
 import qualified Data.Set as S
-import Ligo.BaseDAO.Common.Types (TransferType)
 import Ligo.BaseDAO.Contract
 import Ligo.BaseDAO.Types
 import Test.Ligo.BaseDAO.Common.StorageHelper as StorageHelper
@@ -63,19 +61,6 @@ data DaoOriginateData = DaoOriginateData
   , dodAdmin :: Address
   , dodGuardian :: TAddress (Address, ProposalKey)
   }
-
--- | Shared Proposal type used in Registry DAO and Treasury DAO
-data TransferProposal = TransferProposal
-  { tpAgoraPostId :: Natural
-  , tpTransfers :: [TransferType]
-  }
-
-instance HasAnnotation TransferProposal where
-  annOptions = baseDaoAnnOptions
-
-customGeneric "TransferProposal" ligoLayout
-deriving anyclass instance IsoValue TransferProposal
-
 
 -- | A dummy contract with FA2 parameter that remembers the
 -- transfer calls.

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -21,10 +21,21 @@ import Ligo.BaseDAO.Common.Types
 import Ligo.BaseDAO.Types
 import Ligo.Util
 import Test.Ligo.BaseDAO.Common
-  ( DaoOriginateData(..), OriginateFn, TransferProposal(..)
-  , checkTokenBalance, makeProposalKey, originateLigoDaoWithBalance, sendXtz )
+  ( DaoOriginateData(..), OriginateFn, checkTokenBalance, makeProposalKey
+  , originateLigoDaoWithBalance, sendXtz )
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
+
+data TransferProposal = TransferProposal
+  { tpAgoraPostId :: Natural
+  , tpTransfers :: [TransferType]
+  }
+
+instance HasAnnotation TransferProposal where
+  annOptions = baseDaoAnnOptions
+
+customGeneric "TransferProposal" ligoLayout
+deriving anyclass instance IsoValue TransferProposal
 
 -- | Helper type for unpack/pack
 type TreasuryDaoProposalMetadata = TransferProposal

--- a/src/common/types.mligo
+++ b/src/common/types.mligo
@@ -25,11 +25,6 @@ type transfer_type =
   | Xtz_transfer_type of xtz_transfer
   | Token_transfer_type of token_transfer
 
-type transfer_proposal =
-  { agora_post_id : nat
-  ; transfers : transfer_type list
-  }
-
 // -- Unpack Helpers (fail if the unpacked result is none) -- //
 
 let unpack_transfer_type_list (key_name, packed_b: string * bytes) : transfer_type list =

--- a/src/registryDAO/types.mligo
+++ b/src/registryDAO/types.mligo
@@ -16,8 +16,9 @@ type update_receiver_param =
   | Add_receivers of (address list)
   | Remove_receivers of (address list)
 
-type normal_proposal =
+type transfer_proposal =
   { agora_post_id : nat
+  ; transfers : transfer_type list
   ; registry_diff : registry_diff
   }
 
@@ -31,7 +32,6 @@ type config_proposal =
 
 // Registry dao `proposal_metadata` contains the type of proposal.
 type registry_dao_proposal_metadata =
-  | Normal_proposal of normal_proposal
   | Update_receivers_proposal of update_receiver_param
   | Configuration_proposal of config_proposal
   | Transfer_proposal of transfer_proposal

--- a/src/treasuryDAO.mligo
+++ b/src/treasuryDAO.mligo
@@ -75,7 +75,6 @@ let treasury_DAO_decision_lambda (proposal, extras : proposal * contract_extra)
   if is_valid then
     (ops, extras)
   else
-    // TODO: [#87] Improve handling of failed proposals
     (failwith("FAIL_DECISION_LAMBDA") : operation list * contract_extra)
 
 // A custom entrypoint needed to receive xtz, since most `basedao` entrypoints

--- a/src/treasuryDAO/types.mligo
+++ b/src/treasuryDAO/types.mligo
@@ -20,8 +20,10 @@ type initial_treasuryDAO_storage =
   }
 
 // Treasury dao `proposal_metadata` contains the type of proposal.
-// Currently only `transfer_proposal` type exists.
-type treasury_dao_proposal_metadata = transfer_proposal
+type treasury_dao_proposal_metadata =
+  { agora_post_id : nat
+  ; transfers : transfer_type list
+  }
 
 
 // -- Unpack Helpers (fail if the unpacked result is none) -- //


### PR DESCRIPTION
## Description

Modifies RegistryDAO proposal types and lambda implementation to allow for transfers and registry updates in the same proposal.

Note: currently based on top of #244

## Related issue(s)

Resolves #242

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
