### PR TITLE
[#257] Prevent empty transactions in transfer proposals

### DIFF
--- a/src/registryDAO.mligo
+++ b/src/registryDAO.mligo
@@ -72,7 +72,7 @@ let registry_DAO_proposal_check (params, extras : propose_params * contract_extr
         let is_all_transfers_valid (is_valid, transfer_type: bool * transfer_type) =
           match transfer_type with
           | Token_transfer_type _tt -> is_valid
-          | Xtz_transfer_type xt -> is_valid && min_xtz_amount <= xt.amount && xt.amount <= max_xtz_amount
+          | Xtz_transfer_type xt -> min_xtz_amount <= xt.amount && xt.amount <= max_xtz_amount
         in
         List.fold is_all_transfers_valid tp.transfers has_correct_token_lock
     | Update_receivers_proposal _urp -> has_correct_token_lock

--- a/src/registryDAO.mligo
+++ b/src/registryDAO.mligo
@@ -72,7 +72,9 @@ let registry_DAO_proposal_check (params, extras : propose_params * contract_extr
         let is_all_transfers_valid (is_valid, transfer_type: bool * transfer_type) =
           match transfer_type with
           | Token_transfer_type _tt -> is_valid
-          | Xtz_transfer_type xt -> min_xtz_amount <= xt.amount && xt.amount <= max_xtz_amount
+          | Xtz_transfer_type xt ->
+                 is_valid && xt.amount <> 0mutez
+              && min_xtz_amount <= xt.amount && xt.amount <= max_xtz_amount
         in
         List.fold is_all_transfers_valid tp.transfers has_correct_token_lock
     | Update_receivers_proposal _urp -> has_correct_token_lock

--- a/src/treasuryDAO.mligo
+++ b/src/treasuryDAO.mligo
@@ -32,7 +32,7 @@ let treasury_DAO_proposal_check (params, extras : propose_params * contract_extr
     let is_all_transfers_valid (is_valid, transfer_type: bool * transfer_type) =
       match transfer_type with
       | Token_transfer_type _tt -> is_valid
-      | Xtz_transfer_type xt -> is_valid && min_xtz_amount <= xt.amount && xt.amount <= max_xtz_amount
+      | Xtz_transfer_type xt -> min_xtz_amount <= xt.amount && xt.amount <= max_xtz_amount
     in
       List.fold is_all_transfers_valid pm.transfers true
   else

--- a/src/treasuryDAO.mligo
+++ b/src/treasuryDAO.mligo
@@ -32,7 +32,9 @@ let treasury_DAO_proposal_check (params, extras : propose_params * contract_extr
     let is_all_transfers_valid (is_valid, transfer_type: bool * transfer_type) =
       match transfer_type with
       | Token_transfer_type _tt -> is_valid
-      | Xtz_transfer_type xt -> min_xtz_amount <= xt.amount && xt.amount <= max_xtz_amount
+      | Xtz_transfer_type xt ->
+             is_valid && xt.amount <> 0mutez
+          && min_xtz_amount <= xt.amount && xt.amount <= max_xtz_amount
     in
       List.fold is_all_transfers_valid pm.transfers true
   else


### PR DESCRIPTION
## Description

Problem: Both `treasuryDAO` and `registryDAO` have proposals
that can support xtz transfers.
Both implement `handle_transfer` for `Xtz_transfer_type` in a way
that can fail: empty transactions (of `unit` parameter an `0` amount)
will be rejected by the network.

Solution: `proposal_check` now reject proposal that contains
`Xtz_transfer_type` with 0 mutez, add tests to cover this.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #257 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
