### PR TITLE
[#284] Revert the use of level count to denote time intervals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ifeq ($(OPTIMIZE), true)
 endif
 	#
 
-$(OUT)/trivialDAO_storage.tz : current_level = 100n
+$(OUT)/trivialDAO_storage.tz : now_val = `date +"%s"`
 $(OUT)/trivialDAO_storage.tz : metadata_map = Big_map.empty
 $(OUT)/trivialDAO_storage.tz : freeze_history = []
 $(OUT)/trivialDAO_storage.tz : fixed_proposal_fee_in_token = 0n
@@ -64,12 +64,12 @@ $(OUT)/trivialDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/trivialDAO_storage.tz : min_quorum = 1n
 $(OUT)/trivialDAO_storage.tz : max_quorum = 99n
 $(OUT)/trivialDAO_storage.tz : max_voters = 1000n
-$(OUT)/trivialDAO_storage.tz : period = 15840n # 11 days
+$(OUT)/trivialDAO_storage.tz : period = 950400n # 11 days
 $(OUT)/trivialDAO_storage.tz : quorum_change = 5n
 $(OUT)/trivialDAO_storage.tz : max_quorum_change = 19n
 $(OUT)/trivialDAO_storage.tz : governance_total_supply = 1000n
-$(OUT)/trivialDAO_storage.tz : proposal_flush_level = 36000n # 22 days
-$(OUT)/trivialDAO_storage.tz : proposal_expired_level = 47520n # 33 days
+$(OUT)/trivialDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
+$(OUT)/trivialDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
 $(OUT)/trivialDAO_storage.tz: src/**
 	# ============== Compiling TrivialDAO storage ============== #
 	mkdir -p $(OUT)
@@ -82,7 +82,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
             { address = (\"$(call require_defined,governance_token_address)\" : address) \
             ; token_id = ($(call require_defined,governance_token_id) : nat) \
             } \
-          ; current_level = {blocks = $(current_level)} \
+          ; now_val = ($(now_val) : timestamp)  \
           ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
           ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
           } \
@@ -90,9 +90,9 @@ $(OUT)/trivialDAO_storage.tz: src/**
           { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
           ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
           ; max_voters = ($(max_voters) : nat) \
-          ; period = { blocks = ($(period) : nat) } \
-          ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
-          ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) }\
+          ; period = { length = ($(period) : nat) } \
+          ; proposal_flush_time = ($(proposal_flush_time)  : nat) \
+          ; proposal_expired_time = ($(proposal_expired_time) : nat) \
           ; fixed_proposal_fee_in_token = ($(fixed_proposal_fee_in_token) : nat) \
           ; quorum_threshold = { numerator = (($(quorum_threshold) : nat) * quorum_denominator)/100n } \
           ; quorum_change = { numerator = (($(quorum_change) : nat) * quorum_denominator)/100n } \
@@ -111,7 +111,7 @@ $(OUT)/registryDAO_storage.tz : slash_scale_value = 1n
 $(OUT)/registryDAO_storage.tz : slash_division_value = 0n
 $(OUT)/registryDAO_storage.tz : min_xtz_amount = 0mutez
 $(OUT)/registryDAO_storage.tz : max_xtz_amount = 100mutez
-$(OUT)/registryDAO_storage.tz : current_level = 100n
+$(OUT)/registryDAO_storage.tz : now_val = `date +"%s"`
 $(OUT)/registryDAO_storage.tz : metadata_map = Big_map.empty
 $(OUT)/registryDAO_storage.tz : freeze_history = []
 $(OUT)/registryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
@@ -119,11 +119,11 @@ $(OUT)/registryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/registryDAO_storage.tz : min_quorum = 1n
 $(OUT)/registryDAO_storage.tz : max_quorum = 99n
 $(OUT)/registryDAO_storage.tz : max_voters = 1000n
-$(OUT)/registryDAO_storage.tz : period = 15840n # 11 days
+$(OUT)/registryDAO_storage.tz : period = 950400n # 11 days
 $(OUT)/registryDAO_storage.tz : quorum_change = 5n
 $(OUT)/registryDAO_storage.tz : max_quorum_change = 19n
-$(OUT)/registryDAO_storage.tz : proposal_flush_level = 36000n # 22 days
-$(OUT)/registryDAO_storage.tz : proposal_expired_level = 47520n # 33 days
+$(OUT)/registryDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
+$(OUT)/registryDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
 $(OUT)/registryDAO_storage.tz : governance_total_supply = 1000n
 $(OUT)/registryDAO_storage.tz: src/**
 	# ============== Compiling RegistryDAO storage ============== #
@@ -138,7 +138,7 @@ $(OUT)/registryDAO_storage.tz: src/**
               { address = (\"$(call require_defined,governance_token_address)\" : address) \
               ; token_id = ($(call require_defined,governance_token_id) : nat) \
               } \
-            ; current_level = {blocks = $(current_level)} \
+            ; now_val = ($(now_val) : timestamp)  \
             ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
             ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
             } \
@@ -146,9 +146,9 @@ $(OUT)/registryDAO_storage.tz: src/**
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
             ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
             ; max_voters = ($(max_voters) : nat) \
-            ; period = { blocks = ($(period) : nat) } \
-            ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
-            ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) } \
+            ; period = { length = ($(period) : nat) } \
+            ; proposal_flush_time = ($(proposal_flush_time)  : nat) \
+            ; proposal_expired_time = ($(proposal_expired_time) : nat) \
             ; fixed_proposal_fee_in_token = ($(fixed_proposal_fee_in_token) : nat) \
             ; quorum_threshold = { numerator = (($(quorum_threshold) : nat) * quorum_denominator)/100n } \
             ; quorum_change = { numerator = (($(quorum_change) : nat) * quorum_denominator)/100n } \
@@ -174,7 +174,7 @@ $(OUT)/treasuryDAO_storage.tz : slash_scale_value = 0n
 $(OUT)/treasuryDAO_storage.tz : slash_division_value = 0n
 $(OUT)/treasuryDAO_storage.tz : min_xtz_amount = 0mutez
 $(OUT)/treasuryDAO_storage.tz : max_xtz_amount = 100mutez
-$(OUT)/treasuryDAO_storage.tz : current_level = 100n
+$(OUT)/treasuryDAO_storage.tz : now_val = `date +"%s"`
 $(OUT)/treasuryDAO_storage.tz : metadata_map = Big_map.empty
 $(OUT)/treasuryDAO_storage.tz : freeze_history = []
 $(OUT)/treasuryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
@@ -182,11 +182,11 @@ $(OUT)/treasuryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/treasuryDAO_storage.tz : min_quorum = 1n
 $(OUT)/treasuryDAO_storage.tz : max_quorum = 99n
 $(OUT)/treasuryDAO_storage.tz : max_voters = 1000n
-$(OUT)/treasuryDAO_storage.tz : period = 15840n # 11 days
+$(OUT)/treasuryDAO_storage.tz : period = 950400n # 11 days
 $(OUT)/treasuryDAO_storage.tz : quorum_change = 5n
 $(OUT)/treasuryDAO_storage.tz : max_quorum_change = 19n
-$(OUT)/treasuryDAO_storage.tz : proposal_flush_level = 36000n # 22 days
-$(OUT)/treasuryDAO_storage.tz : proposal_expired_level = 47520n # 33 days
+$(OUT)/treasuryDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
+$(OUT)/treasuryDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
 $(OUT)/treasuryDAO_storage.tz : governance_total_supply = 1000n
 $(OUT)/treasuryDAO_storage.tz: src/**
 	# ============== Compiling TreasuryDAO storage ============== #
@@ -201,7 +201,7 @@ $(OUT)/treasuryDAO_storage.tz: src/**
               { address = (\"$(call require_defined,governance_token_address)\" : address) \
               ; token_id = ($(call require_defined,governance_token_id) : nat) \
               } \
-            ; current_level = {blocks = $(current_level)} \
+            ; now_val = ($(now_val) : timestamp)  \
             ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
             ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
             } \
@@ -209,9 +209,9 @@ $(OUT)/treasuryDAO_storage.tz: src/**
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
             ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
             ; max_voters = ($(max_voters) : nat) \
-            ; period = { blocks = ($(period) : nat) } \
-            ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
-            ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) } \
+            ; period = { length = ($(period) : nat) } \
+            ; proposal_flush_time = ($(proposal_flush_time)  : nat) \
+            ; proposal_expired_time = ($(proposal_expired_time) : nat) \
             ; fixed_proposal_fee_in_token = ($(fixed_proposal_fee_in_token) : nat) \
             ; quorum_threshold = { numerator = (($(quorum_threshold) : nat) * quorum_denominator)/100n } \
             ; quorum_change = { numerator = (($(quorum_change) : nat) * quorum_denominator)/100n } \

--- a/docs/building.md
+++ b/docs/building.md
@@ -75,7 +75,7 @@ make out/trivialDAO_storage.tz \
   guardian_address=KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh \
   governance_token_address=KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5 \
   governance_token_id=0n \
-  current_level=100n \
+  now_val=`date +"%s"` \
   metadata_map=Big_map.empty \
   freeze_history=[] \
   fixed_proposal_fee_in_token=0n \
@@ -83,12 +83,12 @@ make out/trivialDAO_storage.tz \
   min_quorum=1n \
   max_quorum=99n \
   max_voters=1000n \
-  period=15840n  \
+  period=950400n \
   quorum_change=5n \
   max_quorum_change=19n \
   governance_total_supply=1000n \
-  proposal_flush_level=36000n  \
-  proposal_expired_level=47520n \
+  proposal_flush_time=1900801n \
+  proposal_expired_time=2851200n
 ```
 
 The `admin_address`, `guardian_address`, `governance_token_address`, and `governance_token_id`
@@ -115,7 +115,7 @@ make out/registryDAO_storage.tz \
   slash_division_value=0n \
   min_xtz_amount=0mutez \
   max_xtz_amount=100mutez \
-  current_level=100n \
+  now_val=`date +"%s"` \
   metadata_map=Big_map.empty \
   freeze_history=[] \
   fixed_proposal_fee_in_token=0n \
@@ -123,11 +123,11 @@ make out/registryDAO_storage.tz \
   min_quorum=1n \
   max_quorum=99n \
   max_voters=1000n \
-  period=15840n \
+  period=950400n \
   quorum_change=5n \
   max_quorum_change=19n \
-  proposal_flush_level=36000n \
-  proposal_expired_level= 47520n \
+  proposal_flush_time=1900801n \
+  proposal_expired_time=2851200n \
   governance_total_supply=1000n
 ```
 
@@ -152,7 +152,7 @@ make out/treasuryDAO_storage.tz \
   slash_division_value=0n \
   min_xtz_amount=0mutez \
   max_xtz_amount=100mutez \
-  current_level=100n \
+  now_val=`date +"%s"` \
   metadata_map=Big_map.empty \
   freeze_history=Big_map.empty \
   fixed_proposal_fee_in_token=0n \
@@ -161,11 +161,11 @@ make out/treasuryDAO_storage.tz \
   min_quorum=1n \
   max_quorum=99n \
   max_voters=1000n \
-  period=15840n  \
+  period=950400n \
   quorum_change=5n \
   max_quorum_change=19n \
-  proposal_flush_level=36000n \
-  proposal_expired_level=47520n \
+  proposal_flush_time=1900801n \
+  proposal_expired_time=2851200n \
   governance_total_supply=1000n
 ```
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -103,7 +103,7 @@ type config =
   // ^ Determine the minimum value of quorum threshold that is allowed.
 
   ; period : period
-  // ^ Determines the stages length in number of blocks.
+  // ^ Determines the stages length in seconds.
 
   ; fixed_proposal_fee_in_token : nat
   // ^ A base fee paid for submitting a new proposal.
@@ -118,14 +118,14 @@ type config =
   // ^ The total supply of governance tokens used in the computation of
   // of new quorum threshold value at each stage.
 
-  ; proposal_flush_level : blocks
-  // ^ Determine the minimum amount of blocks after the proposal is proposed
+  ; proposal_flush_time : seconds
+  // ^ Determine the minimum amount of seconds after the proposal is proposed
   // to allow it to be `flushed`.
   // Has to be bigger than `period * 2`
-  ; proposal_expired_level : blocks
-  // ^ Determine the minimum amount of blocks after the proposal is proposed
+  ; proposal_expired_time : seconds
+  // ^ Determine the minimum amount of seconds after the proposal is proposed
   // to be considered as expired.
-  // Has to be bigger than `proposal_flush_level`
+  // Has to be bigger than `proposal_flush_time`
 
   ; custom_entrypoints : custom_entrypoints
   // ^ Packed arbitrary lambdas associated to a name for custom execution.
@@ -146,8 +146,8 @@ type proposal =
   // ^ total amount of votes in favor
   ; downvotes : nat
   // ^ total amount of votes against
-  ; start_level : blocks
-  // ^ block level of submission, used to order proposals
+  ; start_date : timestamp
+  // ^ time of submission, used to order proposals
   ; voting_stage_num : nat
   // ^ stage number in which it is possible to vote on this proposal
   ; metadata : proposal_metadata
@@ -175,13 +175,13 @@ These values are:
    in a call to `drop_proposal`
 3. `governance_token` is the FA2 contract address/token_id pair that will be
    used as the governance token.
-4. `period : blocks` specifies how long the stages lasts in blocks.
-5. `proposal_flush_level : blocks`
-    - Specifies in blocks how long after the proposal is proposed it can be flushed.
+4. `period : nat` specifies how long the stages lasts in seconds.
+5. `proposal_flush_time : nat`
+    - Specifies in seconds how long after the proposal is proposed it can be flushed.
     - IMPORTANT: Must be bigger than `period * 2`.
-6. `proposal_expired_level : blocks`
-    - Specifies in blocks how long after the proposal is proposed it is considered expired.
-    - IMPORTANT: Must be bigger than `proposal_flush_level`.
+6. `proposal_expired_time : nat`
+    - Specifies in seconds how long after the proposal is proposed it is considered expired.
+    - IMPORTANT: Must be bigger than `proposal_flush_time`.
 7. `quorum_threshold : quorum_threshold` specifies what fraction of the frozen
    tokens total supply of total votes are required for a successful proposal.
 8. `fixed_proposal_fee_in_token : nat` specifies the fee to be paid for submitting
@@ -611,10 +611,10 @@ Parameter (in Michelson):
 (nat %flush)
 ```
 
-- Finish voting process on an amount of proposals for which their `proposal_flush_level`
-  was reached, but their `proposal_expire_level` wasn't yet.
+- Finish voting process on an amount of proposals for which their `proposal_flush_time`
+  was reached, but their `proposal_expire_time` wasn't yet.
 - The order of processing proposals are from 'the oldest' to 'the newest'.
-  The proposals which have the same level due to being in the same block,
+  The proposals which have the same timestamp due to being in the same block,
   are processed in the order of their proposal keys.
 - Frozen tokens from voters and proposal submitter associated with those proposals
   are returned in the  form of tokens in governance token contract:
@@ -645,9 +645,9 @@ Parameter (in Michelson):
 (bytes %drop_proposal)
 ```
 
-- Delete a proposal when its `proposal_expired_level` is reached.
-- The proposer can call this entrypoint to delete his/her own proposal regardless of `proposal_expired_level`.
-- The `guardian` can call this entrypoint to delete any proposals at anytime regardless of `proposal_expired_level`.
+- Delete a proposal when its `proposal_expired_time` is reached.
+- The proposer can call this entrypoint to delete his/her own proposal regardless of `proposal_expired_time`.
+- The `guardian` can call this entrypoint to delete any proposals at anytime regardless of `proposal_expired_time`.
 - Fails with `DROP_PROPOSAL_CONDITION_NOT_MET` when none of the conditions above are met.
 - Tokens that are frozen for this proposal are returned to the proposer and voters
   as if the proposal was rejected, regardless of the actual votes.

--- a/haskell/baseDAO-ligo-meta.cabal
+++ b/haskell/baseDAO-ligo-meta.cabal
@@ -117,6 +117,7 @@ test-suite baseDAO-test
     , morley-metadata
     , morley-prelude
     , named
+    , o-clock
     , tasty
     , tasty-hunit-compat
     , universum

--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -145,6 +145,7 @@ tests:
     - morley-metadata
     - morley-prelude
     - named
+    - o-clock
     - tasty
     - tasty-hunit-compat
     - universum

--- a/haskell/test/Test/Ligo/BaseDAO/Management.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Management.hs
@@ -51,45 +51,45 @@ test_BaseDAO_Management :: [TestTree]
 test_BaseDAO_Management =
   [ testGroup "Ownership transfer"
     [ nettestScenarioCaps "transfer ownership entrypoint authenticates sender" $ do
-        current_level <- getLevel
-        transferOwnership withOriginated (initialStorage current_level)
+        current_time <- getNow
+        transferOwnership withOriginated (initialStorage current_time)
 
     , nettestScenarioCaps "sets pending owner" $ do
-        current_level <- getLevel
-        transferOwnership withOriginated (initialStorage current_level)
+        current_time <- getNow
+        transferOwnership withOriginated (initialStorage current_time)
 
     , nettestScenarioCaps "does not set administrator" $ do
-        current_level <- getLevel
-        notSetAdmin withOriginated (initialStorage current_level)
+        current_time <- getNow
+        notSetAdmin withOriginated (initialStorage current_time)
 
     , nettestScenarioCaps "rewrite existing pending owner" $ do
-        current_level <- getLevel
-        rewritePendingOwner withOriginated (initialStorage current_level)
+        current_time <- getNow
+        rewritePendingOwner withOriginated (initialStorage current_time)
 
     , nettestScenarioCaps "invalidates pending owner if new owner is current admin" $ do
-        current_level <- getLevel
-        invalidatePendingOwner withOriginated (initialStorage current_level)
+        current_time <- getNow
+        invalidatePendingOwner withOriginated (initialStorage current_time)
 
     , nettestScenarioCaps "bypasses accept_entrypoint if new admin address is self" $ do
-        current_level <- getLevel
-        bypassAcceptForSelf withOriginated (initialStorage current_level)
+        current_time <- getNow
+        bypassAcceptForSelf withOriginated (initialStorage current_time)
     ]
     , testGroup "Accept Ownership"
       [ nettestScenarioCaps "authenticates the sender" $ do
-          current_level <- getLevel
-          authenticateSender withOriginated (initialStorage current_level)
+          current_time <- getNow
+          authenticateSender withOriginated (initialStorage current_time)
 
       , nettestScenarioCaps "changes the administrator to pending owner" $ do
-          current_level <- getLevel
-          changeToPendingAdmin withOriginated (initialStorage current_level)
+          current_time <- getNow
+          changeToPendingAdmin withOriginated (initialStorage current_time)
 
       , nettestScenarioCaps "throws error when there is no pending owner" $ do
-          current_level <- getLevel
-          noPendingAdmin withOriginated (initialStorage current_level)
+          current_time <- getNow
+          noPendingAdmin withOriginated (initialStorage current_time)
 
       , nettestScenarioCaps "throws error when called by current admin, when pending owner is not the same" $ do
-          current_level <- getLevel
-          pendingOwnerNotTheSame withOriginated (initialStorage current_level)
+          current_time <- getNow
+          pendingOwnerNotTheSame withOriginated (initialStorage current_time)
       ]
   ]
 
@@ -104,11 +104,11 @@ test_BaseDAO_Management =
         (L.dip (L.toField #fsStorage) # setField #sAdmin) #
       L.nil # pair
 
-    initialStorage currentLevel admin = mkFullStorage
+    initialStorage now admin = mkFullStorage
       ! #admin admin
       ! #extra dynRecUnsafe
       ! #metadata mempty
-      ! #level currentLevel
+      ! #startTime now
       ! #tokenAddress genesisAddress
       ! #customEps
           [ ([mt|testCustomEp|], lPackValueRaw testCustomEntrypoint)

--- a/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
@@ -31,7 +31,7 @@ offChainViewStorage =
   ! #admin addr
   ! #extra dynRecUnsafe
   ! #metadata mempty
-  ! #level 100
+  ! #startTime (timestampFromSeconds 100)
   ! #tokenAddress genesisAddress
   ! #quorumThreshold (mkQuorumThreshold 1 100)
   ! defaults

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Delegate.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Delegate.hs
@@ -44,7 +44,7 @@ addRemoveDelegate originateFn = do
   withSender dodOwner1 $
     call dodDao (Call @"Freeze") (#amount .! 100)
 
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   let params counter = ProposeParams
         { ppFrozenToken = 10
         , ppProposalMetadata = lPackValueRaw @Integer counter
@@ -58,7 +58,7 @@ addRemoveDelegate originateFn = do
                 , vFrom = dodOwner1
                 }
   withSender dodOperator1 $ call dodDao (Call @"Propose") (params 1)
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOperator1 $ call dodDao (Call @"Vote") [vote]
 
   withSender dodOwner1 $
@@ -66,7 +66,7 @@ addRemoveDelegate originateFn = do
 
   withSender dodOperator1 $ call dodDao (Call @"Vote") [vote]
     & expectCustomErrorNoArg #nOT_DELEGATE dodDao
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOperator1 $ call dodDao (Call @"Propose") (params 2)
     & expectCustomErrorNoArg #nOT_DELEGATE dodDao
 

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
@@ -18,8 +18,8 @@ module Test.Ligo.BaseDAO.Proposal.Flush
 
 import Universum
 
-import Lorentz.Test (contractConsumer)
 import Lorentz hiding (assert, (>>))
+import Lorentz.Test (contractConsumer)
 import Morley.Nettest
 import Util.Named
 
@@ -48,12 +48,12 @@ flushAcceptedProposals originateFn getFreezeHistoryFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- Accepted Proposals
   key1 <- createSampleProposal 1 dodOwner1 dodDao
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   let upvote' = NoPermit VoteParam
         { vFrom = dodOwner2
@@ -77,7 +77,7 @@ flushAcceptedProposals originateFn getFreezeHistoryFn = do
   fhOwner2 @== Just (AddressFreezeHistory 0 0 2 15)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel (dodPeriod+1)
+  advanceTime (addSec dodPeriod)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
@@ -110,11 +110,11 @@ flushAcceptedProposalsWithAnAmount originateFn checkBalanceFn = do
   withSender dodOwner2 $
     call dodDao (Call @"Freeze") (#amount .! 10)
 
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- [Proposing]
   (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
-  advanceLevel 1
+  advanceTime (sec 1)
   _key3 <- createSampleProposal 3 dodOwner1 dodDao
 
   let vote' key = NoPermit VoteParam
@@ -124,7 +124,7 @@ flushAcceptedProposalsWithAnAmount originateFn checkBalanceFn = do
         , vProposalKey = key
         }
 
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- [Voting]
   withSender dodOwner2 . inBatch $ do
@@ -132,7 +132,7 @@ flushAcceptedProposalsWithAnAmount originateFn checkBalanceFn = do
       call dodDao (Call @"Vote") [vote' key2]
       pure ()
 
-  advanceLevel (dodPeriod + 1)
+  advanceTime (addSec dodPeriod)
 
   -- [Proposing]
   withSender dodAdmin $ call dodDao (Call @"Flush") 2
@@ -165,7 +165,7 @@ flushRejectProposalQuorum originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- Rejected Proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -179,11 +179,11 @@ flushRejectProposalQuorum originateFn checkBalanceFn = do
           }
         ]
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") votes
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel (dodPeriod + 1)
+  advanceTime (addSec dodPeriod)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
@@ -213,7 +213,7 @@ flushRejectProposalNegativeVotes originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- Rejected Proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -239,14 +239,14 @@ flushRejectProposalNegativeVotes originateFn checkBalanceFn = do
           }
         ]
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") votes
 
   -- Check proposer balance
   checkBalanceFn (unTAddress dodDao) dodOwner1 10
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel (dodPeriod + 1)
+  advanceTime (addSec dodPeriod)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
@@ -276,7 +276,7 @@ flushWithBadConfig originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   let upvote' = NoPermit VoteParam
@@ -286,11 +286,11 @@ flushWithBadConfig originateFn checkBalanceFn = do
         , vFrom = dodOwner2
         }
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote']
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel (dodPeriod+1)
+  advanceTime (addSec dodPeriod)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
@@ -318,7 +318,7 @@ flushDecisionLambda originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   let upvote' = NoPermit VoteParam
@@ -328,11 +328,11 @@ flushDecisionLambda originateFn = do
         , vFrom = dodOwner2
         }
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote']
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel (dodPeriod + 1)
+  advanceTime (addSec dodPeriod)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   results <- fromVal <$> getStorage (toAddress consumer)
@@ -360,11 +360,11 @@ flushFailOnExpiredProposal originateFn checkBalanceFn = withFrozenCallStack $ do
     call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   let params key = NoPermit VoteParam
         { vVoteType = True
         , vVoteAmount = 20
@@ -373,10 +373,10 @@ flushFailOnExpiredProposal originateFn checkBalanceFn = withFrozenCallStack $ do
         }
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params key1]
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   _key2 <- createSampleProposal 2 dodOwner1 dodDao
 
-  advanceLevel (2*dodPeriod + 1)
+  advanceTime (addSec $ doubleTime dodPeriod)
   -- `key1` is now expired, and `key2` is not yet expired.
   withSender dodAdmin $ call dodDao (Call @"Flush") 2
     & expectCustomErrorNoArg #eXPIRED_PROPOSAL dodDao
@@ -405,12 +405,12 @@ flushProposalFlushTimeNotReach originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 30)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   (_key1, _key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
   -- Advance two voting period to another proposing stage.
-  advanceLevel dodPeriod -- skip voting period
-  advanceLevel (dodPeriod + 1)
+  advanceTime dodPeriod -- skip voting period
+  advanceTime (addSec dodPeriod)
   _key3 <- createSampleProposal 3 dodOwner1 dodDao
 
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
@@ -441,11 +441,11 @@ flushNotEmpty originateFn = withFrozenCallStack $ do
   withSender dodOwner2 $ call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   let params key = NoPermit VoteParam
         { vVoteType = True
         , vVoteAmount = 20
@@ -455,12 +455,12 @@ flushNotEmpty originateFn = withFrozenCallStack $ do
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params key1]
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   -- the proposal exists at this point (and has votes), but it can't be flushed
   -- yet, because it needs one more level to meet the `proposal_flush_time`
   withSender dodAdmin $ call dodDao (Call @"Flush") 1
     & expectCustomErrorNoArg #eMPTY_FLUSH dodDao
 
   -- however after one more level flushing is allowed
-  advanceLevel 1
+  advanceTime $ sec 1
   withSender dodAdmin $ call dodDao (Call @"Flush") 1

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Quorum.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Quorum.hs
@@ -67,7 +67,7 @@ checkQuorumThresholdDynamicUpdate originateFn getQtAtCycle = do
   withSender proposer $
     call dao (Call @"Freeze") (#amount .! (2 * requiredFrozen))
 
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   -- First proposal period, cycle 0
 
   withSender proposer $
@@ -78,7 +78,7 @@ checkQuorumThresholdDynamicUpdate originateFn getQtAtCycle = do
   assert (quorumThresholdActual_ == quorumThresholdExpected_) "Unexpected quorumThreshold update"
 
   -- skip this proposal period and next voting period to be in next proposal period
-  advanceLevel (2 * dodPeriod + 1)
+  advanceTime (addSec $ doubleTime dodPeriod)
 
   let proposalMeta2 = "A"
   withSender proposer $
@@ -113,14 +113,14 @@ checkQuorumThresholdDynamicUpdateUpperBound originateFn getQtAtCycle = do
   withSender proposer $
     call dao (Call @"Freeze") (#amount .! (2 * requiredFrozen))
 
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   -- First proposal period, cycle 0
 
   withSender proposer $
     call dodDao (Call @"Propose") (ProposeParams proposer requiredFrozen proposalMeta1)
 
   -- skip this proposal period and next voting period to be in next proposal period
-  advanceLevel (2 * dodPeriod + 1)
+  advanceTime (addSec $ doubleTime dodPeriod)
 
   let proposalMeta2 = "A"
   withSender proposer $
@@ -158,14 +158,14 @@ checkQuorumThresholdDynamicUpdateLowerBound originateFn getQtAtCycle = do
   withSender proposer $
     call dao (Call @"Freeze") (#amount .! (2 * requiredFrozen))
 
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   -- First proposal period, cycle 0
 
   withSender proposer $
     call dodDao (Call @"Propose") (ProposeParams proposer requiredFrozen proposalMeta1)
 
   -- skip this proposal period and next voting period to be in next proposal period
-  advanceLevel (2 * dodPeriod + 1)
+  advanceTime (addSec $ doubleTime dodPeriod)
 
   let proposalMeta2 = "A"
   withSender proposer $
@@ -203,14 +203,14 @@ checkProposalSavesQuorum originateFn getProposal = do
   withSender proposer $
     call dao (Call @"Freeze") (#amount .! (2 * requiredFrozen))
 
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   -- First proposal period, cycle 0
 
   withSender proposer $
     call dodDao (Call @"Propose") (ProposeParams proposer requiredFrozen proposalMeta1)
 
   -- skip this proposal period and next voting period to be in next proposal period
-  advanceLevel (2 * dodPeriod + 1)
+  advanceTime (addSec $ doubleTime dodPeriod)
 
   let proposalMeta2 = "A"
   let proposeParams = ProposeParams proposer requiredFrozen proposalMeta2
@@ -253,10 +253,10 @@ proposalIsRejectedIfNoQuorum checkBalanceFn = do
     call dao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   key1 <- createSampleProposal 1 proposer dao
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   let vote_ =
         NoPermit VoteParam
           { vVoteType = True
@@ -272,7 +272,7 @@ proposalIsRejectedIfNoQuorum checkBalanceFn = do
   checkBalanceFn (unTAddress dao) proposer expectedFrozen
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender admin $ call dao (Call @"Flush") 100
 
   checkBalanceFn (unTAddress dao) proposer 10 -- We expect 42 tokens to have burned
@@ -304,10 +304,10 @@ proposalSucceedsIfUpVotesGtDownvotesAndQuorum checkBalanceFn = do
     call dao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   key1 <- createSampleProposal 1 proposer dao
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   let vote_ =
         NoPermit VoteParam
           { vVoteType = True
@@ -323,7 +323,7 @@ proposalSucceedsIfUpVotesGtDownvotesAndQuorum checkBalanceFn = do
   checkBalanceFn (unTAddress dao) proposer expectedFrozen
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender admin $ call dao (Call @"Flush") 100
 
   checkBalanceFn (unTAddress dao) proposer 52

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Tokens.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Tokens.hs
@@ -54,9 +54,9 @@ checkFreezeHistoryTracking originateFn getFreezeHistory = do
   let requiredFrozen = proposalSize1 * frozen_scale_value + frozen_extra_value
 
   withSender dodOwner1 $ call dodDao (Call @"Freeze") (#amount .! requiredFrozen)
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOwner1 $ call dodDao (Call @"Propose") (ProposeParams dodOwner1 requiredFrozen proposalMeta1)
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   fh <- getFreezeHistory (unTAddress dodDao) dodOwner1 -- TODO [#31]
   let expected = AddressFreezeHistory
@@ -78,7 +78,7 @@ canUnfreezeFromPreviousPeriod originateFn checkBalanceFn = do
   checkBalanceFn (unTAddress dodDao) dodOwner1 10
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   withSender dodOwner1 $ call dodDao (Call @"Unfreeze") (#amount .! 10)
   checkBalanceFn (unTAddress dodDao) dodOwner1 00
@@ -104,7 +104,7 @@ cannotUnfreezeStakedTokens originateFn checkBalanceFn = do
   checkBalanceFn (unTAddress dodDao) dodOwner1 50
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   void $ createSampleProposal 1 dodOwner1 dodDao
 
   -- the frozen tokens are still the same

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
@@ -40,7 +40,7 @@ voteNonExistingProposal originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   -- Create sample proposal
   _ <- createSampleProposal 1 dodOwner1 dodDao
   let params = NoPermit VoteParam
@@ -50,7 +50,7 @@ voteNonExistingProposal originateFn = do
         , vFrom = dodOwner2
         }
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params]
     & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dodDao
@@ -68,7 +68,7 @@ voteMultiProposals originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 5)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- Create sample proposal
   (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
@@ -88,7 +88,7 @@ voteMultiProposals originateFn checkBalanceFn = do
         ]
 
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") params
   checkBalanceFn (unTAddress dodDao) dodOwner2 5
   -- TODO [#31]: check storage if the vote update the proposal properly
@@ -115,7 +115,7 @@ proposalCorrectlyTrackVotes originateFn getProposalFn = do
     call dodDao (Call @"Freeze") (#amount .! 40)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- Create sample proposal
   (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
@@ -165,7 +165,7 @@ proposalCorrectlyTrackVotes originateFn getProposalFn = do
         ]
 
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender voter1 . inBatch $ do
     call dodDao (Call @"Vote") params1
     call dodDao (Call @"Vote") params3
@@ -213,7 +213,7 @@ voteOutdatedProposal originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- Create sample proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -226,12 +226,12 @@ voteOutdatedProposal originateFn = do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   withSender dodOwner2 $ do
     call dodDao (Call @"Vote") [params]
     -- Advance two voting period to another voting stage.
-    advanceLevel (2 * dodPeriod)
+    advanceTime (doubleTime dodPeriod)
     call dodDao (Call @"Vote") [params]
       & expectCustomErrorNoArg #vOTING_STAGE_OVER dodDao
 
@@ -250,7 +250,7 @@ voteValidProposal originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- Create sample proposal (first proposal has id = 0)
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -262,7 +262,7 @@ voteValidProposal originateFn checkBalanceFn = do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params]
   checkBalanceFn (unTAddress dodDao) dodOwner2 2
   -- TODO [#31]: check if the vote is updated properly
@@ -276,7 +276,7 @@ voteWithPermit originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 12)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- Create sample proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -290,7 +290,7 @@ voteWithPermit originateFn checkBalanceFn = do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params]
   checkBalanceFn (unTAddress dodDao) dodOwner1 12
@@ -309,7 +309,7 @@ voteWithPermitNonce originateFn getVotePermitsCounterFn = do
     call dodDao (Call @"Freeze") (#amount .! 50)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   -- Create sample proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -322,7 +322,7 @@ voteWithPermitNonce originateFn getVotePermitsCounterFn = do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   -- Going to try calls with different nonces
   signed1@(_          , _) <- addDataToSign dodDao (Nonce 0) voteParam
   signed2@(dataToSign2, _) <- addDataToSign dodDao (Nonce 1) voteParam
@@ -366,7 +366,7 @@ votesBoundedValue originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 11)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   key1 <- createSampleProposal 1 dodOwner2 dodDao
   let upvote' = NoPermit VoteParam
         { vVoteType = False
@@ -381,7 +381,7 @@ votesBoundedValue originateFn = do
         , vFrom = dodOwner1
         }
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOwner1 $ do
     call dodDao (Call @"Vote") [downvote']
 

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -79,7 +79,7 @@ validProposal checkBalanceFn = withFrozenCallStack $ do
     call dodDao (Call @"Freeze") (#amount .! proposalSize)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   withSender dodOwner1 $
     call dodDao (Call @"Propose") (ProposeParams dodOwner1 (proposalSize + 1) proposalMeta)
@@ -112,7 +112,7 @@ flushTokenTransfer checkBalanceFn = withFrozenCallStack $ do
     call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting periods to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   withSender dodOwner1 $ call dodDao (Call @"Propose") proposeParams
   let key1 = makeProposalKey proposeParams
@@ -128,10 +128,10 @@ flushTokenTransfer checkBalanceFn = withFrozenCallStack $ do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote]
   -- Advance one voting period to a proposing stage.
-  advanceLevel $ dodPeriod + 1 -- meet `proposal_flush_time`
+  advanceTime $ addSec dodPeriod -- meet `proposal_flush_time`
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   checkBalanceFn (unTAddress dodDao) dodOwner1 proposalSize
@@ -160,7 +160,7 @@ flushXtzTransfer checkBalanceFn = withFrozenCallStack $ do
   withSender dodOwner2 $
     call dodDao (Call @"Freeze") (#amount .! 10)
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   withSender dodOwner1 $ do
   -- due to smaller than min_xtz_amount
@@ -185,10 +185,10 @@ flushXtzTransfer checkBalanceFn = withFrozenCallStack $ do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote]
   -- Advance one voting period to a proposing stage.
-  advanceLevel $ dodPeriod + 1 -- meet `proposal_flush_time`
+  advanceTime $ addSec dodPeriod -- meet `proposal_flush_time`
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: check xtz balance
@@ -216,7 +216,7 @@ proposalCheckFailZeroMutez = withFrozenCallStack do
     call dodDao (Call @"Freeze") (#amount .! proposalSize)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceTime dodPeriod
 
   withSender dodOwner1 $
     call dodDao (Call @"Propose") (ProposeParams dodOwner1 proposalSize proposalMeta)
@@ -239,7 +239,7 @@ proposalCheckBiggerThanMaxProposalSize = withFrozenCallStack do
     call dodDao (Call @"Freeze") (#amount .! largeProposalSize)
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel 10
+  advanceTime $ sec 10
 
   withSender dodOwner1 $
     call dodDao (Call @"Propose") (ProposeParams dodOwner1 largeProposalSize largeProposalMeta)

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -4,11 +4,11 @@
 #include "types.mligo"
 #include "proposal.mligo"
 
-let validate_proposal_flush_expired_level (data : initial_config_data) : unit =
-  if data.proposal_expired_level.blocks <= data.proposal_flush_level.blocks then
-    failwith("proposal_expired_level needs to be bigger than proposal_flush_level")
-  else if data.proposal_flush_level.blocks <= (data.period.blocks * 2n) then
-    failwith("proposal_flush_level needs to be more than twice the voting_period length")
+let validate_proposal_flush_expired_time (data : initial_config_data) : unit =
+  if data.proposal_expired_time <= data.proposal_flush_time then
+    failwith("'proposal_expired_time' needs to be bigger than 'proposal_flush_time'.")
+  else if data.proposal_flush_time <= (data.period.length * 2n) then
+    failwith("'proposal_flush_time' needs to be more than twice the 'period' length.")
   else unit
 
 let validate_quorum_threshold_bound (data : initial_config_data) : unit =
@@ -33,7 +33,7 @@ let freeze_history_constructor (acc, param : (freeze_history * nat) * (address *
   )
 
 let default_config (data : initial_config_data) : config =
-  let _ : unit = validate_proposal_flush_expired_level(data) in
+  let _ : unit = validate_proposal_flush_expired_time(data) in
   let _ : unit = validate_quorum_threshold_bound(data) in {
     // TODO [#271] We have to find a safe value for max_voters
     // and check if the value contained in the `data` is
@@ -50,8 +50,8 @@ let default_config (data : initial_config_data) : config =
     max_quorum_change = to_signed(data.max_quorum_change);
     quorum_change = to_signed(data.quorum_change);
     governance_total_supply = data.governance_total_supply;
-    proposal_flush_level = data.proposal_flush_level;
-    proposal_expired_level = data.proposal_expired_level;
+    proposal_flush_time = data.proposal_flush_time;
+    proposal_expired_time = data.proposal_expired_time;
     custom_entrypoints = (Big_map.empty : custom_entrypoints);
   }
 
@@ -73,11 +73,11 @@ let default_storage (data, config_data : initial_storage_data * initial_config_d
     metadata = data.metadata_map;
     extra = (Big_map.empty : (string, bytes) big_map);
     proposals = (Big_map.empty : (proposal_key, proposal) big_map);
-    proposal_key_list_sort_by_level = (Set.empty : (blocks * proposal_key) set);
+    proposal_key_list_sort_by_date = (Set.empty : (timestamp * proposal_key) set);
     permits_counter = 0n;
     freeze_history = freeze_history;
     frozen_token_id = frozen_token_id;
-    start_level = data.current_level;
+    start_time = data.now_val;
     quorum_threshold_at_cycle =
       { last_updated_cycle = 1n
       // We use 1 here so that the initial quorum will be used for proposals raised in stage 1

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -59,9 +59,11 @@ type voter_map_key = (address * vote_type)
 
 type voter_map = (voter_map_key, nat) map
 
-// Amount of blocks.
-type blocks = { blocks : nat }
-type period = blocks
+// Amount of `seconds` used for lengths of time
+type seconds = nat
+
+// Length of a 'stage'
+type period = { length : seconds }
 
 // For efficiency, we only keep a `nat` for the numerator, whereas the
 // denominator is not stored and has a fixed value of `1000000`.
@@ -86,8 +88,8 @@ type proposal =
   // ^ total amount of votes in favor
   ; downvotes : nat
   // ^ total amount of votes against
-  ; start_level : blocks
-  // ^ block level of submission, used to order proposals
+  ; start_date : timestamp
+  // ^ time of submission, used to order proposals
   ; voting_stage_num : nat
   // ^ stage number in which it is possible to vote on this proposal
   ; metadata : proposal_metadata
@@ -153,11 +155,11 @@ type storage =
   ; metadata : metadata_map
   ; extra : contract_extra
   ; proposals : (proposal_key, proposal) big_map
-  ; proposal_key_list_sort_by_level : (blocks * proposal_key) set
+  ; proposal_key_list_sort_by_date : (timestamp * proposal_key) set
   ; permits_counter : nonce
   ; freeze_history : freeze_history
   ; frozen_token_id : token_id
-  ; start_level : blocks
+  ; start_time : timestamp
   ; quorum_threshold_at_cycle : quorum_threshold_at_cycle
   ; frozen_total_supply : nat
   ; delegates : delegates
@@ -260,8 +262,8 @@ type initial_config_data =
   ; quorum_threshold : quorum_threshold
   ; max_voters : nat
   ; period : period
-  ; proposal_flush_level: blocks
-  ; proposal_expired_level: blocks
+  ; proposal_flush_time: seconds
+  ; proposal_expired_time: seconds
   ; fixed_proposal_fee_in_token: nat
   ; max_quorum_change : unsigned_quorum_fraction
   ; quorum_change : unsigned_quorum_fraction
@@ -272,7 +274,7 @@ type initial_storage_data =
   { admin : address
   ; guardian : address
   ; governance_token : governance_token
-  ; current_level : blocks
+  ; now_val : timestamp
   ; metadata_map : metadata_map
   ; freeze_history : freeze_history_list
   }
@@ -320,12 +322,12 @@ type config =
   // ^ The total supply of governance tokens used in the computation of
   // of new quorum threshold value at each stage.
 
-  ; proposal_flush_level : blocks
-  // ^ Determine the minimum number of levels after the proposal is proposed
+  ; proposal_flush_time : seconds
+  // ^ Determine the minimum amount of seconds after the proposal is proposed
   // to allow it to be `flushed`.
   // Has to be bigger than `period * 2`
-  ; proposal_expired_level : blocks
-  // ^ Determine the minimum number of levels after the proposal is proposed
+  ; proposal_expired_time : seconds
+  // ^ Determine the minimum amount of seconds after the proposal is proposed
   // to be considered as expired.
   // Has to be bigger than `proposal_flush_time`
 


### PR DESCRIPTION
## Description

Reverts the use of Levels for denoting time intervals. 

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves: part of #284

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
