### PR TITLE
[#234] Throw more and better failure messages on storage creation

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -117,7 +117,7 @@ rec {
     name = "baseDAO-ligo";
     src = ./.;
     nativeBuildInputs = [ ligo ];
-    buildPhase = "make";
+    buildPhase = "make all; make test-storage";
     installPhase = "mkdir -p $out; cp -r out/* $out";
   };
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -24,13 +24,6 @@ which will use `ligo compile-contract` and save the result in `out/baseDAO.tz`.
 If you prefer to build it manually, the contract's main entrypoint is
 `base_DAO_contract`, located in [src/base_DAO.mligo](../src/base_DAO.mligo).
 
-You can also use:
-```sh
-make all
-```
-to generate the contract as well as all the example DAOs' initial storage
-defined below.
-
 ## Generating a contract storage
 
 You can use `ligo` to also generate a contract initial storage, using the
@@ -49,9 +42,9 @@ make out/trivialDAO_storage.tz \
   governance_token_address=KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5 \
   governance_token_id=0n \
   now_val=`date +"%s"` \
-  metadata_map=(Big_map.empty : metadata_map) \
+  metadata_map=Big_map.empty \
   fixed_proposal_fee_in_token=0n \
-  ledger=([] : ledger_list) \
+  ledger=[] \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
@@ -63,8 +56,9 @@ make out/trivialDAO_storage.tz \
   proposal_expired_time=2851200n
 ```
 
-All its arguments are optional and will be equal to the values above if not
-specified.
+The `admin_address`, `guardian_address`, `governance_token_address`, and `governance_token_id`
+are required values. For the rest of the arguments, they are optional and will be equal to the
+values above if not specified.
 
 You can see the [specification](specification.md) for more info about these
 values.
@@ -87,9 +81,9 @@ make out/registryDAO_storage.tz \
   min_xtz_amount=0mutez \
   max_xtz_amount=100mutez \
   now_val=`date +"%s"` \
-  metadata_map=(Big_map.empty : metadata_map) \
+  metadata_map="Big_map.empty" \
   fixed_proposal_fee_in_token=0n \
-  ledger=([] : ledger_list) \
+  ledger="[]" \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
@@ -101,8 +95,9 @@ make out/registryDAO_storage.tz \
   governance_total_supply=100n
 ```
 
-All its arguments are optional and will be equal to the values above if not
-specified.
+The `admin_address`, `guardian_address`, `governance_token_address`, and `governance_token_id`
+are required values. For the rest of the arguments, they are optional and will be equal to the
+values above if not specified.
 
 ### TreasuryDAO
 
@@ -122,9 +117,9 @@ make out/treasuryDAO_storage.tz \
   min_xtz_amount=0mutez \
   max_xtz_amount=100mutez \
   now_val=`date +"%s"` \
-  metadata_map=(Big_map.empty : metadata_map) \
+  metadata_map=Big_map.empty \
   fixed_proposal_fee_in_token=0n \
-  ledger=([] : ledger_list) \
+  ledger=[] \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
@@ -136,8 +131,9 @@ make out/treasuryDAO_storage.tz \
   governance_total_supply=100n
 ```
 
-As for the other examples, all the arguments are optional and will be equal to
-the values above the values above if not specified.
+The `admin_address`, `guardian_address`, `governance_token_address`, and `governance_token_id`
+are required values. For the rest of the arguments, they are optional and will be equal to the
+values above if not specified.
 
 ## Storage generation checks
 The LIGO functions used by the `Makefile` targets above perform some automatic check, specifically:

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -4,15 +4,24 @@
 #include "types.mligo"
 #include "proposal.mligo"
 
-let validate_default_config (data : initial_config_data) : unit =
+let validate_proposal_flush_expired_time (data : initial_config_data) : unit =
   if data.proposal_expired_time <= data.proposal_flush_time then
-    failwith("proposal_expired_time needs to be bigger than proposal_flush_time")
+    failwith("'proposal_expired_time' needs to be bigger than 'proposal_flush_time'.")
   else if data.proposal_flush_time <= (data.period.length * 2n) then
-    failwith("proposal_flush_time needs to be more than twice the period length")
+    failwith("'proposal_flush_time' needs to be more than twice the 'period' length.")
   else unit
 
+let validate_quorum_threshold_bound (data : initial_config_data) : unit =
+  if data.quorum_threshold >= data.max_quorum then
+    failwith("'quorum_threshold' needs to be smaller than or equal to 'max_quorum'")
+  else if data.quorum_threshold <= data.min_quorum then
+    failwith("'quorum_threshold' needs to be bigger than or equal to 'min_quorum'")
+  else
+    unit
+
 let default_config (data : initial_config_data) : config =
-  let _ : unit = validate_default_config(data) in {
+  let _ : unit = validate_proposal_flush_expired_time(data) in
+  let _ : unit = validate_quorum_threshold_bound(data) in {
     proposal_check = (fun (_params, _extras : propose_params * contract_extra) -> true);
     rejected_proposal_slash_value = (fun (_proposal, _extras : proposal * contract_extra) -> 0n);
     decision_lambda = (fun (_proposal, extras : proposal * contract_extra) -> (([] : (operation list)), extras));


### PR DESCRIPTION
## Description

Problem: Currently, we provide `Makefile` arugments by default and we
handle some storage check silently. This is not really a good idea.

Solution: Remove default values in `Makefile`, and throw error instead.
Add more validate function to storage generation.



<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #234 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
