### PR TITLE
[#256] Allow more xtz entrypoints

### DIFF
--- a/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/Types.hs
@@ -456,12 +456,10 @@ type UnfreezeParam = ("amount" :! Natural)
 -- issue has been fixed:
 -- https://gitlab.com/morley-framework/morley/-/issues/527
 data ForbidXTZParam
-  = Accept_ownership ()
-  | Call_FA2 FA2.Parameter
+  = Call_FA2 FA2.Parameter
   | Drop_proposal ProposalKey
   | Flush Natural
   | Freeze FreezeParam
-  | Transfer_ownership TransferOwnershipParam
   | Unfreeze UnfreezeParam
   | Vote [PermitProtected VoteParam]
   deriving stock (Show)
@@ -470,6 +468,8 @@ data AllowXTZParam
   = CallCustom CallCustomParam
   | Propose ProposeParams
   | Transfer_contract_tokens TransferContractTokensParam
+  | Transfer_ownership TransferOwnershipParam
+  | Accept_ownership ()
   deriving stock (Show)
 
 data Parameter

--- a/haskell/test/Test/Ligo/BaseDAO/Management.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Management.hs
@@ -17,10 +17,8 @@ import Lorentz as L hiding (now, (>>))
 import Michelson.Runtime.GState (genesisAddress)
 import Michelson.Typed (convertContract)
 import Michelson.Typed.Convert (untypeValue)
-import Michelson.Untyped.Entrypoints (unsafeBuildEpName)
 import Morley.Nettest
 import Morley.Nettest.Tasty (nettestScenarioCaps)
-import Tezos.Core (unsafeMkMutez)
 import Util.Named
 
 import Ligo.BaseDAO.Contract
@@ -51,18 +49,7 @@ withOriginated addrCount storageFn tests = do
 test_BaseDAO_Management :: [TestTree]
 test_BaseDAO_Management =
   [ testGroup "Ownership transfer"
-    [ nettestScenarioCaps "Contract forbids XTZ transfer" $ do
-        now <- getNow
-        withOriginated 2 (\(owner:_) -> initialStorage now owner) $ \[owner, wallet1] baseDao ->
-          withSender owner $ transfer TransferData
-            { tdTo = unTAddress baseDao
-            , tdAmount = unsafeMkMutez 1
-            , tdEntrypoint = unsafeBuildEpName "transfer_ownership"
-            , tdParameter = (#newOwner .! wallet1)
-            }
-          & expectForbiddenXTZ baseDao
-
-    , nettestScenarioCaps "transfer ownership entrypoint authenticates sender" $ do
+    [ nettestScenarioCaps "transfer ownership entrypoint authenticates sender" $ do
         now <- getNow
         transferOwnership withOriginated (initialStorage now)
 
@@ -259,8 +246,3 @@ expectNotPendingOwner
   :: (MonadNettest caps base m, ToAddress addr)
   => addr -> m a -> m ()
 expectNotPendingOwner = expectCustomErrorNoArg #nOT_PENDING_ADMIN
-
-expectForbiddenXTZ
-  :: (MonadNettest caps base m, ToAddress addr)
-  => addr -> m a -> m ()
-expectForbiddenXTZ = expectCustomErrorNoArg #fORBIDDEN_XTZ

--- a/src/base_DAO.mligo
+++ b/src/base_DAO.mligo
@@ -22,8 +22,6 @@ let requiring_no_xtz (param, store, config : forbid_xtz_params * storage * confi
     match param with
     | Call_FA2 (p)           -> call_fa2(p, store)
     | Drop_proposal (p)      -> drop_proposal(p, config, store)
-    | Transfer_ownership (p) -> transfer_ownership(p, store)
-    | Accept_ownership       -> accept_ownership(store)
     | Vote (p)               -> vote(p, config, store)
     | Flush (p)              -> flush (p, config, store)
     | Freeze p               -> freeze(p, config, store)
@@ -38,6 +36,8 @@ let allowing_xtz (param, store, config : allow_xtz_params * storage * config) =
   | CallCustom p               -> call_custom(p, store, config)
   | Propose (p)                -> propose(p, config, store)
   | Transfer_contract_tokens p -> transfer_contract_tokens(p, store)
+  | Transfer_ownership (p)     -> transfer_ownership(p, store)
+  | Accept_ownership           -> accept_ownership(store)
 
 (*
  * The actual DAO contract, which in this version is the same independently from

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -264,8 +264,6 @@ type transfer_contract_tokens_param =
 type forbid_xtz_params =
   | Call_FA2 of fa2_parameter
   | Drop_proposal of proposal_key
-  | Transfer_ownership of transfer_ownership_param
-  | Accept_ownership of unit
   | Vote of vote_param_permited list
   | Flush of nat
   | Freeze of freeze_param
@@ -278,6 +276,8 @@ type allow_xtz_params =
   | CallCustom of custom_ep_param
   | Propose of propose_params
   | Transfer_contract_tokens of transfer_contract_tokens_param
+  | Transfer_ownership of transfer_ownership_param
+  | Accept_ownership of unit
 
 (*
  * Full parameter of the contract.


### PR DESCRIPTION
## Description

Problem: We currently have a safety check for most entrypoints to
disallow xtz tokens to be mistakenly sent to the contract and allow
these funds to be stuck there.
We need to reconsider on which entrypoints we should keep this check
and on which we don't need to (see #91).

Solution: Move `accept_ownership` and `transfer_ownership` to
`allowing_xtz` entrypoints.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #256 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
