### PR TITLE
[#234] put back escaping in metadata_map and ledger Makefile options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ $(OUT)/trivialDAO_storage.tz: src/**
             ; token_id = ($(call require_defined,governance_token_id) : nat) \
             } \
           ; current_level = {blocks = $(current_level)} \
-          ; metadata_map = ($(metadata_map) : metadata_map) \
-          ; ledger_lst = ($(ledger) : ledger_list) \
+          ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
+          ; ledger_lst = ($(call escape_double_quote,$(ledger)) : ledger_list) \
           } \
         ; config_data = \
           { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
@@ -139,8 +139,8 @@ $(OUT)/registryDAO_storage.tz: src/**
               ; token_id = ($(call require_defined,governance_token_id) : nat) \
               } \
             ; current_level = {blocks = $(current_level)} \
-            ; metadata_map = ($(metadata_map) : metadata_map) \
-            ; ledger_lst = ($(ledger) : ledger_list) \
+            ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
+            ; ledger_lst = ($(call escape_double_quote,$(ledger)) : ledger_list) \
             } \
           ; config_data = \
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
@@ -202,8 +202,8 @@ $(OUT)/treasuryDAO_storage.tz: src/**
               ; token_id = ($(call require_defined,governance_token_id) : nat) \
               } \
             ; current_level = {blocks = $(current_level)} \
-            ; metadata_map = ($(metadata_map) : metadata_map) \
-            ; ledger_lst = ($(ledger) : ledger_list) \
+            ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
+            ; ledger_lst = ($(call escape_double_quote,$(ledger)) : ledger_list) \
             } \
           ; config_data = \
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \


### PR DESCRIPTION
## Description

Problem: in the previous PR for this issue (#251) the escaping of
double quotes was removed by mistake from the 'metadata_map' and
'ledger' options in the Makefile storage targets.

Solution: put the escaping back.

## Related issue(s)

Hotfix for #234

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
