### PR TITLE
[#229] store voting stage number in proposals

### DIFF
--- a/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/Types.hs
@@ -437,7 +437,7 @@ data Proposal = Proposal
   { plUpvotes                 :: Natural
   , plDownvotes               :: Natural
   , plStartDate               :: Timestamp
-  , plPeriodNum               :: Natural
+  , plVotingStageNum          :: Natural
 
   , plMetadata                :: ProposalMetadata
 

--- a/src/proposal.mligo
+++ b/src/proposal.mligo
@@ -35,7 +35,7 @@ let get_current_period_num(start_time, vp_length : timestamp * voting_period) : 
 [@inline]
 let ensure_proposal_voting_period (proposal, voting_period, store : proposal * voting_period * storage): storage =
   let current_period = get_current_period_num(store.start_time, voting_period) in
-  if current_period = (proposal.period_num + 1n)
+  if current_period = proposal.voting_stage_num
   then store
   else (failwith("VOTING_PERIOD_OVER") : storage)
 
@@ -207,7 +207,7 @@ let add_proposal (propose_params, voting_period, store : propose_params * voting
     { upvotes = 0n
     ; downvotes = 0n
     ; start_date = timestamp
-    ; period_num = current_period
+    ; voting_stage_num = current_period + 1n
     ; metadata = propose_params.proposal_metadata
     ; proposer = Tezos.sender
     ; proposer_frozen_token = propose_params.frozen_token
@@ -332,7 +332,7 @@ let unfreeze_proposer_and_voter_token
 [@inline]
 let is_voting_period_over (proposal, voting_period, store : proposal * voting_period * storage): bool =
   let current_period = get_current_period_num(store.start_time, voting_period) in
-  current_period > proposal.period_num + 1n
+  current_period > proposal.voting_stage_num
 
 [@inline]
 let is_time_reached (proposal, sec : proposal * seconds): bool =

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -130,7 +130,8 @@ type proposal =
   { upvotes : nat
   ; downvotes : nat
   ; start_date : timestamp
-  ; period_num : nat
+  ; voting_stage_num : nat
+  // ^ stage number in which it is possible to vote on this proposal
   ; metadata : proposal_metadata
   ; proposer : address
   ; proposer_frozen_token : nat


### PR DESCRIPTION
## Description

Problem: when creating a new proposal we store the stage number in
which this was created, however we only need to know in which stage
number this can be voted on.

Solution: modify the proposal type to contain the voting period
stage.

Note: currently based on #245 

## Related issue(s)

Resolves #229

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
