### PR TITLE
[#276] throw an error to avoid empty flush calls

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -351,6 +351,7 @@ The list of errors may be inaccurate and incomplete, it will be updated during t
 | `BAD_VIEW_CONTRACT`                  | Throw when the contract for a view entrypoint is not of the expected type.                                  |
 | `DROP_PROPOSAL_CONDITION_NOT_MET`    | Throw when calling `drop_proposal` when the sender is not proposer or guardian and proposal is not expired. |
 | `EXPIRED_PROPOSAL`                   | Throw when trying to `flush` expired proposals.                                                             |
+| `EMPTY_FLUSH`                        | Thrown when trying to `flush` with no available proposals.                                                  |
 | `BAD_STATE`                          | Throw when storage is in an unexpected state, indicating a contract error.                                  |
 
 # Entrypoints
@@ -774,6 +775,7 @@ Parameter (in Michelson):
   stored in the proposal, and this threshold will be used to check if the votes
   meet the quorum threshold.
   So any dynamic update to the quorum threshold shall not affect the proposal.
+- If no proposals can be flushed when called, fails with `EMPTY_FLUSH`.
 
 ### **drop_proposal**
 

--- a/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/Types.hs
@@ -897,6 +897,13 @@ instance CustomErrorHasDoc "eXPIRED_PROPOSAL" where
   customErrDocMdCause =
     "Throw when trying to `flush` expired proposals."
 
+type instance ErrorArg "eMPTY_FLUSH" = NoErrorArg
+
+instance CustomErrorHasDoc "eMPTY_FLUSH" where
+  customErrClass = ErrClassActionException
+  customErrDocMdCause =
+    "Thrown when trying to `flush` with no available proposals."
+
 type instance ErrorArg "nEGATIVE_TOTAL_SUPPLY" = ()
 
 instance CustomErrorHasDoc "nEGATIVE_TOTAL_SUPPLY" where

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -97,6 +97,9 @@ test_BaseDAO_Proposal =
       , nettestScenarioOnEmulatorCaps "flush and run decision lambda" $
           flushDecisionLambda (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
+      , nettestScenarioOnEmulatorCaps "empty flush calls are rejected" $
+          flushNotEmpty (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
       , nettestScenarioOnEmulatorCaps "can drop proposals, only when allowed" $
           dropProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
 

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Propose.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Propose.hs
@@ -135,7 +135,7 @@ proposerIsReturnedFeeAfterSucceeding = do
   checkTokenBalance frozenTokenId dodDao proposer expectedFrozen
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceLevel $ dodPeriod + 1
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   checkTokenBalance frozenTokenId dodDao proposer 152

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -135,7 +135,7 @@ flushTokenTransfer = uncapsNettest $ withFrozenCallStack $ do
   advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote]
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceLevel $ dodPeriod + 1 -- meet `proposal_flush_time`
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   checkTokenBalance frozenTokenId dodDao dodOwner1 proposalSize
@@ -190,7 +190,7 @@ flushXtzTransfer = uncapsNettest $ withFrozenCallStack $ do
   advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote]
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceLevel $ dodPeriod + 1 -- meet `proposal_flush_time`
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: check xtz balance

--- a/src/proposal.mligo
+++ b/src/proposal.mligo
@@ -301,9 +301,13 @@ let flush(n, config, store : nat * config * storage): return =
           let (start_level, proposal_key) = e in
           handle_proposal_is_over (config, start_level, proposal_key, store, ops, counter)
         in
-    let (ops, store, _) =
+    let (ops, store, counter) =
       Set.fold flush_one store.proposal_key_list_sort_by_level (nil_op, store, counter)
-    in (ops, store)
+    in
+    // prevent empty flushes to avoid gas costs when unnecessary.
+    if counter.current = 0n
+    then (failwith("EMPTY_FLUSH") : return)
+    else (ops, store)
 
 // Removes an accepted and finished proposal by key.
 let drop_proposal (proposal_key, config, store : proposal_key * config * storage): return =


### PR DESCRIPTION
## Description

Problem: the conditions for a successful flush are complex and user may
try to optimistically call the entrypoint when unnecessary.
This will create no issue, but will result in gas costs that could be
avoided.

Solution: throw an error when flush is called without any available
proposals.

## Related issue(s)

Resolves #276

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
