### PR TITLE
[#233] allow setting max_votes in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,11 @@ $(OUT)/trivialDAO_storage.tz : ledger = []
 $(OUT)/trivialDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/trivialDAO_storage.tz : min_quorum = 1n
 $(OUT)/trivialDAO_storage.tz : max_quorum = 99n
+$(OUT)/trivialDAO_storage.tz : max_votes = 1000n
 $(OUT)/trivialDAO_storage.tz : period = 950400n # 11 days
 $(OUT)/trivialDAO_storage.tz : quorum_change = 5n
 $(OUT)/trivialDAO_storage.tz : max_quorum_change = 19n
-$(OUT)/trivialDAO_storage.tz : governance_total_supply = 100n
+$(OUT)/trivialDAO_storage.tz : governance_total_supply = 1000n
 $(OUT)/trivialDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
 $(OUT)/trivialDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
 $(OUT)/trivialDAO_storage.tz: src/**
@@ -88,6 +89,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
         ; config_data = \
           { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
           ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
+          ; max_votes = ($(max_votes) : nat) \
           ; period = { length = ($(period) : nat) } \
           ; proposal_flush_time = ($(proposal_flush_time)  : nat) \
           ; proposal_expired_time = ($(proposal_expired_time) : nat) \
@@ -116,12 +118,13 @@ $(OUT)/registryDAO_storage.tz : ledger = []
 $(OUT)/registryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/registryDAO_storage.tz : min_quorum = 1n
 $(OUT)/registryDAO_storage.tz : max_quorum = 99n
+$(OUT)/registryDAO_storage.tz : max_votes = 1000n
 $(OUT)/registryDAO_storage.tz : period = 950400n # 11 days
 $(OUT)/registryDAO_storage.tz : quorum_change = 5n
 $(OUT)/registryDAO_storage.tz : max_quorum_change = 19n
 $(OUT)/registryDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
 $(OUT)/registryDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
-$(OUT)/registryDAO_storage.tz : governance_total_supply = 100n
+$(OUT)/registryDAO_storage.tz : governance_total_supply = 1000n
 $(OUT)/registryDAO_storage.tz: src/**
 	# ============== Compiling RegistryDAO storage ============== #
 	mkdir -p $(OUT)
@@ -142,6 +145,7 @@ $(OUT)/registryDAO_storage.tz: src/**
           ; config_data = \
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
             ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
+            ; max_votes = ($(max_votes) : nat) \
             ; period = { length = ($(period) : nat) } \
             ; proposal_flush_time = ($(proposal_flush_time)  : nat) \
             ; proposal_expired_time = ($(proposal_expired_time) : nat) \
@@ -177,12 +181,13 @@ $(OUT)/treasuryDAO_storage.tz : ledger = []
 $(OUT)/treasuryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/treasuryDAO_storage.tz : min_quorum = 1n
 $(OUT)/treasuryDAO_storage.tz : max_quorum = 99n
+$(OUT)/treasuryDAO_storage.tz : max_votes = 1000n
 $(OUT)/treasuryDAO_storage.tz : period = 950400n # 11 days
 $(OUT)/treasuryDAO_storage.tz : quorum_change = 5n
 $(OUT)/treasuryDAO_storage.tz : max_quorum_change = 19n
 $(OUT)/treasuryDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
 $(OUT)/treasuryDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
-$(OUT)/treasuryDAO_storage.tz : governance_total_supply = 100n
+$(OUT)/treasuryDAO_storage.tz : governance_total_supply = 1000n
 $(OUT)/treasuryDAO_storage.tz: src/**
 	# ============== Compiling TreasuryDAO storage ============== #
 	mkdir -p $(OUT)
@@ -203,6 +208,7 @@ $(OUT)/treasuryDAO_storage.tz: src/**
           ; config_data = \
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
             ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
+            ; max_votes = ($(max_votes) : nat) \
             ; period = { length = ($(period) : nat) } \
             ; proposal_flush_time = ($(proposal_flush_time)  : nat) \
             ; proposal_expired_time = ($(proposal_expired_time) : nat) \

--- a/docs/building.md
+++ b/docs/building.md
@@ -48,10 +48,11 @@ make out/trivialDAO_storage.tz \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
+  max_votes=1000n \
   period=950400n \
   quorum_change=5n \
   max_quorum_change=19n \
-  governance_total_supply=100n \
+  governance_total_supply=1000n \
   proposal_flush_time=1900801n \
   proposal_expired_time=2851200n
 ```
@@ -87,12 +88,13 @@ make out/registryDAO_storage.tz \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
+  max_votes=1000n \
   period=950400n \
   quorum_change=5n \
   max_quorum_change=19n \
   proposal_flush_time=1900801n \
   proposal_expired_time=2851200n \
-  governance_total_supply=100n
+  governance_total_supply=1000n
 ```
 
 The `admin_address`, `guardian_address`, `governance_token_address`, and `governance_token_id`
@@ -123,12 +125,13 @@ make out/treasuryDAO_storage.tz \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
+  max_votes=1000n \
   period=950400n \
   quorum_change=5n \
   max_quorum_change=19n \
   proposal_flush_time=1900801n \
   proposal_expired_time=2851200n \
-  governance_total_supply=100n
+  governance_total_supply=1000n
 ```
 
 The `admin_address`, `guardian_address`, `governance_token_address`, and `governance_token_id`

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -11,6 +11,12 @@ let validate_proposal_flush_expired_time (data : initial_config_data) : unit =
     failwith("'proposal_flush_time' needs to be more than twice the 'period' length.")
   else unit
 
+let validate_max_votes (data : initial_config_data) : unit =
+  if data.max_votes > data.governance_total_supply then
+    failwith("The 'max_votes' number cannot exceed the 'governance_total_supply'.")
+  // TODO #271: check for maximum reasonable value
+  else unit
+
 let validate_quorum_threshold_bound (data : initial_config_data) : unit =
   if data.quorum_threshold >= data.max_quorum then
     failwith("'quorum_threshold' needs to be smaller than or equal to 'max_quorum'")
@@ -21,6 +27,7 @@ let validate_quorum_threshold_bound (data : initial_config_data) : unit =
 
 let default_config (data : initial_config_data) : config =
   let _ : unit = validate_proposal_flush_expired_time(data) in
+  let _ : unit = validate_max_votes(data) in
   let _ : unit = validate_quorum_threshold_bound(data) in {
     proposal_check = (fun (_params, _extras : propose_params * contract_extra) -> true);
     rejected_proposal_slash_value = (fun (_proposal, _extras : proposal * contract_extra) -> 0n);
@@ -28,7 +35,7 @@ let default_config (data : initial_config_data) : config =
     fixed_proposal_fee_in_token = data.fixed_proposal_fee_in_token;
     period = data.period;
     max_proposals = 500n;
-    max_votes = 1000n;
+    max_votes = data.max_votes;
     max_quorum_threshold = to_signed(data.max_quorum);
     min_quorum_threshold = to_signed(data.min_quorum);
     max_quorum_change = to_signed(data.max_quorum_change);

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -304,6 +304,7 @@ type initial_config_data =
   { max_quorum : quorum_threshold
   ; min_quorum : quorum_threshold
   ; quorum_threshold : quorum_threshold
+  ; max_votes : nat
   ; period : period
   ; proposal_flush_time: seconds
   ; proposal_expired_time: seconds


### PR DESCRIPTION
## Description

Problem: there is no option to set the 'max_vote' configuration field
from the Makefile.

Solution: add an option to Makefile for all 3 storage types and a small
check on its value.

## Related issue(s)

Part of the improvements for #233 

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
