### PR TITLE
[#47] Implement batch calls in tests where possible

### DIFF
--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -1,5 +1,6 @@
 -- SPDX-FileCopyrightText: 2021 TQ Tezos
 -- SPDX-License-Identifier: LicenseRef-MIT-TQ
+{-# LANGUAGE ApplicativeDo #-}
 
 module Test.Ligo.BaseDAO.Proposal
   ( test_BaseDAO_Proposal

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Propose.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Propose.hs
@@ -334,8 +334,7 @@ dropProposal originateFn = withFrozenCallStack $ do
   -- Advance one voting period to a proposing stage.
   advanceLevel 20
 
-  key1 <- createSampleProposal 1 dodOwner1 dodDao
-  key2 <- createSampleProposal 2 dodOwner1 dodDao
+  (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
 
   -- Advance one voting period to a voting stage.
   advanceLevel 20

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
@@ -67,8 +67,7 @@ voteMultiProposals originateFn = do
   advanceLevel dodPeriod
 
   -- Create sample proposal
-  key1 <- createSampleProposal 1 dodOwner1 dodDao
-  key2 <- createSampleProposal 2 dodOwner1 dodDao
+  (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
   let params = fmap NoPermit
         [ VoteParam
             { vVoteType = True


### PR DESCRIPTION
Problem: In our tests, we sometimes send consecutive calls from the same
sender. And in some such places batching can be implemented to make it
faster.

Solution: Find such places, and use batching there. Three places have
been left out because it appear not easy to batch `createSampleProposal`
calls without duplicating some code.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves part of #47 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
