### PR TITLE
[#277] Use max voters instead of max votes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ $(OUT)/trivialDAO_storage.tz : ledger = []
 $(OUT)/trivialDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/trivialDAO_storage.tz : min_quorum = 1n
 $(OUT)/trivialDAO_storage.tz : max_quorum = 99n
-$(OUT)/trivialDAO_storage.tz : max_votes = 1000n
+$(OUT)/trivialDAO_storage.tz : max_voters = 1000n
 $(OUT)/trivialDAO_storage.tz : period = 15840n # 11 days
 $(OUT)/trivialDAO_storage.tz : quorum_change = 5n
 $(OUT)/trivialDAO_storage.tz : max_quorum_change = 19n
@@ -89,7 +89,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
         ; config_data = \
           { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
           ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
-          ; max_votes = ($(max_votes) : nat) \
+          ; max_voters = ($(max_voters) : nat) \
           ; period = { blocks = ($(period) : nat) } \
           ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
           ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) }\
@@ -118,7 +118,7 @@ $(OUT)/registryDAO_storage.tz : ledger = []
 $(OUT)/registryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/registryDAO_storage.tz : min_quorum = 1n
 $(OUT)/registryDAO_storage.tz : max_quorum = 99n
-$(OUT)/registryDAO_storage.tz : max_votes = 1000n
+$(OUT)/registryDAO_storage.tz : max_voters = 1000n
 $(OUT)/registryDAO_storage.tz : period = 15840n # 11 days
 $(OUT)/registryDAO_storage.tz : quorum_change = 5n
 $(OUT)/registryDAO_storage.tz : max_quorum_change = 19n
@@ -145,7 +145,7 @@ $(OUT)/registryDAO_storage.tz: src/**
           ; config_data = \
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
             ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
-            ; max_votes = ($(max_votes) : nat) \
+            ; max_voters = ($(max_voters) : nat) \
             ; period = { blocks = ($(period) : nat) } \
             ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
             ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) } \
@@ -181,7 +181,7 @@ $(OUT)/treasuryDAO_storage.tz : ledger = []
 $(OUT)/treasuryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/treasuryDAO_storage.tz : min_quorum = 1n
 $(OUT)/treasuryDAO_storage.tz : max_quorum = 99n
-$(OUT)/treasuryDAO_storage.tz : max_votes = 1000n
+$(OUT)/treasuryDAO_storage.tz : max_voters = 1000n
 $(OUT)/treasuryDAO_storage.tz : period = 15840n # 11 days
 $(OUT)/treasuryDAO_storage.tz : quorum_change = 5n
 $(OUT)/treasuryDAO_storage.tz : max_quorum_change = 19n
@@ -208,7 +208,7 @@ $(OUT)/treasuryDAO_storage.tz: src/**
           ; config_data = \
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
             ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
-            ; max_votes = ($(max_votes) : nat) \
+            ; max_voters = ($(max_voters) : nat) \
             ; period = { blocks = ($(period) : nat) } \
             ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
             ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) } \

--- a/docs/building.md
+++ b/docs/building.md
@@ -82,7 +82,7 @@ make out/trivialDAO_storage.tz \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
-  max_votes=1000n \
+  max_voters=1000n \
   period=15840n  \
   quorum_change=5n \
   max_quorum_change=19n \
@@ -122,7 +122,7 @@ make out/registryDAO_storage.tz \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
-  max_votes=1000n \
+  max_voters=1000n \
   period=15840n \
   quorum_change=5n \
   max_quorum_change=19n \
@@ -159,7 +159,7 @@ make out/treasuryDAO_storage.tz \
   quorum_threshold=10n \
   min_quorum=1n \
   max_quorum=99n \
-  max_votes=1000n \
+  max_voters=1000n \
   period=15840n  \
   quorum_change=5n \
   max_quorum_change=19n \

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -101,8 +101,9 @@ type config =
 
   ; max_proposals : nat
   // ^ Determine the maximum number of ongoing proposals that are allowed in the contract.
-  ; max_votes : nat
-  // ^ Determine the maximum number of votes associated with a proposal.
+  ; max_voters : nat
+  // ^ Determine the maximum number of voters that are allowed to vote on a proposal.
+  // Voters who votes on a proposal, both ways are counted twice.
   ; max_quorum_threshold : quorum_fraction
   // ^ Determine the maximum value of quorum threshold that is allowed.
   ; min_quorum_threshold : quorum_fraction
@@ -299,6 +300,11 @@ Moreover the proposal to vote on must have been submitted in the proposing `stag
 immediately preceding and the voter must have frozen his tokens in one of the
 preceding `stage`s.
 
+Each vote stakes one frozen token. Staked tokens cannot be unfreezed till they
+are unstaked when the associated proposal is flushed. The number of staked tokens
+only depend on the number of votes, and does not depend on whether the vote is in
+favor or against a proposal.
+
 It's possible to vote positively or negatively.
 After the voting ends, the contract is "flushed" by calling a dedicated entrypoint.
 
@@ -335,7 +341,7 @@ The list of errors may be inaccurate and incomplete, it will be updated during t
 | `QUORUM_NOT_MET`                     | A proposal is flushed, but there are not enough votes                                                                    |
 | `VOTING_STAGE_OVER`                  | Throws when trying to vote on a proposal that is already ended                                                           |
 | `MAX_PROPOSALS_REACHED`              | Throws when trying to propose a proposal when proposals max amount is already reached                                    |
-| `MAX_VOTES_REACHED`                  | Throws when trying to vote on a proposal when the votes max amount of that proposal is already reached                   |
+| `MAX_VOTERS_REACHED`                 | Throws when trying to vote on a proposal when the max voter count of that proposal is already reached                   |
 | `FORBIDDEN_XTZ`                      | Throws when some XTZ was received as part of the contract call                                                           |
 | `PROPOSER_NOT_EXIST_IN_LEDGER`       | Expect a proposer address to exist in Ledger but it is not found                                                         |
 | `PROPOSAL_NOT_UNIQUE`                | Trying to propose a proposal that is already existed in the Storage.                                                     |
@@ -739,7 +745,7 @@ Parameter (in Michelson):
   from past stages that is not staked is less than specified `vote_amount` .
 - Fails with `PROPOSAL_NOT_EXIST` if the proposal key is not associated with any ongoing proposals.
 - Fails with `VOTING_STAGE_OVER` if the voting `stage` for the proposal has already ended.
-- Fails with `MAX_VOTES_REACHED` if the amount of votes of the associated proposal
+- Fails with `MAX_VOTERS_REACHED` if the voter count of the associated proposal
   is already at the max value set by the configuration.
 - Fails with `MISSIGNED` if permit is incorrect with respect to the provided vote parameter and contract state.
 - The entrypoint accepts a list of vote params. As a result, it is possible to

--- a/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/Types.hs
@@ -227,8 +227,7 @@ instance HasAnnotation GovernanceTotalSupply where
 type VoteType = Bool
 
 data Voter = Voter
-  { voterAddress :: Address
-  , voteAmount :: Natural
+  { voteAmount :: Natural
   , voteType :: VoteType
   }
   deriving stock (Show)
@@ -423,7 +422,6 @@ type ContractExtra = ContractExtra' BigMap
 type CustomEntrypoints' big_map = DynamicRec' big_map "ep"
 type CustomEntrypoints = CustomEntrypoints' BigMap
 
-
 data Proposal = Proposal
   { plUpvotes                 :: Natural
   , plDownvotes               :: Natural
@@ -435,7 +433,7 @@ data Proposal = Proposal
   , plProposer                :: Address
   , plProposerFrozenToken     :: Natural
 
-  , plVoters                  :: [Voter]
+  , plVoters                  :: Map (Address, Bool) Natural
   , plQuorumThreshold         :: QuorumThreshold
   }
   deriving stock (Show)
@@ -609,7 +607,7 @@ data Config' big_map = Config'
       :-> '[List Operation, ContractExtra' big_map]
 
   , cMaxProposals :: Natural
-  , cMaxVotes :: Natural
+  , cMaxVoters :: Natural
   , cMaxQuorumThreshold :: QuorumFraction
   , cMinQuorumThreshold :: QuorumFraction
 
@@ -662,7 +660,7 @@ mkConfig customEps votingPeriod fixedProposalFee maxChangePercent changePercent 
   , cMaxQuorumThreshold = percentageToFractionNumerator 99 -- 99%
   , cMinQuorumThreshold = percentageToFractionNumerator 1 -- 1%
 
-  , cMaxVotes = 1000
+  , cMaxVoters = 1000
   , cMaxProposals = 500
   }
 
@@ -847,9 +845,9 @@ instance CustomErrorHasDoc "mAX_PROPOSALS_REACHED" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to propose a proposal when proposals max amount is already reached"
 
-type instance ErrorArg "mAX_VOTES_REACHED" = NoErrorArg
+type instance ErrorArg "mAX_VOTERS_REACHED" = NoErrorArg
 
-instance CustomErrorHasDoc "mAX_VOTES_REACHED" where
+instance CustomErrorHasDoc "mAX_VOTERS_REACHED" where
   customErrClass = ErrClassActionException
   customErrDocMdCause = "Trying to vote on a proposal when the votes max amount of that proposal is already reached"
 

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -51,6 +51,9 @@ test_BaseDAO_Proposal =
       , nettestScenarioOnEmulatorCaps "cannot vote on outdated proposal" $
           voteOutdatedProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
+      , nettestScenarioOnEmulatorCaps "proposal track votes" $
+          proposalCorrectlyTrackVotes (originateLigoDaoWithConfigDesc dynRecUnsafe) getProposalEmulator
+
       ]
 
 
@@ -153,6 +156,9 @@ test_BaseDAO_Proposal =
 
     , nettestScenarioOnEmulatorCaps "the fee is burned if the proposal doesn't meet the quorum" $
         burnsFeeOnFailure QuorumNotMet
+
+    , nettestScenarioOnEmulatorCaps "the frozen tokens are correctly unstaked when address cast multiple votes" $
+        unstakesTokensForMultipleVotes getFreezeHistoryEmulator
     ]
 
   , testGroup "QuorumThreshold Updates"

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Config.hs
@@ -82,7 +82,7 @@ ConfigDesc a >>- ConfigDesc b = ConfigDesc (ConfigDescChain a b)
 
 data ConfigConstants = ConfigConstants
   { cmMaxProposals :: Maybe Natural
-  , cmMaxVotes :: Maybe Natural
+  , cmMaxVoters :: Maybe Natural
   , cmQuorumThreshold :: Maybe DAO.QuorumThreshold
   , cmPeriod :: Maybe DAO.Period
   , cmProposalFlushTime :: Maybe Natural
@@ -184,7 +184,7 @@ decisionLambdaConfig target = ConfigDesc $ passProposerOnDecision target
 instance IsConfigDescExt DAO.Config ConfigConstants where
   fillConfig ConfigConstants{..} DAO.Config'{..} = DAO.Config'
     { cMaxProposals = cmMaxProposals ?: cMaxProposals
-    , cMaxVotes = cmMaxVotes ?: cMaxVotes
+    , cMaxVoters = cmMaxVoters ?: cMaxVoters
     , cProposalFlushTime = cmProposalFlushTime ?: cProposalFlushTime
     , cProposalExpiredTime = cmProposalExpiredTime ?: cProposalExpiredTime
     , ..

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
@@ -1,9 +1,11 @@
 -- SPDX-FileCopyrightText: 2021 TQ Tezos
 -- SPDX-License-Identifier: LicenseRef-MIT-TQ
 
+{-# LANGUAGE ApplicativeDo #-}
 -- | Contains test on @vote@ entrypoint for the LIGO contract.
 module Test.Ligo.BaseDAO.Proposal.Vote
-  ( voteNonExistingProposal
+  ( proposalCorrectlyTrackVotes
+  , voteNonExistingProposal
   , voteMultiProposals
   , voteOutdatedProposal
   , voteValidProposal
@@ -14,7 +16,8 @@ module Test.Ligo.BaseDAO.Proposal.Vote
 
 import Universum
 
-import Lorentz hiding ((>>))
+import qualified Data.Map as Map
+import Lorentz hiding (assert, (>>))
 import Morley.Nettest
 import Util.Named
 
@@ -86,6 +89,107 @@ voteMultiProposals originateFn = do
   withSender dodOwner2 $ call dodDao (Call @"Vote") params
   checkTokenBalance (frozenTokenId) dodDao dodOwner2 105
   -- TODO [#31]: check storage if the vote update the proposal properly
+
+proposalCorrectlyTrackVotes
+  :: (MonadNettest caps base m, HasCallStack)
+  => (ConfigDesc Config -> OriginateFn m)
+  -> GetProposalFn m
+  -> m ()
+proposalCorrectlyTrackVotes originateFn getProposalFn = do
+  DaoOriginateData{..} <- originateFn voteConfig defaultQuorumThreshold
+
+  let proposer = dodOwner1
+  let voter1 = dodOwner2
+  let voter2 = dodOperator1
+
+  withSender proposer $
+    call dodDao (Call @"Freeze") (#amount .! 20)
+
+  withSender voter1 $
+    call dodDao (Call @"Freeze") (#amount .! 40)
+
+  withSender voter2 $
+    call dodDao (Call @"Freeze") (#amount .! 40)
+
+  -- Advance one voting period to a proposing stage.
+  advanceLevel dodPeriod
+
+  -- Create sample proposal
+  (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
+  let params1 = fmap NoPermit
+        [ VoteParam
+            { vVoteType = True
+            , vVoteAmount = 5
+            , vProposalKey = key1
+            }
+        , VoteParam
+            { vVoteType = False
+            , vVoteAmount = 3
+            , vProposalKey = key2
+            }
+        ]
+
+  let params2 = fmap NoPermit
+        [ VoteParam
+            { vVoteType = False
+            , vVoteAmount = 2
+            , vProposalKey = key1
+            }
+        , VoteParam
+            { vVoteType = True
+            , vVoteAmount = 4
+            , vProposalKey = key2
+            }
+        ]
+
+  let params3 = fmap NoPermit
+        [ VoteParam
+            { vVoteType = True
+            , vVoteAmount = 3
+            , vProposalKey = key1
+            }
+        , VoteParam
+            { vVoteType = True
+            , vVoteAmount = 3
+            , vProposalKey = key2
+            }
+        ]
+
+  -- Advance one voting period to a voting stage.
+  advanceLevel dodPeriod
+  withSender voter1 . inBatch $ do
+    call dodDao (Call @"Vote") params1
+    call dodDao (Call @"Vote") params3
+    pure ()
+
+  withSender voter2  do
+    call dodDao (Call @"Vote") params2
+
+  proposal1 <- fromMaybe (error "proposal not found") <$> getProposalFn (unTAddress dodDao) key1
+  proposal2 <- fromMaybe (error "proposal not found") <$> getProposalFn (unTAddress dodDao) key2
+
+  assert (plUpvotes proposal1 == 8) "proposal did not track upvotes correctly"
+  assert (plDownvotes proposal1 == 2) "proposal did not track downvotes correctly"
+
+  assert (plUpvotes proposal2 == 7) "proposal did not track upvotes correctly"
+  assert (plDownvotes proposal2 == 3) "proposal did not track downvotes correctly"
+
+  let proposal1Voters = plVoters proposal1
+  let proposal2Voters = plVoters proposal2
+
+  assert ((Map.lookup (voter1, True) proposal1Voters) == Just 8) $ "proposal did not track upvote count for voter correctly"
+  assert (isNothing $ (Map.lookup (voter1, False) proposal1Voters)) $ "proposal did not track upvote count for voter correctly"
+
+  assert ((Map.lookup (voter1, True) proposal2Voters) == Just 3) $ "proposal did not track upvote count for voter correctly"
+  assert ((Map.lookup (voter1, False) proposal2Voters) == Just 3) $ "proposal did not track upvote count for voter correctly"
+
+
+  assert (isNothing $ (Map.lookup (voter2, True) proposal1Voters)) $ "proposal did not track upvote count for voter correctly"
+  assert ((Map.lookup (voter2, False) proposal1Voters) == Just 2) $ "proposal did not track upvote count for voter correctly"
+
+  assert ((Map.lookup (voter2, True) proposal2Voters) == Just 4) $ "proposal did not track upvote count for voter correctly"
+  assert (isNothing $ (Map.lookup (voter2, False) proposal2Voters)) $ "proposal did not track upvote count for voter correctly"
+
 
 voteOutdatedProposal
   :: (MonadNettest caps base m, HasCallStack)
@@ -238,13 +342,13 @@ votesBoundedValue
 votesBoundedValue originateFn = do
   DaoOriginateData{..} <- originateFn
     ( voteConfig >>-
-      ConfigDesc configConsts{ cmMaxVotes = Just 1 }
+      ConfigDesc configConsts{ cmMaxVoters = Just 1 }
     ) defaultQuorumThreshold
   withSender dodOwner1 $
     call dodDao (Call @"Freeze") (#amount .! 2)
 
   withSender dodOwner2 $
-    call dodDao (Call @"Freeze") (#amount .! 10)
+    call dodDao (Call @"Freeze") (#amount .! 11)
 
   -- Advance one voting period to a proposing stage.
   advanceLevel dodPeriod
@@ -263,5 +367,7 @@ votesBoundedValue originateFn = do
   advanceLevel dodPeriod
   withSender dodOwner1 $ do
     call dodDao (Call @"Vote") [downvote']
+
+  withSender dodOwner2 $ do
     call dodDao (Call @"Vote") [upvote']
-      & expectCustomErrorNoArg #mAX_VOTES_REACHED dodDao
+      & expectCustomErrorNoArg #mAX_VOTERS_REACHED dodDao

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -11,12 +11,6 @@ let validate_proposal_flush_expired_level (data : initial_config_data) : unit =
     failwith("proposal_flush_level needs to be more than twice the voting_period length")
   else unit
 
-let validate_max_votes (data : initial_config_data) : unit =
-  if data.max_votes > data.governance_total_supply then
-    failwith("The 'max_votes' number cannot exceed the 'governance_total_supply'.")
-  // TODO #271: check for maximum reasonable value
-  else unit
-
 let validate_quorum_threshold_bound (data : initial_config_data) : unit =
   if data.quorum_threshold >= data.max_quorum then
     failwith("'quorum_threshold' needs to be smaller than or equal to 'max_quorum'")
@@ -27,15 +21,17 @@ let validate_quorum_threshold_bound (data : initial_config_data) : unit =
 
 let default_config (data : initial_config_data) : config =
   let _ : unit = validate_proposal_flush_expired_level(data) in
-  let _ : unit = validate_max_votes(data) in
   let _ : unit = validate_quorum_threshold_bound(data) in {
+    // TODO [#271] We have to find a safe value for max_voters
+    // and check if the value contained in the `data` is
+    // within bounds.
     proposal_check = (fun (_params, _extras : propose_params * contract_extra) -> unit);
     rejected_proposal_slash_value = (fun (_proposal, _extras : proposal * contract_extra) -> 0n);
     decision_lambda = (fun (_proposal, extras : proposal * contract_extra) -> (([] : (operation list)), extras));
     fixed_proposal_fee_in_token = data.fixed_proposal_fee_in_token;
     period = data.period;
     max_proposals = 500n;
-    max_votes = data.max_votes;
+    max_voters = data.max_voters;
     max_quorum_threshold = to_signed(data.max_quorum);
     min_quorum_threshold = to_signed(data.min_quorum);
     max_quorum_change = to_signed(data.max_quorum_change);

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -109,12 +109,9 @@ type nonce = nat
 // Represents whether a voter has voted against (false) or for (true) a given proposal.
 type vote_type = bool
 
-// Voter info for a proposal
-type voter =
-  { voter_address : address
-  ; vote_amount : nat
-  ; vote_type : vote_type
-  }
+type voter_map_key = (address * vote_type)
+
+type voter_map = (voter_map_key, nat) map
 
 // Amount of blocks.
 type blocks = { blocks : nat }
@@ -153,7 +150,7 @@ type proposal =
   // ^ address of the proposer
   ; proposer_frozen_token : nat
   // ^ amount of frozen tokens used by the proposer, exluding the fixed fee
-  ; voters : voter list
+  ; voters : voter_map
   // ^ voter data
   ; quorum_threshold: quorum_threshold
   // ^ quorum threshold at the cycle in which proposal was raised
@@ -302,7 +299,7 @@ type initial_config_data =
   { max_quorum : quorum_threshold
   ; min_quorum : quorum_threshold
   ; quorum_threshold : quorum_threshold
-  ; max_votes : nat
+  ; max_voters : nat
   ; period : period
   ; proposal_flush_level: blocks
   ; proposal_expired_level: blocks
@@ -341,8 +338,8 @@ type config =
 
   ; max_proposals : nat
   // ^ Determine the maximum number of ongoing proposals that are allowed in the contract.
-  ; max_votes : nat
-  // ^ Determine the maximum number of votes associated with a proposal.
+  ; max_voters : nat
+  // ^ Determine the maximum number of voters allowed to vote in the context of a proposal.
   ; max_quorum_threshold : quorum_fraction
   // ^ Determine the maximum value of quorum threshold that is allowed.
   ; min_quorum_threshold : quorum_fraction


### PR DESCRIPTION
## Description

Changes max_votes to max_voters. So the number of voters who has casted a vote on a proposal in counted instead
of the total number of votes. This is done to limit the size of the voters map (for which we will find a sensible default value in #271).

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #277 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
