### PR TITLE
[#284] Restore use of blocks to denote intervals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ ifeq ($(OPTIMIZE), true)
 endif
 	#
 
-$(OUT)/trivialDAO_storage.tz : current_level = 100n
 $(OUT)/trivialDAO_storage.tz : metadata_map = Big_map.empty
 $(OUT)/trivialDAO_storage.tz : freeze_history = []
 $(OUT)/trivialDAO_storage.tz : fixed_proposal_fee_in_token = 0n
@@ -64,12 +63,12 @@ $(OUT)/trivialDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/trivialDAO_storage.tz : min_quorum = 1n
 $(OUT)/trivialDAO_storage.tz : max_quorum = 99n
 $(OUT)/trivialDAO_storage.tz : max_voters = 1000n
-$(OUT)/trivialDAO_storage.tz : period = 15840n # 11 days
+$(OUT)/trivialDAO_storage.tz : period = 15840n
 $(OUT)/trivialDAO_storage.tz : quorum_change = 5n
 $(OUT)/trivialDAO_storage.tz : max_quorum_change = 19n
 $(OUT)/trivialDAO_storage.tz : governance_total_supply = 1000n
-$(OUT)/trivialDAO_storage.tz : proposal_flush_level = 36000n # 22 days
-$(OUT)/trivialDAO_storage.tz : proposal_expired_level = 47520n # 33 days
+$(OUT)/trivialDAO_storage.tz : proposal_flush_level = 36000n
+$(OUT)/trivialDAO_storage.tz : proposal_expired_level = 47520n
 $(OUT)/trivialDAO_storage.tz: src/**
 	# ============== Compiling TrivialDAO storage ============== #
 	mkdir -p $(OUT)
@@ -82,7 +81,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
             { address = (\"$(call require_defined,governance_token_address)\" : address) \
             ; token_id = ($(call require_defined,governance_token_id) : nat) \
             } \
-          ; current_level = {blocks = $(current_level)} \
+          ; start_level = {blocks = $(call require_defined,start_level)} \
           ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
           ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
           } \
@@ -111,7 +110,6 @@ $(OUT)/registryDAO_storage.tz : slash_scale_value = 1n
 $(OUT)/registryDAO_storage.tz : slash_division_value = 0n
 $(OUT)/registryDAO_storage.tz : min_xtz_amount = 0mutez
 $(OUT)/registryDAO_storage.tz : max_xtz_amount = 100mutez
-$(OUT)/registryDAO_storage.tz : current_level = 100n
 $(OUT)/registryDAO_storage.tz : metadata_map = Big_map.empty
 $(OUT)/registryDAO_storage.tz : freeze_history = []
 $(OUT)/registryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
@@ -119,11 +117,11 @@ $(OUT)/registryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/registryDAO_storage.tz : min_quorum = 1n
 $(OUT)/registryDAO_storage.tz : max_quorum = 99n
 $(OUT)/registryDAO_storage.tz : max_voters = 1000n
-$(OUT)/registryDAO_storage.tz : period = 15840n # 11 days
+$(OUT)/registryDAO_storage.tz : period = 15840n
 $(OUT)/registryDAO_storage.tz : quorum_change = 5n
 $(OUT)/registryDAO_storage.tz : max_quorum_change = 19n
-$(OUT)/registryDAO_storage.tz : proposal_flush_level = 36000n # 22 days
-$(OUT)/registryDAO_storage.tz : proposal_expired_level = 47520n # 33 days
+$(OUT)/registryDAO_storage.tz : proposal_flush_level = 36000n
+$(OUT)/registryDAO_storage.tz : proposal_expired_level = 47520n
 $(OUT)/registryDAO_storage.tz : governance_total_supply = 1000n
 $(OUT)/registryDAO_storage.tz: src/**
 	# ============== Compiling RegistryDAO storage ============== #
@@ -138,7 +136,7 @@ $(OUT)/registryDAO_storage.tz: src/**
               { address = (\"$(call require_defined,governance_token_address)\" : address) \
               ; token_id = ($(call require_defined,governance_token_id) : nat) \
               } \
-            ; current_level = {blocks = $(current_level)} \
+            ; start_level = {blocks = $(call require_defined,start_level)} \
             ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
             ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
             } \
@@ -174,7 +172,6 @@ $(OUT)/treasuryDAO_storage.tz : slash_scale_value = 0n
 $(OUT)/treasuryDAO_storage.tz : slash_division_value = 0n
 $(OUT)/treasuryDAO_storage.tz : min_xtz_amount = 0mutez
 $(OUT)/treasuryDAO_storage.tz : max_xtz_amount = 100mutez
-$(OUT)/treasuryDAO_storage.tz : current_level = 100n
 $(OUT)/treasuryDAO_storage.tz : metadata_map = Big_map.empty
 $(OUT)/treasuryDAO_storage.tz : freeze_history = []
 $(OUT)/treasuryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
@@ -182,11 +179,11 @@ $(OUT)/treasuryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/treasuryDAO_storage.tz : min_quorum = 1n
 $(OUT)/treasuryDAO_storage.tz : max_quorum = 99n
 $(OUT)/treasuryDAO_storage.tz : max_voters = 1000n
-$(OUT)/treasuryDAO_storage.tz : period = 15840n # 11 days
+$(OUT)/treasuryDAO_storage.tz : period = 15840n
 $(OUT)/treasuryDAO_storage.tz : quorum_change = 5n
 $(OUT)/treasuryDAO_storage.tz : max_quorum_change = 19n
-$(OUT)/treasuryDAO_storage.tz : proposal_flush_level = 36000n # 22 days
-$(OUT)/treasuryDAO_storage.tz : proposal_expired_level = 47520n # 33 days
+$(OUT)/treasuryDAO_storage.tz : proposal_flush_level = 36000n
+$(OUT)/treasuryDAO_storage.tz : proposal_expired_level = 47520n
 $(OUT)/treasuryDAO_storage.tz : governance_total_supply = 1000n
 $(OUT)/treasuryDAO_storage.tz: src/**
 	# ============== Compiling TreasuryDAO storage ============== #
@@ -201,7 +198,7 @@ $(OUT)/treasuryDAO_storage.tz: src/**
               { address = (\"$(call require_defined,governance_token_address)\" : address) \
               ; token_id = ($(call require_defined,governance_token_id) : nat) \
               } \
-            ; current_level = {blocks = $(current_level)} \
+            ; start_level = {blocks = $(call require_defined,start_level)} \
             ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
             ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
             } \
@@ -237,19 +234,22 @@ test-storage:
 		admin_address=tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af \
 		guardian_address=KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh \
 		governance_token_address=KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5 \
-		governance_token_id=0n
+		governance_token_id=0n \
+		start_level=100n
 
 	make $(OUT)/treasuryDAO_storage.tz \
 		admin_address=tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af \
 		guardian_address=KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh \
 		governance_token_address=KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5 \
-		governance_token_id=0n
+		governance_token_id=0n \
+		start_level=100n
 
 	make $(OUT)/registryDAO_storage.tz \
 		admin_address=tz1QozfhaUW4wLnohDo6yiBUmh7cPCSXE9Af \
 		guardian_address=KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh \
 		governance_token_address=KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5 \
-		governance_token_id=0n
+		governance_token_id=0n \
+		start_level=100n
 
 
 metadata : output = metadata.json

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ifeq ($(OPTIMIZE), true)
 endif
 	#
 
-$(OUT)/trivialDAO_storage.tz : now_val = `date +"%s"`
+$(OUT)/trivialDAO_storage.tz : current_level = 100n
 $(OUT)/trivialDAO_storage.tz : metadata_map = Big_map.empty
 $(OUT)/trivialDAO_storage.tz : freeze_history = []
 $(OUT)/trivialDAO_storage.tz : fixed_proposal_fee_in_token = 0n
@@ -64,12 +64,12 @@ $(OUT)/trivialDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/trivialDAO_storage.tz : min_quorum = 1n
 $(OUT)/trivialDAO_storage.tz : max_quorum = 99n
 $(OUT)/trivialDAO_storage.tz : max_voters = 1000n
-$(OUT)/trivialDAO_storage.tz : period = 950400n # 11 days
+$(OUT)/trivialDAO_storage.tz : period = 15840n # 11 days
 $(OUT)/trivialDAO_storage.tz : quorum_change = 5n
 $(OUT)/trivialDAO_storage.tz : max_quorum_change = 19n
 $(OUT)/trivialDAO_storage.tz : governance_total_supply = 1000n
-$(OUT)/trivialDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
-$(OUT)/trivialDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
+$(OUT)/trivialDAO_storage.tz : proposal_flush_level = 36000n # 22 days
+$(OUT)/trivialDAO_storage.tz : proposal_expired_level = 47520n # 33 days
 $(OUT)/trivialDAO_storage.tz: src/**
 	# ============== Compiling TrivialDAO storage ============== #
 	mkdir -p $(OUT)
@@ -82,7 +82,7 @@ $(OUT)/trivialDAO_storage.tz: src/**
             { address = (\"$(call require_defined,governance_token_address)\" : address) \
             ; token_id = ($(call require_defined,governance_token_id) : nat) \
             } \
-          ; now_val = ($(now_val) : timestamp)  \
+          ; current_level = {blocks = $(current_level)} \
           ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
           ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
           } \
@@ -90,9 +90,9 @@ $(OUT)/trivialDAO_storage.tz: src/**
           { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
           ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
           ; max_voters = ($(max_voters) : nat) \
-          ; period = { length = ($(period) : nat) } \
-          ; proposal_flush_time = ($(proposal_flush_time)  : nat) \
-          ; proposal_expired_time = ($(proposal_expired_time) : nat) \
+          ; period = { blocks = ($(period) : nat) } \
+          ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
+          ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) }\
           ; fixed_proposal_fee_in_token = ($(fixed_proposal_fee_in_token) : nat) \
           ; quorum_threshold = { numerator = (($(quorum_threshold) : nat) * quorum_denominator)/100n } \
           ; quorum_change = { numerator = (($(quorum_change) : nat) * quorum_denominator)/100n } \
@@ -111,7 +111,7 @@ $(OUT)/registryDAO_storage.tz : slash_scale_value = 1n
 $(OUT)/registryDAO_storage.tz : slash_division_value = 0n
 $(OUT)/registryDAO_storage.tz : min_xtz_amount = 0mutez
 $(OUT)/registryDAO_storage.tz : max_xtz_amount = 100mutez
-$(OUT)/registryDAO_storage.tz : now_val = `date +"%s"`
+$(OUT)/registryDAO_storage.tz : current_level = 100n
 $(OUT)/registryDAO_storage.tz : metadata_map = Big_map.empty
 $(OUT)/registryDAO_storage.tz : freeze_history = []
 $(OUT)/registryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
@@ -119,11 +119,11 @@ $(OUT)/registryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/registryDAO_storage.tz : min_quorum = 1n
 $(OUT)/registryDAO_storage.tz : max_quorum = 99n
 $(OUT)/registryDAO_storage.tz : max_voters = 1000n
-$(OUT)/registryDAO_storage.tz : period = 950400n # 11 days
+$(OUT)/registryDAO_storage.tz : period = 15840n # 11 days
 $(OUT)/registryDAO_storage.tz : quorum_change = 5n
 $(OUT)/registryDAO_storage.tz : max_quorum_change = 19n
-$(OUT)/registryDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
-$(OUT)/registryDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
+$(OUT)/registryDAO_storage.tz : proposal_flush_level = 36000n # 22 days
+$(OUT)/registryDAO_storage.tz : proposal_expired_level = 47520n # 33 days
 $(OUT)/registryDAO_storage.tz : governance_total_supply = 1000n
 $(OUT)/registryDAO_storage.tz: src/**
 	# ============== Compiling RegistryDAO storage ============== #
@@ -138,7 +138,7 @@ $(OUT)/registryDAO_storage.tz: src/**
               { address = (\"$(call require_defined,governance_token_address)\" : address) \
               ; token_id = ($(call require_defined,governance_token_id) : nat) \
               } \
-            ; now_val = ($(now_val) : timestamp)  \
+            ; current_level = {blocks = $(current_level)} \
             ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
             ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
             } \
@@ -146,9 +146,9 @@ $(OUT)/registryDAO_storage.tz: src/**
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
             ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
             ; max_voters = ($(max_voters) : nat) \
-            ; period = { length = ($(period) : nat) } \
-            ; proposal_flush_time = ($(proposal_flush_time)  : nat) \
-            ; proposal_expired_time = ($(proposal_expired_time) : nat) \
+            ; period = { blocks = ($(period) : nat) } \
+            ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
+            ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) } \
             ; fixed_proposal_fee_in_token = ($(fixed_proposal_fee_in_token) : nat) \
             ; quorum_threshold = { numerator = (($(quorum_threshold) : nat) * quorum_denominator)/100n } \
             ; quorum_change = { numerator = (($(quorum_change) : nat) * quorum_denominator)/100n } \
@@ -174,7 +174,7 @@ $(OUT)/treasuryDAO_storage.tz : slash_scale_value = 0n
 $(OUT)/treasuryDAO_storage.tz : slash_division_value = 0n
 $(OUT)/treasuryDAO_storage.tz : min_xtz_amount = 0mutez
 $(OUT)/treasuryDAO_storage.tz : max_xtz_amount = 100mutez
-$(OUT)/treasuryDAO_storage.tz : now_val = `date +"%s"`
+$(OUT)/treasuryDAO_storage.tz : current_level = 100n
 $(OUT)/treasuryDAO_storage.tz : metadata_map = Big_map.empty
 $(OUT)/treasuryDAO_storage.tz : freeze_history = []
 $(OUT)/treasuryDAO_storage.tz : fixed_proposal_fee_in_token = 0n
@@ -182,11 +182,11 @@ $(OUT)/treasuryDAO_storage.tz : quorum_threshold = 10n
 $(OUT)/treasuryDAO_storage.tz : min_quorum = 1n
 $(OUT)/treasuryDAO_storage.tz : max_quorum = 99n
 $(OUT)/treasuryDAO_storage.tz : max_voters = 1000n
-$(OUT)/treasuryDAO_storage.tz : period = 950400n # 11 days
+$(OUT)/treasuryDAO_storage.tz : period = 15840n # 11 days
 $(OUT)/treasuryDAO_storage.tz : quorum_change = 5n
 $(OUT)/treasuryDAO_storage.tz : max_quorum_change = 19n
-$(OUT)/treasuryDAO_storage.tz : proposal_flush_time = 1900801n # 22 days 1 seconds
-$(OUT)/treasuryDAO_storage.tz : proposal_expired_time = 2851200n # 33 days
+$(OUT)/treasuryDAO_storage.tz : proposal_flush_level = 36000n # 22 days
+$(OUT)/treasuryDAO_storage.tz : proposal_expired_level = 47520n # 33 days
 $(OUT)/treasuryDAO_storage.tz : governance_total_supply = 1000n
 $(OUT)/treasuryDAO_storage.tz: src/**
 	# ============== Compiling TreasuryDAO storage ============== #
@@ -201,7 +201,7 @@ $(OUT)/treasuryDAO_storage.tz: src/**
               { address = (\"$(call require_defined,governance_token_address)\" : address) \
               ; token_id = ($(call require_defined,governance_token_id) : nat) \
               } \
-            ; now_val = ($(now_val) : timestamp)  \
+            ; current_level = {blocks = $(current_level)} \
             ; metadata_map = ($(call escape_double_quote,$(metadata_map)) : metadata_map) \
             ; freeze_history = ($(call escape_double_quote,$(freeze_history)) : freeze_history_list) \
             } \
@@ -209,9 +209,9 @@ $(OUT)/treasuryDAO_storage.tz: src/**
             { max_quorum = { numerator = (($(max_quorum) : nat) * quorum_denominator)/100n } \
             ; min_quorum = { numerator = (($(min_quorum) : nat) * quorum_denominator)/100n } \
             ; max_voters = ($(max_voters) : nat) \
-            ; period = { length = ($(period) : nat) } \
-            ; proposal_flush_time = ($(proposal_flush_time)  : nat) \
-            ; proposal_expired_time = ($(proposal_expired_time) : nat) \
+            ; period = { blocks = ($(period) : nat) } \
+            ; proposal_flush_level = { blocks = ($(proposal_flush_level) : nat) } \
+            ; proposal_expired_level = { blocks = ($(proposal_expired_level) : nat) } \
             ; fixed_proposal_fee_in_token = ($(fixed_proposal_fee_in_token) : nat) \
             ; quorum_threshold = { numerator = (($(quorum_threshold) : nat) * quorum_denominator)/100n } \
             ; quorum_change = { numerator = (($(quorum_change) : nat) * quorum_denominator)/100n } \

--- a/docs/building.md
+++ b/docs/building.md
@@ -75,7 +75,7 @@ make out/trivialDAO_storage.tz \
   guardian_address=KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh \
   governance_token_address=KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5 \
   governance_token_id=0n \
-  now_val=`date +"%s"` \
+  current_level=100n \
   metadata_map=Big_map.empty \
   freeze_history=[] \
   fixed_proposal_fee_in_token=0n \
@@ -83,12 +83,12 @@ make out/trivialDAO_storage.tz \
   min_quorum=1n \
   max_quorum=99n \
   max_voters=1000n \
-  period=950400n \
+  period=15840n  \
   quorum_change=5n \
   max_quorum_change=19n \
   governance_total_supply=1000n \
-  proposal_flush_time=1900801n \
-  proposal_expired_time=2851200n
+  proposal_flush_level=36000n  \
+  proposal_expired_level=47520n \
 ```
 
 The `admin_address`, `guardian_address`, `governance_token_address`, and `governance_token_id`
@@ -115,7 +115,7 @@ make out/registryDAO_storage.tz \
   slash_division_value=0n \
   min_xtz_amount=0mutez \
   max_xtz_amount=100mutez \
-  now_val=`date +"%s"` \
+  current_level=100n \
   metadata_map=Big_map.empty \
   freeze_history=[] \
   fixed_proposal_fee_in_token=0n \
@@ -123,11 +123,11 @@ make out/registryDAO_storage.tz \
   min_quorum=1n \
   max_quorum=99n \
   max_voters=1000n \
-  period=950400n \
+  period=15840n \
   quorum_change=5n \
   max_quorum_change=19n \
-  proposal_flush_time=1900801n \
-  proposal_expired_time=2851200n \
+  proposal_flush_level=36000n \
+  proposal_expired_level= 47520n \
   governance_total_supply=1000n
 ```
 
@@ -152,7 +152,7 @@ make out/treasuryDAO_storage.tz \
   slash_division_value=0n \
   min_xtz_amount=0mutez \
   max_xtz_amount=100mutez \
-  now_val=`date +"%s"` \
+  current_level=100n \
   metadata_map=Big_map.empty \
   freeze_history=Big_map.empty \
   fixed_proposal_fee_in_token=0n \
@@ -161,11 +161,11 @@ make out/treasuryDAO_storage.tz \
   min_quorum=1n \
   max_quorum=99n \
   max_voters=1000n \
-  period=950400n \
+  period=15840n  \
   quorum_change=5n \
   max_quorum_change=19n \
-  proposal_flush_time=1900801n \
-  proposal_expired_time=2851200n \
+  proposal_flush_level=36000n \
+  proposal_expired_level=47520n \
   governance_total_supply=1000n
 ```
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -75,7 +75,7 @@ make out/trivialDAO_storage.tz \
   guardian_address=KT1QbdJ7M7uAQZwLpvzerUyk7LYkJWDL7eDh \
   governance_token_address=KT1RdwP8XJPjFyGoUsXFQnQo1yNm6gUqVdp5 \
   governance_token_id=0n \
-  current_level=100n \
+  start_level=100n \
   metadata_map=Big_map.empty \
   freeze_history=[] \
   fixed_proposal_fee_in_token=0n \
@@ -91,9 +91,9 @@ make out/trivialDAO_storage.tz \
   proposal_expired_level=47520n \
 ```
 
-The `admin_address`, `guardian_address`, `governance_token_address`, and `governance_token_id`
-are required values. The rest of the arguments are optional and will be equal to the
-values above if not specified.
+The `admin_address`, `guardian_address`, `governance_token_address`,
+`start_level` and `governance_token_id` are required values. The rest of the
+arguments are optional and will be equal to the values above if not specified.
 
 You can see the [specification](specification.md) for more info about these
 values.
@@ -115,7 +115,7 @@ make out/registryDAO_storage.tz \
   slash_division_value=0n \
   min_xtz_amount=0mutez \
   max_xtz_amount=100mutez \
-  current_level=100n \
+  start_level=100n \
   metadata_map=Big_map.empty \
   freeze_history=[] \
   fixed_proposal_fee_in_token=0n \
@@ -131,9 +131,9 @@ make out/registryDAO_storage.tz \
   governance_total_supply=1000n
 ```
 
-The `admin_address`, `guardian_address`, `governance_token_address`, and `governance_token_id`
-are required values. The rest of the arguments are optional and will be equal to the
-values above if not specified.
+The `admin_address`, `guardian_address`, `governance_token_address`,
+`start_level`, and `governance_token_id` are required values. The rest of the
+arguments are optional and will be equal to the values above if not specified.
 
 ### TreasuryDAO
 
@@ -152,7 +152,7 @@ make out/treasuryDAO_storage.tz \
   slash_division_value=0n \
   min_xtz_amount=0mutez \
   max_xtz_amount=100mutez \
-  current_level=100n \
+  start_level=100n \
   metadata_map=Big_map.empty \
   freeze_history=Big_map.empty \
   fixed_proposal_fee_in_token=0n \
@@ -169,9 +169,9 @@ make out/treasuryDAO_storage.tz \
   governance_total_supply=1000n
 ```
 
-The `admin_address`, `guardian_address`, `governance_token_address`, and `governance_token_id`
-are required values. The rest of the arguments are optional and will be equal to the
-values above if not specified.
+The `admin_address`, `guardian_address`, `governance_token_address`,
+`start_level` and `governance_token_id` are required values. The rest of the
+arguments are optional and will be equal to the values above if not specified.
 
 ## Storage generation checks
 The LIGO functions used by the `Makefile` targets above perform some automatic check, specifically:

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -119,12 +119,10 @@ type config =
   // of new quorum threshold value at each stage.
 
   ; proposal_flush_level : blocks
-  // ^ Determine the minimum amount of blocks after the proposal is proposed
-  // to allow it to be `flushed`.
+  // ^ The proposal age at (and above) which the proposal is considered flushable.
   // Has to be bigger than `period * 2`
   ; proposal_expired_level : blocks
-  // ^ Determine the minimum amount of blocks after the proposal is proposed
-  // to be considered as expired.
+  // ^ The proposal age at (and above) which the proposal is considered expired.
   // Has to be bigger than `proposal_flush_level`
 
   ; custom_entrypoints : custom_entrypoints
@@ -200,6 +198,7 @@ This chapter provides a high-level overview of the contract's logic.
 - The contract stores a list of proposals that can be in one of the states:
   "proposed", "ongoing", "pending flush", "accepted", "rejected", or "expired".
 - The contract forbids transferring XTZ to it on certain entrypoints.
+- The contract tracks 'stages' by counting the blocks.
 
 ## Roles
 
@@ -230,6 +229,15 @@ starting from "voting" for `stage` number `0`.
 A proposing and voting couple of `stage`s is called a `cycle`.
 
 The `period` is specified for the whole smart contract and never changes.
+
+The length of a period is measured by counting blocks as discrete entities. So
+if the configuration value of period is `3`, then the very first period only
+exist for blocks `0`, `1` and `2`.
+
+Similarly a proposal raised in block `100`, with an expiry of `3` blocks will
+remain unexpired for blocks `100`, `101`, `102`, and will be considered expired
+on the `103` th block, because at that block, the proposal will be considered to
+have an age of `3`.
 
 Tokens can be frozen in any `stage`, but they can only be used for voting, proposing
 and unfreezing starting from the one following and onwards.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -103,7 +103,7 @@ type config =
   // ^ Determine the minimum value of quorum threshold that is allowed.
 
   ; period : period
-  // ^ Determines the stages length in seconds.
+  // ^ Determines the stages length in number of blocks.
 
   ; fixed_proposal_fee_in_token : nat
   // ^ A base fee paid for submitting a new proposal.
@@ -118,14 +118,14 @@ type config =
   // ^ The total supply of governance tokens used in the computation of
   // of new quorum threshold value at each stage.
 
-  ; proposal_flush_time : seconds
-  // ^ Determine the minimum amount of seconds after the proposal is proposed
+  ; proposal_flush_level : blocks
+  // ^ Determine the minimum amount of blocks after the proposal is proposed
   // to allow it to be `flushed`.
   // Has to be bigger than `period * 2`
-  ; proposal_expired_time : seconds
-  // ^ Determine the minimum amount of seconds after the proposal is proposed
+  ; proposal_expired_level : blocks
+  // ^ Determine the minimum amount of blocks after the proposal is proposed
   // to be considered as expired.
-  // Has to be bigger than `proposal_flush_time`
+  // Has to be bigger than `proposal_flush_level`
 
   ; custom_entrypoints : custom_entrypoints
   // ^ Packed arbitrary lambdas associated to a name for custom execution.
@@ -146,8 +146,8 @@ type proposal =
   // ^ total amount of votes in favor
   ; downvotes : nat
   // ^ total amount of votes against
-  ; start_date : timestamp
-  // ^ time of submission, used to order proposals
+  ; start_level : blocks
+  // ^ block level of submission, used to order proposals
   ; voting_stage_num : nat
   // ^ stage number in which it is possible to vote on this proposal
   ; metadata : proposal_metadata
@@ -175,15 +175,15 @@ These values are:
    in a call to `drop_proposal`.
 3. `governance_token` is the FA2 contract address/token_id pair that will be
    used as the governance token.
-4. `period : nat` specifies how long the stages lasts in seconds.
-5. `proposal_flush_time : nat`
-    - Specifies, in seconds, how long it takes before a proposal can be flushed,
+4. `period : blocks` specifies how long the stages lasts in blocks.
+5. `proposal_flush_level : blocks`
+    - Specifies, in blocks, how long it takes before a proposal can be flushed,
       from when it was proposed.
     - IMPORTANT: Must be bigger than `period * 2`.
-6. `proposal_expired_time : nat`
-    - Specifies, in seconds, how long it takes for a proposal to be considered
+6. `proposal_expired_level : blocks`
+    - Specifies, in blocks, how long it takes for a proposal to be considered
       expired, from when it was proposed.
-    - IMPORTANT: Must be bigger than `proposal_flush_time`.
+    - IMPORTANT: Must be bigger than `proposal_flush_level`.
 7. `quorum_threshold : quorum_threshold` specifies what fraction of the frozen
    tokens total supply are required in total to vote for a successful proposal.
 8. `fixed_proposal_fee_in_token : nat` specifies the fee to be paid for submitting
@@ -607,10 +607,10 @@ Parameter (in Michelson):
 (nat %flush)
 ```
 
-- Finish voting process on an amount of proposals for which their `proposal_flush_time`
-  was reached, but their `proposal_expire_time` wasn't yet.
+- Finish voting process on an amount of proposals for which their `proposal_flush_level`
+  was reached, but their `proposal_expire_level` wasn't yet.
 - The order of processing proposals are from 'the oldest' to 'the newest'.
-  The proposals which have the same timestamp due to being in the same block,
+  The proposals which have the same level due to being in the same block,
   are processed in the order of their proposal keys.
 - Frozen tokens from voters and proposal submitter associated with those proposals
   are returned in the form of tokens in governance token contract:
@@ -642,9 +642,9 @@ Parameter (in Michelson):
 ```
 
 - Delete a proposal when either:
-  - The `proposal_expired_time` has been reached.
-  - The proposer is the `SENDER`, regardless of the `proposal_expired_time`.
-  - The `guardian` is the `SENDER`, regardless of the `proposal_expired_time`.
+  - The `proposal_expired_level` has been reached.
+  - The proposer is the `SENDER`, regardless of the `proposal_expired_level`.
+  - The `guardian` is the `SENDER`, regardless of the `proposal_expired_level`.
 - Fails with `DROP_PROPOSAL_CONDITION_NOT_MET` when none of the conditions above are met.
 - Tokens that are frozen for this proposal are returned to the proposer and voters
   as if the proposal was rejected, regardless of the actual votes.

--- a/haskell/baseDAO-ligo-meta.cabal
+++ b/haskell/baseDAO-ligo-meta.cabal
@@ -117,7 +117,6 @@ test-suite baseDAO-test
     , morley-metadata
     , morley-prelude
     , named
-    , o-clock
     , tasty
     , tasty-hunit-compat
     , universum

--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -145,7 +145,6 @@ tests:
     - morley-metadata
     - morley-prelude
     - named
-    - o-clock
     - tasty
     - tasty-hunit-compat
     - universum

--- a/haskell/src/Ligo/BaseDAO/Types.hs
+++ b/haskell/src/Ligo/BaseDAO/Types.hs
@@ -68,10 +68,10 @@ module Ligo.BaseDAO.Types
   , setExtra
   ) where
 
-import Universum (Enum, Integral, Num, One(..), Real, div, fromIntegral, maybe, (*))
+import Universum (Enum, Integral, Num, One(..), Real, fromIntegral, div, maybe, (*))
 
-import qualified Data.Map as M
 import Fmt (Buildable, build, genericF)
+import qualified Data.Map as M
 
 import Lorentz hiding (now)
 import Lorentz.Annotation ()
@@ -432,7 +432,7 @@ type CustomEntrypoints = CustomEntrypoints' BigMap
 data Proposal = Proposal
   { plUpvotes                 :: Natural
   , plDownvotes               :: Natural
-  , plStartDate               :: Timestamp
+  , plStartLevel              :: Natural
   , plVotingStageNum          :: Natural
 
   , plMetadata                :: ProposalMetadata
@@ -521,10 +521,10 @@ data Storage' big_map = Storage'
   , sPendingOwner :: Address
   , sPermitsCounter :: Nonce
   , sProposals :: big_map ProposalKey Proposal
-  , sProposalKeyListSortByDate :: Set (Timestamp, ProposalKey)
+  , sProposalKeyListSortByDate :: Set (Natural, ProposalKey)
   , sGovernanceToken :: GovernanceToken
   , sFreezeHistory :: big_map Address AddressFreezeHistory
-  , sStartTime :: Timestamp
+  , sStartLevel :: Natural
   , sQuorumThresholdAtCycle :: QuorumThresholdAtCycle
   , sFrozenTotalSupply :: Natural
   , sDelegates :: Delegates' big_map
@@ -562,11 +562,11 @@ mkStorage
   :: "admin" :! Address
   -> "extra" :! ContractExtra
   -> "metadata" :! TZIP16.MetadataMap BigMap
-  -> "startTime" :! Timestamp
+  -> "level" :! Natural
   -> "tokenAddress" :! Address
   -> "quorumThreshold" :! QuorumThreshold
   -> Storage
-mkStorage admin extra metadata start tokenAddress qt =
+mkStorage admin extra metadata lvl tokenAddress qt =
   Storage'
     { sAdmin = arg #admin admin
     , sGuardian = arg #admin admin
@@ -581,7 +581,7 @@ mkStorage admin extra metadata start tokenAddress qt =
         , gtTokenId = FA2.theTokenId
         }
     , sFreezeHistory = mempty
-    , sStartTime = arg #startTime start
+    , sStartLevel = arg #level lvl
     , sFrozenTokenId = frozenTokenId
     , sQuorumThresholdAtCycle = QuorumThresholdAtCycle 1 (arg #quorumThreshold qt) 0
     , sFrozenTotalSupply = 0
@@ -705,7 +705,7 @@ mkConfig customEps votingPeriod fixedProposalFee maxChangePercent changePercent 
   }
 
 defaultConfig :: Config
-defaultConfig = mkConfig [] (Period 10) 0 19 5 500
+defaultConfig = mkConfig [] 10 0 19 5 500
 
 data FullStorage' big_map = FullStorage'
   { fsStorage :: Storage' big_map
@@ -741,18 +741,18 @@ mkFullStorage
   -> "governanceTotalSupply" :? GovernanceTotalSupply
   -> "extra" :! ContractExtra
   -> "metadata" :! TZIP16.MetadataMap BigMap
-  -> "startTime" :! Timestamp
+  -> "level" :! Natural
   -> "tokenAddress" :! Address
   -> "customEps" :? [CustomEntrypoint]
   -> FullStorage
-mkFullStorage admin vp qt mcp cp gts extra mdt start tokenAddress cEps = FullStorage'
-  { fsStorage = mkStorage admin extra mdt start tokenAddress (#quorumThreshold (argDef #quorumThreshold quorumThresholdDef qt))
+mkFullStorage admin vp qt mcp cp gts extra mdt lvl tokenAddress cEps = FullStorage'
+  { fsStorage = mkStorage admin extra mdt lvl tokenAddress (#quorumThreshold (argDef #quorumThreshold quorumThresholdDef qt))
   , fsConfig  = mkConfig (argDef #customEps [] cEps)
       (argDef #votingPeriod votingPeriodDef vp) 0 (argDef #maxChangePercent 19 mcp) (argDef #changePercent 5 cp) (argDef #governanceTotalSupply 100 gts)
   }
   where
     quorumThresholdDef = mkQuorumThreshold 1 10 -- 10% of frozen total supply
-    votingPeriodDef = Period $ 60 * 60 * 24 * 7  -- 7 days
+    votingPeriodDef = 60 * 60 * 24 * 7  -- 7 days
 
 setExtra :: forall a. NicePackedValue a => MText -> a -> FullStorage -> FullStorage
 setExtra key v (s@FullStorage' {..}) = s { fsStorage = newStorage }

--- a/haskell/test/Test/Ligo/BaseDAO/Common.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Common.hs
@@ -6,13 +6,10 @@
 module Test.Ligo.BaseDAO.Common
   ( DaoOriginateData(..)
   , OriginateFn
-  , Seconds
 
-  , addDataToSign
-  , addSec
-  , doubleTime
   , dummyFA2Contract
   , makeProposalKey
+  , addDataToSign
   , permitProtect
   , sendXtz
 
@@ -26,7 +23,6 @@ module Test.Ligo.BaseDAO.Common
   -- * Re-export
   , module Errors
   , module StorageHelper
-  , sec
   ) where
 
 import Universum hiding (drop, swap)
@@ -37,7 +33,6 @@ import Michelson.Typed.Convert (convertContract, untypeValue)
 import Morley.Nettest
 import Morley.Nettest.Caps (MonadOps)
 import Named ((!))
-import Time (Second, Time, sec, (*:*), (+:+))
 
 import Ligo.BaseDAO.Contract
 import Ligo.BaseDAO.Types
@@ -46,14 +41,6 @@ import Test.Ligo.BaseDAO.Common.StorageHelper as StorageHelper
 import Test.Ligo.BaseDAO.Proposal.Config (ConfigDesc, fillConfig)
 
 type OriginateFn m = QuorumThreshold -> m DaoOriginateData
-
-type Seconds = Time Second
-
-doubleTime :: Time Second -> Time Second
-doubleTime c = 2 *:* c
-
-addSec :: Time Second -> Time Second
-addSec c = (sec 1) +:+ c
 
 data DaoOriginateData = DaoOriginateData
   { dodOwner1 :: Address
@@ -64,7 +51,7 @@ data DaoOriginateData = DaoOriginateData
   , dodTokenContract :: TAddress FA2.Parameter
   , dodAdmin :: Address
   , dodGuardian :: TAddress (Address, ProposalKey)
-  , dodPeriod :: Seconds
+  , dodPeriod :: Natural
   }
 
 -- | A dummy contract with FA2 parameter that remembers the
@@ -129,6 +116,7 @@ sendXtz addr epName pm = withFrozenCallStack $ do
         }
   transfer transferData
 
+
 -- TODO: Implement this via [#31] instead
 -- checkIfAProposalExist
 --   :: MonadNettest caps base m
@@ -160,7 +148,7 @@ originateLigoDaoWithConfig extra config qt = do
 
   admin :: Address <- newAddress "admin"
 
-  currentLevel <- getNow
+  currentLevel <- getLevel
   tokenContract <- originateSimple "TokenContract" [] dummyFA2Contract
   guardianContract <- originateSimple "guardian" () dummyGuardianContract
 
@@ -171,7 +159,7 @@ originateLigoDaoWithConfig extra config qt = do
               ! #admin admin
               ! #metadata mempty
               ! #tokenAddress (unTAddress tokenContract)
-              ! #startTime currentLevel
+              ! #level currentLevel
               ! #quorumThreshold qt
             )
             { sGuardian = unTAddress guardianContract
@@ -191,7 +179,7 @@ originateLigoDaoWithConfig extra config qt = do
   let dao = TAddress @Parameter daoUntyped
 
   pure $ DaoOriginateData owner1 operator1 owner2 operator2 dao tokenContract
-      admin guardianContract (sec $ fromIntegral $ unPeriod $ cPeriod config)
+      admin guardianContract (unPeriod $ cPeriod config)
 
 originateLigoDaoWithConfigDesc
  :: MonadNettest caps base m

--- a/haskell/test/Test/Ligo/BaseDAO/Management.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Management.hs
@@ -51,45 +51,45 @@ test_BaseDAO_Management :: [TestTree]
 test_BaseDAO_Management =
   [ testGroup "Ownership transfer"
     [ nettestScenarioCaps "transfer ownership entrypoint authenticates sender" $ do
-        current_time <- getNow
-        transferOwnership withOriginated (initialStorage current_time)
+        current_level <- getLevel
+        transferOwnership withOriginated (initialStorage current_level)
 
     , nettestScenarioCaps "sets pending owner" $ do
-        current_time <- getNow
-        transferOwnership withOriginated (initialStorage current_time)
+        current_level <- getLevel
+        transferOwnership withOriginated (initialStorage current_level)
 
     , nettestScenarioCaps "does not set administrator" $ do
-        current_time <- getNow
-        notSetAdmin withOriginated (initialStorage current_time)
+        current_level <- getLevel
+        notSetAdmin withOriginated (initialStorage current_level)
 
     , nettestScenarioCaps "rewrite existing pending owner" $ do
-        current_time <- getNow
-        rewritePendingOwner withOriginated (initialStorage current_time)
+        current_level <- getLevel
+        rewritePendingOwner withOriginated (initialStorage current_level)
 
     , nettestScenarioCaps "invalidates pending owner if new owner is current admin" $ do
-        current_time <- getNow
-        invalidatePendingOwner withOriginated (initialStorage current_time)
+        current_level <- getLevel
+        invalidatePendingOwner withOriginated (initialStorage current_level)
 
     , nettestScenarioCaps "bypasses accept_entrypoint if new admin address is self" $ do
-        current_time <- getNow
-        bypassAcceptForSelf withOriginated (initialStorage current_time)
+        current_level <- getLevel
+        bypassAcceptForSelf withOriginated (initialStorage current_level)
     ]
     , testGroup "Accept Ownership"
       [ nettestScenarioCaps "authenticates the sender" $ do
-          current_time <- getNow
-          authenticateSender withOriginated (initialStorage current_time)
+          current_level <- getLevel
+          authenticateSender withOriginated (initialStorage current_level)
 
       , nettestScenarioCaps "changes the administrator to pending owner" $ do
-          current_time <- getNow
-          changeToPendingAdmin withOriginated (initialStorage current_time)
+          current_level <- getLevel
+          changeToPendingAdmin withOriginated (initialStorage current_level)
 
       , nettestScenarioCaps "throws error when there is no pending owner" $ do
-          current_time <- getNow
-          noPendingAdmin withOriginated (initialStorage current_time)
+          current_level <- getLevel
+          noPendingAdmin withOriginated (initialStorage current_level)
 
       , nettestScenarioCaps "throws error when called by current admin, when pending owner is not the same" $ do
-          current_time <- getNow
-          pendingOwnerNotTheSame withOriginated (initialStorage current_time)
+          current_level <- getLevel
+          pendingOwnerNotTheSame withOriginated (initialStorage current_level)
       ]
   ]
 
@@ -104,11 +104,11 @@ test_BaseDAO_Management =
         (L.dip (L.toField #fsStorage) # setField #sAdmin) #
       L.nil # pair
 
-    initialStorage now admin = mkFullStorage
+    initialStorage currentLevel admin = mkFullStorage
       ! #admin admin
       ! #extra dynRecUnsafe
       ! #metadata mempty
-      ! #startTime now
+      ! #level currentLevel
       ! #tokenAddress genesisAddress
       ! #customEps
           [ ([mt|testCustomEp|], lPackValueRaw testCustomEntrypoint)

--- a/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/OffChainViews.hs
@@ -31,7 +31,7 @@ offChainViewStorage =
   ! #admin addr
   ! #extra dynRecUnsafe
   ! #metadata mempty
-  ! #startTime (timestampFromSeconds 100)
+  ! #level 100
   ! #tokenAddress genesisAddress
   ! #quorumThreshold (mkQuorumThreshold 1 100)
   ! defaults

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Delegate.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Delegate.hs
@@ -44,7 +44,7 @@ addRemoveDelegate originateFn = do
   withSender dodOwner1 $
     call dodDao (Call @"Freeze") (#amount .! 100)
 
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   let params counter = ProposeParams
         { ppFrozenToken = 10
         , ppProposalMetadata = lPackValueRaw @Integer counter
@@ -58,7 +58,7 @@ addRemoveDelegate originateFn = do
                 , vFrom = dodOwner1
                 }
   withSender dodOperator1 $ call dodDao (Call @"Propose") (params 1)
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOperator1 $ call dodDao (Call @"Vote") [vote]
 
   withSender dodOwner1 $
@@ -66,7 +66,7 @@ addRemoveDelegate originateFn = do
 
   withSender dodOperator1 $ call dodDao (Call @"Vote") [vote]
     & expectCustomErrorNoArg #nOT_DELEGATE dodDao
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOperator1 $ call dodDao (Call @"Propose") (params 2)
     & expectCustomErrorNoArg #nOT_DELEGATE dodDao
 

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
@@ -18,8 +18,8 @@ module Test.Ligo.BaseDAO.Proposal.Flush
 
 import Universum
 
-import Lorentz hiding (assert, (>>))
 import Lorentz.Test (contractConsumer)
+import Lorentz hiding (assert, (>>))
 import Morley.Nettest
 import Util.Named
 
@@ -48,12 +48,12 @@ flushAcceptedProposals originateFn getFreezeHistoryFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Accepted Proposals
   key1 <- createSampleProposal 1 dodOwner1 dodDao
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   let upvote' = NoPermit VoteParam
         { vFrom = dodOwner2
@@ -77,7 +77,7 @@ flushAcceptedProposals originateFn getFreezeHistoryFn = do
   fhOwner2 @== Just (AddressFreezeHistory 0 0 2 15)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime (addSec dodPeriod)
+  advanceLevel (dodPeriod+1)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
@@ -110,11 +110,11 @@ flushAcceptedProposalsWithAnAmount originateFn checkBalanceFn = do
   withSender dodOwner2 $
     call dodDao (Call @"Freeze") (#amount .! 10)
 
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- [Proposing]
   (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
-  advanceTime (sec 1)
+  advanceLevel 1
   _key3 <- createSampleProposal 3 dodOwner1 dodDao
 
   let vote' key = NoPermit VoteParam
@@ -124,7 +124,7 @@ flushAcceptedProposalsWithAnAmount originateFn checkBalanceFn = do
         , vProposalKey = key
         }
 
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- [Voting]
   withSender dodOwner2 . inBatch $ do
@@ -132,7 +132,7 @@ flushAcceptedProposalsWithAnAmount originateFn checkBalanceFn = do
       call dodDao (Call @"Vote") [vote' key2]
       pure ()
 
-  advanceTime (addSec dodPeriod)
+  advanceLevel (dodPeriod + 1)
 
   -- [Proposing]
   withSender dodAdmin $ call dodDao (Call @"Flush") 2
@@ -165,7 +165,7 @@ flushRejectProposalQuorum originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Rejected Proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -179,11 +179,11 @@ flushRejectProposalQuorum originateFn checkBalanceFn = do
           }
         ]
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") votes
 
   -- Advance one voting period to a proposing stage.
-  advanceTime (addSec dodPeriod)
+  advanceLevel (dodPeriod + 1)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
@@ -213,7 +213,7 @@ flushRejectProposalNegativeVotes originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Rejected Proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -239,14 +239,14 @@ flushRejectProposalNegativeVotes originateFn checkBalanceFn = do
           }
         ]
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") votes
 
   -- Check proposer balance
   checkBalanceFn (unTAddress dodDao) dodOwner1 10
 
   -- Advance one voting period to a proposing stage.
-  advanceTime (addSec dodPeriod)
+  advanceLevel (dodPeriod + 1)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
@@ -276,7 +276,7 @@ flushWithBadConfig originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   let upvote' = NoPermit VoteParam
@@ -286,11 +286,11 @@ flushWithBadConfig originateFn checkBalanceFn = do
         , vFrom = dodOwner2
         }
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote']
 
   -- Advance one voting period to a proposing stage.
-  advanceTime (addSec dodPeriod)
+  advanceLevel (dodPeriod+1)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: [#31]
@@ -318,7 +318,7 @@ flushDecisionLambda originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   let upvote' = NoPermit VoteParam
@@ -328,11 +328,11 @@ flushDecisionLambda originateFn = do
         , vFrom = dodOwner2
         }
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote']
 
   -- Advance one voting period to a proposing stage.
-  advanceTime (addSec dodPeriod)
+  advanceLevel (dodPeriod + 1)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   results <- fromVal <$> getStorage (toAddress consumer)
@@ -360,11 +360,11 @@ flushFailOnExpiredProposal originateFn checkBalanceFn = withFrozenCallStack $ do
     call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   let params key = NoPermit VoteParam
         { vVoteType = True
         , vVoteAmount = 20
@@ -373,10 +373,10 @@ flushFailOnExpiredProposal originateFn checkBalanceFn = withFrozenCallStack $ do
         }
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params key1]
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   _key2 <- createSampleProposal 2 dodOwner1 dodDao
 
-  advanceTime (addSec $ doubleTime dodPeriod)
+  advanceLevel (2*dodPeriod + 1)
   -- `key1` is now expired, and `key2` is not yet expired.
   withSender dodAdmin $ call dodDao (Call @"Flush") 2
     & expectCustomErrorNoArg #eXPIRED_PROPOSAL dodDao
@@ -405,12 +405,12 @@ flushProposalFlushTimeNotReach originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 30)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   (_key1, _key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
   -- Advance two voting period to another proposing stage.
-  advanceTime dodPeriod -- skip voting period
-  advanceTime (addSec dodPeriod)
+  advanceLevel dodPeriod -- skip voting period
+  advanceLevel (dodPeriod + 1)
   _key3 <- createSampleProposal 3 dodOwner1 dodDao
 
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
@@ -441,11 +441,11 @@ flushNotEmpty originateFn = withFrozenCallStack $ do
   withSender dodOwner2 $ call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 dodOwner1 dodDao
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   let params key = NoPermit VoteParam
         { vVoteType = True
         , vVoteAmount = 20
@@ -455,12 +455,12 @@ flushNotEmpty originateFn = withFrozenCallStack $ do
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params key1]
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   -- the proposal exists at this point (and has votes), but it can't be flushed
   -- yet, because it needs one more level to meet the `proposal_flush_time`
   withSender dodAdmin $ call dodDao (Call @"Flush") 1
     & expectCustomErrorNoArg #eMPTY_FLUSH dodDao
 
   -- however after one more level flushing is allowed
-  advanceTime $ sec 1
+  advanceLevel 1
   withSender dodAdmin $ call dodDao (Call @"Flush") 1

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Flush.hs
@@ -18,8 +18,8 @@ module Test.Ligo.BaseDAO.Proposal.Flush
 
 import Universum
 
-import Lorentz.Test (contractConsumer)
 import Lorentz hiding (assert, (>>))
+import Lorentz.Test (contractConsumer)
 import Morley.Nettest
 import Util.Named
 
@@ -455,7 +455,7 @@ flushNotEmpty originateFn = withFrozenCallStack $ do
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params key1]
 
   -- Advance one voting period to a proposing stage.
-  advanceLevel dodPeriod
+  advanceLevel (dodPeriod - 1)
   -- the proposal exists at this point (and has votes), but it can't be flushed
   -- yet, because it needs one more level to meet the `proposal_flush_time`
   withSender dodAdmin $ call dodDao (Call @"Flush") 1

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Propose.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Propose.hs
@@ -67,7 +67,7 @@ validProposal originateFn getFrozenTotalSupplyFn getFreezeHistoryFn = do
     (toVal [[FA2.TransferItem { tiFrom = dodOwner1, tiTxs = [FA2.TransferDestination { tdTo = unTAddress dodDao, tdTokenId = FA2.theTokenId, tdAmount = 10 }] }]])
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner1 $ call dodDao (Call @"Propose") params
 
@@ -96,7 +96,7 @@ validProposalWithFixedFee getFrozenTotalSupplyFn getFreezeHistoryFn = do
   withSender proposer $
     call dodDao (Call @"Freeze") (#amount .! 52)
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender proposer $ call dodDao (Call @"Propose") params
 
@@ -130,10 +130,10 @@ proposerIsReturnedFeeAfterSucceeding checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 proposer dodDao
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   let vote_ =
         NoPermit VoteParam
           { vVoteType = True
@@ -148,7 +148,7 @@ proposerIsReturnedFeeAfterSucceeding checkBalanceFn = do
   checkBalanceFn (unTAddress dodDao) proposer expectedFrozen
 
   -- Advance one voting period to a proposing stage.
-  advanceTime $ addSec dodPeriod
+  advanceLevel $ dodPeriod + 1
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   checkBalanceFn (unTAddress dodDao) proposer 52
@@ -164,7 +164,7 @@ cannotProposeWithInsufficientTokens = do
   withSender proposer $
     call dodDao (Call @"Freeze") (#amount .! 52)
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   let params = ProposeParams
         { ppFrozenToken = 1
@@ -189,7 +189,7 @@ rejectProposal originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   (withSender dodOwner1 $ call dodDao (Call @"Propose") params)
     & expectCustomError #fAIL_PROPOSAL_CHECK dodDao tooSmallXtzErrMsg
@@ -204,7 +204,7 @@ nonUniqueProposal originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   _ <- createSampleProposal 1 dodOwner1 dodDao
   createSampleProposal 1 dodOwner1 dodDao
     & expectCustomErrorNoArg #pROPOSAL_NOT_UNIQUE dodDao
@@ -235,7 +235,7 @@ nonProposalPeriodProposal originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance two voting periods to another voting stage.
-  advanceTime (doubleTime dodPeriod)
+  advanceLevel (2 * dodPeriod)
 
   let params = ProposeParams
         { ppFrozenToken = 10
@@ -270,11 +270,11 @@ burnsFeeOnFailure reason checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 proposer dodDao
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   case reason of
     Downvoted -> do
       withSender voter $
@@ -285,7 +285,7 @@ burnsFeeOnFailure reason checkBalanceFn = do
   checkBalanceFn (unTAddress dodDao) proposer expectedFrozen
 
   -- Advance one voting period to a proposing stage.
-  advanceTime (addSec dodPeriod)
+  advanceLevel (dodPeriod+1)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- Tokens frozen with the proposal are returned as unstaked (but still
@@ -316,11 +316,11 @@ unstakesTokensForMultipleVotes getFhFn = do
     call dodDao (Call @"Freeze") (#amount .! 30)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 proposer dodDao
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   let vote_ typ =
         NoPermit VoteParam
           { vVoteType = typ
@@ -344,7 +344,7 @@ unstakesTokensForMultipleVotes getFhFn = do
   assert (fh == expected) "Unexpected freeze history after voting"
 
   -- Advance one voting period to a proposing stage.
-  advanceTime (addSec dodPeriod)
+  advanceLevel (dodPeriod+1)
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
   fh_after_flush <- getFhFn (unTAddress dodDao) voter
   let expected_after_flush = Just (AddressFreezeHistory
@@ -383,7 +383,7 @@ insufficientTokenVote originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Create sample proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -402,7 +402,7 @@ insufficientTokenVote originateFn = do
             }
         ]
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner2 $ call dodDao (Call @"Vote") params
     & expectCustomError_ #nOT_ENOUGH_FROZEN_TOKENS dodDao
@@ -426,12 +426,12 @@ dropProposal originateFn checkBalanceFn = withFrozenCallStack $ do
     call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   let params key = NoPermit VoteParam
         { vVoteType = True
         , vVoteAmount = 20
@@ -440,7 +440,7 @@ dropProposal originateFn checkBalanceFn = withFrozenCallStack $ do
         }
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params key1]
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   key3 <- createSampleProposal 3 dodOwner1 dodDao
 
@@ -453,7 +453,7 @@ dropProposal originateFn checkBalanceFn = withFrozenCallStack $ do
     call dodDao (Call @"Drop_proposal") key2
       & expectCustomErrorNoArg #dROP_PROPOSAL_CONDITION_NOT_MET dodDao
 
-  advanceTime (addSec dodPeriod)
+  advanceLevel (dodPeriod + 1)
   -- `key2` is expired, so it is possible to `drop_proposal`
   withSender dodOwner2 $ do
     call dodDao (Call @"Drop_proposal") key2
@@ -488,7 +488,7 @@ proposalBoundedValue originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   let params = ProposeParams
         { ppFrozenToken = 10

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Propose.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Propose.hs
@@ -219,7 +219,7 @@ nonUniqueProposalEvenAfterDrop originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 dodOwner1 dodDao
   withSender dodOwner1 $ call dodDao (Call @"Drop_proposal") key1
   createSampleProposal 1 dodOwner1 dodDao

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Quorum.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Quorum.hs
@@ -67,7 +67,7 @@ checkQuorumThresholdDynamicUpdate originateFn getQtAtCycle = do
   withSender proposer $
     call dao (Call @"Freeze") (#amount .! (2 * requiredFrozen))
 
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   -- First proposal period, cycle 0
 
   withSender proposer $
@@ -78,7 +78,7 @@ checkQuorumThresholdDynamicUpdate originateFn getQtAtCycle = do
   assert (quorumThresholdActual_ == quorumThresholdExpected_) "Unexpected quorumThreshold update"
 
   -- skip this proposal period and next voting period to be in next proposal period
-  advanceTime (addSec $ doubleTime dodPeriod)
+  advanceLevel (2 * dodPeriod + 1)
 
   let proposalMeta2 = "A"
   withSender proposer $
@@ -113,14 +113,14 @@ checkQuorumThresholdDynamicUpdateUpperBound originateFn getQtAtCycle = do
   withSender proposer $
     call dao (Call @"Freeze") (#amount .! (2 * requiredFrozen))
 
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   -- First proposal period, cycle 0
 
   withSender proposer $
     call dodDao (Call @"Propose") (ProposeParams proposer requiredFrozen proposalMeta1)
 
   -- skip this proposal period and next voting period to be in next proposal period
-  advanceTime (addSec $ doubleTime dodPeriod)
+  advanceLevel (2 * dodPeriod + 1)
 
   let proposalMeta2 = "A"
   withSender proposer $
@@ -158,14 +158,14 @@ checkQuorumThresholdDynamicUpdateLowerBound originateFn getQtAtCycle = do
   withSender proposer $
     call dao (Call @"Freeze") (#amount .! (2 * requiredFrozen))
 
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   -- First proposal period, cycle 0
 
   withSender proposer $
     call dodDao (Call @"Propose") (ProposeParams proposer requiredFrozen proposalMeta1)
 
   -- skip this proposal period and next voting period to be in next proposal period
-  advanceTime (addSec $ doubleTime dodPeriod)
+  advanceLevel (2 * dodPeriod + 1)
 
   let proposalMeta2 = "A"
   withSender proposer $
@@ -203,14 +203,14 @@ checkProposalSavesQuorum originateFn getProposal = do
   withSender proposer $
     call dao (Call @"Freeze") (#amount .! (2 * requiredFrozen))
 
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   -- First proposal period, cycle 0
 
   withSender proposer $
     call dodDao (Call @"Propose") (ProposeParams proposer requiredFrozen proposalMeta1)
 
   -- skip this proposal period and next voting period to be in next proposal period
-  advanceTime (addSec $ doubleTime dodPeriod)
+  advanceLevel (2 * dodPeriod + 1)
 
   let proposalMeta2 = "A"
   let proposeParams = ProposeParams proposer requiredFrozen proposalMeta2
@@ -253,10 +253,10 @@ proposalIsRejectedIfNoQuorum checkBalanceFn = do
     call dao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 proposer dao
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   let vote_ =
         NoPermit VoteParam
           { vVoteType = True
@@ -272,7 +272,7 @@ proposalIsRejectedIfNoQuorum checkBalanceFn = do
   checkBalanceFn (unTAddress dao) proposer expectedFrozen
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender admin $ call dao (Call @"Flush") 100
 
   checkBalanceFn (unTAddress dao) proposer 10 -- We expect 42 tokens to have burned
@@ -304,10 +304,10 @@ proposalSucceedsIfUpVotesGtDownvotesAndQuorum checkBalanceFn = do
     call dao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 proposer dao
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   let vote_ =
         NoPermit VoteParam
           { vVoteType = True
@@ -323,7 +323,7 @@ proposalSucceedsIfUpVotesGtDownvotesAndQuorum checkBalanceFn = do
   checkBalanceFn (unTAddress dao) proposer expectedFrozen
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender admin $ call dao (Call @"Flush") 100
 
   checkBalanceFn (unTAddress dao) proposer 52

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Tokens.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Tokens.hs
@@ -54,9 +54,9 @@ checkFreezeHistoryTracking originateFn getFreezeHistory = do
   let requiredFrozen = proposalSize1 * frozen_scale_value + frozen_extra_value
 
   withSender dodOwner1 $ call dodDao (Call @"Freeze") (#amount .! requiredFrozen)
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner1 $ call dodDao (Call @"Propose") (ProposeParams dodOwner1 requiredFrozen proposalMeta1)
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   fh <- getFreezeHistory (unTAddress dodDao) dodOwner1 -- TODO [#31]
   let expected = AddressFreezeHistory
@@ -78,7 +78,7 @@ canUnfreezeFromPreviousPeriod originateFn checkBalanceFn = do
   checkBalanceFn (unTAddress dodDao) dodOwner1 10
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner1 $ call dodDao (Call @"Unfreeze") (#amount .! 10)
   checkBalanceFn (unTAddress dodDao) dodOwner1 00
@@ -104,7 +104,7 @@ cannotUnfreezeStakedTokens originateFn checkBalanceFn = do
   checkBalanceFn (unTAddress dodDao) dodOwner1 50
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   void $ createSampleProposal 1 dodOwner1 dodDao
 
   -- the frozen tokens are still the same

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
@@ -41,7 +41,7 @@ voteNonExistingProposal originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   -- Create sample proposal
   _ <- createSampleProposal 1 dodOwner1 dodDao
   let params = NoPermit VoteParam
@@ -51,7 +51,7 @@ voteNonExistingProposal originateFn = do
         , vFrom = dodOwner2
         }
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params]
     & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dodDao
@@ -69,7 +69,7 @@ voteMultiProposals originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 5)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Create sample proposal
   (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
@@ -89,7 +89,7 @@ voteMultiProposals originateFn checkBalanceFn = do
         ]
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") params
   checkBalanceFn (unTAddress dodDao) dodOwner2 5
   -- TODO [#31]: check storage if the vote update the proposal properly
@@ -116,7 +116,7 @@ proposalCorrectlyTrackVotes originateFn getProposalFn = do
     call dodDao (Call @"Freeze") (#amount .! 40)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Create sample proposal
   (key1, key2) <- createSampleProposals (1, 2) dodOwner1 dodDao
@@ -166,7 +166,7 @@ proposalCorrectlyTrackVotes originateFn getProposalFn = do
         ]
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender voter1 . inBatch $ do
     call dodDao (Call @"Vote") params1
     call dodDao (Call @"Vote") params3
@@ -214,7 +214,7 @@ voteOutdatedProposal originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Create sample proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -227,12 +227,12 @@ voteOutdatedProposal originateFn = do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner2 $ do
     call dodDao (Call @"Vote") [params]
     -- Advance two voting period to another voting stage.
-    advanceTime (doubleTime dodPeriod)
+    advanceLevel (2 * dodPeriod)
     call dodDao (Call @"Vote") [params]
       & expectCustomErrorNoArg #vOTING_STAGE_OVER dodDao
 
@@ -251,7 +251,7 @@ voteValidProposal originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Create sample proposal (first proposal has id = 0)
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -263,7 +263,7 @@ voteValidProposal originateFn checkBalanceFn = do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params]
   checkBalanceFn (unTAddress dodDao) dodOwner2 2
   -- TODO [#31]: check if the vote is updated properly
@@ -308,7 +308,7 @@ voteWithPermit originateFn checkBalanceFn = do
     call dodDao (Call @"Freeze") (#amount .! 12)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Create sample proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -322,7 +322,7 @@ voteWithPermit originateFn checkBalanceFn = do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params]
   checkBalanceFn (unTAddress dodDao) dodOwner1 12
@@ -341,7 +341,7 @@ voteWithPermitNonce originateFn getVotePermitsCounterFn = do
     call dodDao (Call @"Freeze") (#amount .! 50)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Create sample proposal
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -354,7 +354,7 @@ voteWithPermitNonce originateFn getVotePermitsCounterFn = do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   -- Going to try calls with different nonces
   signed1@(_          , _) <- addDataToSign dodDao (Nonce 0) voteParam
   signed2@(dataToSign2, _) <- addDataToSign dodDao (Nonce 1) voteParam
@@ -398,7 +398,7 @@ votesBoundedValue originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 11)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   key1 <- createSampleProposal 1 dodOwner2 dodDao
   let upvote' = NoPermit VoteParam
         { vVoteType = False
@@ -413,7 +413,7 @@ votesBoundedValue originateFn = do
         , vFrom = dodOwner1
         }
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner1 $ do
     call dodDao (Call @"Vote") [downvote']
 

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal/Vote.hs
@@ -282,7 +282,7 @@ voteDeletedProposal originateFn = do
     call dodDao (Call @"Freeze") (#amount .! 10)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   -- Create sample proposal (first proposal has id = 0)
   key1 <- createSampleProposal 1 dodOwner1 dodDao
@@ -294,7 +294,7 @@ voteDeletedProposal originateFn = do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner1 $ call dodDao (Call @"Drop_proposal") key1
   withSender dodOwner2 $ call dodDao (Call @"Vote") [params]
     & expectCustomErrorNoArg #pROPOSAL_NOT_EXIST dodDao

--- a/haskell/test/Test/Ligo/TreasuryDAO.hs
+++ b/haskell/test/Test/Ligo/TreasuryDAO.hs
@@ -90,7 +90,7 @@ validProposal checkBalanceFn = withFrozenCallStack $ do
     call dodDao (Call @"Freeze") (#amount .! proposalSize)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner1 $
     call dodDao (Call @"Propose") (ProposeParams dodOwner1 (proposalSize + 1) proposalMeta)
@@ -123,7 +123,7 @@ flushTokenTransfer checkBalanceFn = withFrozenCallStack $ do
     call dodDao (Call @"Freeze") (#amount .! 20)
 
   -- Advance one voting periods to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner1 $ call dodDao (Call @"Propose") proposeParams
   let key1 = makeProposalKey proposeParams
@@ -139,10 +139,10 @@ flushTokenTransfer checkBalanceFn = withFrozenCallStack $ do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote]
   -- Advance one voting period to a proposing stage.
-  advanceTime $ addSec dodPeriod -- meet `proposal_flush_time`
+  advanceLevel $ dodPeriod + 1 -- meet `proposal_flush_time`
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   checkBalanceFn (unTAddress dodDao) dodOwner1 proposalSize
@@ -171,7 +171,7 @@ flushXtzTransfer checkBalanceFn = withFrozenCallStack $ do
   withSender dodOwner2 $
     call dodDao (Call @"Freeze") (#amount .! 10)
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner1 $ do
   -- due to smaller than min_xtz_amount
@@ -196,10 +196,10 @@ flushXtzTransfer checkBalanceFn = withFrozenCallStack $ do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote]
   -- Advance one voting period to a proposing stage.
-  advanceTime $ addSec dodPeriod -- meet `proposal_flush_time`
+  advanceLevel $ dodPeriod + 1 -- meet `proposal_flush_time`
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
 
   -- TODO: check xtz balance
@@ -224,7 +224,7 @@ flushUpdateGuardian checkGuardian = withFrozenCallStack $ do
   withSender dodOwner2 $
     call dodDao (Call @"Freeze") (#amount .! 10)
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner1 $
     call dodDao (Call @"Propose") proposeParams
@@ -239,10 +239,10 @@ flushUpdateGuardian checkGuardian = withFrozenCallStack $ do
         }
 
   -- Advance one voting period to a voting stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
   withSender dodOwner2 $ call dodDao (Call @"Vote") [upvote]
   -- Advance one voting period to a proposing stage.
-  advanceTime $ addSec dodPeriod -- meet `proposal_flush_time`
+  advanceLevel $ (dodPeriod + 1) -- meet `proposal_flush_level`
   withSender dodAdmin $ call dodDao (Call @"Flush") 100
   checkGuardian (unTAddress dodDao) dodOwner2
 
@@ -268,7 +268,7 @@ proposalCheckFailZeroMutez = withFrozenCallStack do
     call dodDao (Call @"Freeze") (#amount .! proposalSize)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime dodPeriod
+  advanceLevel dodPeriod
 
   withSender dodOwner1 $
     call dodDao (Call @"Propose") (ProposeParams dodOwner1 proposalSize proposalMeta)
@@ -291,7 +291,7 @@ proposalCheckBiggerThanMaxProposalSize = withFrozenCallStack do
     call dodDao (Call @"Freeze") (#amount .! largeProposalSize)
 
   -- Advance one voting period to a proposing stage.
-  advanceTime $ sec 10
+  advanceLevel 10
 
   withSender dodOwner1 $
     call dodDao (Call @"Propose") (ProposeParams dodOwner1 largeProposalSize largeProposalMeta)

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -4,11 +4,11 @@
 #include "types.mligo"
 #include "proposal.mligo"
 
-let validate_proposal_flush_expired_time (data : initial_config_data) : unit =
-  if data.proposal_expired_time <= data.proposal_flush_time then
-    failwith("'proposal_expired_time' needs to be bigger than 'proposal_flush_time'.")
-  else if data.proposal_flush_time <= (data.period.length * 2n) then
-    failwith("'proposal_flush_time' needs to be more than twice the 'period' length.")
+let validate_proposal_flush_expired_level (data : initial_config_data) : unit =
+  if data.proposal_expired_level.blocks <= data.proposal_flush_level.blocks then
+    failwith("proposal_expired_level needs to be bigger than proposal_flush_level")
+  else if data.proposal_flush_level.blocks <= (data.period.blocks * 2n) then
+    failwith("proposal_flush_level needs to be more than twice the 'period' length.")
   else unit
 
 let validate_quorum_threshold_bound (data : initial_config_data) : unit =
@@ -33,7 +33,7 @@ let freeze_history_constructor (acc, param : (freeze_history * nat) * (address *
   )
 
 let default_config (data : initial_config_data) : config =
-  let _ : unit = validate_proposal_flush_expired_time(data) in
+  let _ : unit = validate_proposal_flush_expired_level(data) in
   let _ : unit = validate_quorum_threshold_bound(data) in {
     // TODO [#271] We have to find a safe value for max_voters
     // and check if the value contained in the `data` is
@@ -51,8 +51,8 @@ let default_config (data : initial_config_data) : config =
     max_quorum_change = to_signed(data.max_quorum_change);
     quorum_change = to_signed(data.quorum_change);
     governance_total_supply = data.governance_total_supply;
-    proposal_flush_time = data.proposal_flush_time;
-    proposal_expired_time = data.proposal_expired_time;
+    proposal_flush_level = data.proposal_flush_level;
+    proposal_expired_level = data.proposal_expired_level;
     custom_entrypoints = (Big_map.empty : custom_entrypoints);
   }
 
@@ -74,11 +74,11 @@ let default_storage (data, config_data : initial_storage_data * initial_config_d
     metadata = data.metadata_map;
     extra = (Big_map.empty : (string, bytes) big_map);
     proposals = (Big_map.empty : (proposal_key, proposal) big_map);
-    proposal_key_list_sort_by_date = (Set.empty : (timestamp * proposal_key) set);
+    proposal_key_list_sort_by_level = (Set.empty : (blocks * proposal_key) set);
     permits_counter = 0n;
     freeze_history = freeze_history;
     frozen_token_id = frozen_token_id;
-    start_time = data.now_val;
+    start_level = data.current_level;
     quorum_threshold_at_cycle =
       { last_updated_cycle = 1n
       // We use 1 here so that the initial quorum will be used for proposals raised in stage 1

--- a/src/defaults.mligo
+++ b/src/defaults.mligo
@@ -7,7 +7,7 @@
 let validate_proposal_flush_expired_level (data : initial_config_data) : unit =
   if data.proposal_expired_level.blocks <= data.proposal_flush_level.blocks then
     failwith("proposal_expired_level needs to be bigger than proposal_flush_level")
-  else if data.proposal_flush_level.blocks <= (data.period.blocks * 2n) then
+  else if data.proposal_flush_level.blocks < (data.period.blocks * 2n) then
     failwith("proposal_flush_level needs to be more than twice the 'period' length.")
   else unit
 
@@ -78,7 +78,7 @@ let default_storage (data, config_data : initial_storage_data * initial_config_d
     permits_counter = 0n;
     freeze_history = freeze_history;
     frozen_token_id = frozen_token_id;
-    start_level = data.current_level;
+    start_level = data.start_level;
     quorum_threshold_at_cycle =
       { last_updated_cycle = 1n
       // We use 1 here so that the initial quorum will be used for proposals raised in stage 1

--- a/src/proposal.mligo
+++ b/src/proposal.mligo
@@ -29,16 +29,16 @@ let check_if_proposal_exist (proposal_key, store : proposal_key * storage): prop
     else (failwith("PROPOSAL_NOT_EXIST") : proposal)
 
 // Gets the current stage counting how many `period` s have passed since
-// the 'started_on` timestamp. The stages are zero-indexed.
-let get_current_stage_num(start_time, period : timestamp * period) : nat =
-  match is_nat((Tezos.now - start_time) : int) with
-  | Some (elapsed_time) -> elapsed_time/period.length
+// the 'start_level`. The stages are zero-index.
+let get_current_stage_num(start, vp : blocks * period) : nat =
+  match is_nat((Tezos.level - start.blocks) : int) with
+  | Some (elapsed_levels) -> elapsed_levels/vp.blocks
   | None -> ([%Michelson ({| { FAILWITH } |} : string * unit -> nat)]
       ("BAD_STATE", ()))
 
 [@inline]
 let ensure_proposal_voting_stage (proposal, period, store : proposal * period * storage): storage =
-  let current_stage = get_current_stage_num(store.start_time, period) in
+  let current_stage = get_current_stage_num(store.start_level, period) in
   if current_stage = proposal.voting_stage_num
   then store
   else (failwith("VOTING_STAGE_OVER") : storage)
@@ -94,7 +94,7 @@ let update_delegates (params, store : update_delegate_params * storage): return 
 
 [@inline]
 let check_proposal_limit_reached (config, store : config * storage): storage =
-  if config.max_proposals <= List.length store.proposal_key_list_sort_by_date
+  if config.max_proposals <= List.length store.proposal_key_list_sort_by_level
   then (failwith("MAX_PROPOSALS_REACHED") : storage)
   else store
 
@@ -107,7 +107,7 @@ let lock_governance_tokens (tokens, addr, frozen_total_supply, governance_token 
   ([operation], frozen_total_supply + tokens)
 
 let stake_tk(token_amount, addr, period, store : nat * address * period * storage): storage =
-  let current_stage = get_current_stage_num(store.start_time, period) in
+  let current_stage = get_current_stage_num(store.start_level, period) in
   let new_cycle_staked = store.quorum_threshold_at_cycle.staked + token_amount in
   let new_freeze_history = match Big_map.find_opt addr store.freeze_history with
     | Some fh ->
@@ -136,13 +136,12 @@ let unlock_governance_tokens (tokens, addr, frozen_total_supply, governance_toke
 
 let add_proposal (propose_params, period, store : propose_params * period * storage): storage =
   let proposal_key = ensure_proposal_is_unique (propose_params, store) in
-  let current_stage = get_current_stage_num(store.start_time, period) in
+  let current_stage = get_current_stage_num(store.start_level, period) in
   let store = ensure_proposing_stage(current_stage, store) in
-  let timestamp = Tezos.now in
   let proposal : proposal =
     { upvotes = 0n
     ; downvotes = 0n
-    ; start_date = timestamp
+    ; start_level = {blocks = Tezos.level}
     ; voting_stage_num = current_stage + 1n
     ; metadata = propose_params.proposal_metadata
     ; proposer = propose_params.from
@@ -153,8 +152,8 @@ let add_proposal (propose_params, period, store : propose_params * period * stor
   { store with
     proposals =
       Map.add proposal_key proposal store.proposals
-  ; proposal_key_list_sort_by_date =
-      Set.add (timestamp, proposal_key) store.proposal_key_list_sort_by_date
+  ; proposal_key_list_sort_by_level =
+      Set.add ({blocks = Tezos.level}, proposal_key) store.proposal_key_list_sort_by_level
   }
 
 // -----------------------------------------------------------------
@@ -199,7 +198,7 @@ let vote(votes, config, store : vote_param_permited list * config * storage): re
 
 
 let unstake_tk(token_amount, burn_amount, addr, period, store : nat * nat * address * period * storage): storage =
-  let current_stage = get_current_stage_num(store.start_time, period) in
+  let current_stage = get_current_stage_num(store.start_level, period) in
   match Big_map.find_opt addr store.freeze_history with
     | Some(fh) ->
         let fh = update_fh(current_stage, fh) in
@@ -243,8 +242,8 @@ let unfreeze_proposer_and_voter_token
   Map.fold do_unfreeze proposal.voters store
 
 [@inline]
-let is_time_reached (proposal, sec : proposal * seconds): bool =
-  Tezos.now > proposal.start_date + int(sec)
+let is_level_reached (proposal, target : proposal * blocks): bool =
+  Tezos.level > proposal.start_level.blocks + target.blocks
 
 
 [@inline]
@@ -257,12 +256,12 @@ let do_total_vote_meet_quorum_threshold (proposal, store: proposal * storage): b
   let reached_quorum = (votes_placed * quorum_denominator) / total_supply in
   (reached_quorum >= proposal.quorum_threshold.numerator)
 
-// Delete a proposal from 'proposal_key_list_sort_by_date'
+// Delete a proposal from 'proposal_key_list_sort_by_level'
 [@inline]
 let delete_proposal
-    (start_date, proposal_key, store : timestamp * proposal_key * storage): storage =
-  { store with proposal_key_list_sort_by_date =
-    Set.remove (start_date, proposal_key) store.proposal_key_list_sort_by_date
+    (level, proposal_key, store : blocks * proposal_key * storage): storage =
+  { store with proposal_key_list_sort_by_level =
+    Set.remove (level, proposal_key) store.proposal_key_list_sort_by_level
   }
 
 let propose (param, config, store : propose_params * config * storage): return =
@@ -270,7 +269,7 @@ let propose (param, config, store : propose_params * config * storage): return =
   let _ : unit = config.proposal_check (param, store.extra) in
   let store = check_proposal_limit_reached (config, store) in
   let amount_to_freeze = param.frozen_token + config.fixed_proposal_fee_in_token in
-  let current_stage = get_current_stage_num(store.start_time, config.period) in
+  let current_stage = get_current_stage_num(store.start_level, config.period) in
   let store = update_quorum(current_stage, store, config) in
   let store = stake_tk(amount_to_freeze, valid_from, config.period, store) in
   let store = add_proposal (param, config.period, store) in
@@ -278,15 +277,15 @@ let propose (param, config, store : propose_params * config * storage): return =
 
 [@inline]
 let handle_proposal_is_over
-    (config, start_date, proposal_key, store, ops, counter
-      : config * timestamp * proposal_key * storage * operation list * counter
+    (config, start_level, proposal_key, store, ops, counter
+      : config * blocks * proposal_key * storage * operation list * counter
     )
     : (operation list * storage * counter) =
   let proposal = fetch_proposal (proposal_key, store) in
 
-  if is_time_reached (proposal, config.proposal_expired_time)
+  if is_level_reached (proposal, config.proposal_expired_level)
   then (failwith("EXPIRED_PROPOSAL") : (operation list * storage * counter))
-  else if is_time_reached (proposal, config.proposal_flush_time)
+  else if is_level_reached (proposal, config.proposal_flush_level)
        && counter.current < counter.total // not finished
   then
     let counter = { counter with current = counter.current + 1n } in
@@ -310,7 +309,7 @@ let handle_proposal_is_over
     in
     let cons = fun (l, e : operation list * operation) -> e :: l in
     let ops = List.fold cons ops new_ops in
-    let store = delete_proposal (start_date, proposal_key, store) in
+    let store = delete_proposal (start_level, proposal_key, store) in
     (ops, store, counter)
   else (ops, store, counter)
 
@@ -321,13 +320,13 @@ let flush(n, config, store : nat * config * storage): return =
   else
     let counter : counter = { current = 0n; total = n } in
     let flush_one
-        (acc, e: (operation list * storage * counter) * (timestamp * proposal_key)) =
+        (acc, e: (operation list * storage * counter) * (blocks * proposal_key)) =
           let (ops, store, counter) = acc in
-          let (start_date, proposal_key) = e in
-          handle_proposal_is_over (config, start_date, proposal_key, store, ops, counter)
+          let (start_level, proposal_key) = e in
+          handle_proposal_is_over (config, start_level, proposal_key, store, ops, counter)
         in
     let (ops, store, counter) =
-      Set.fold flush_one store.proposal_key_list_sort_by_date (nil_op, store, counter)
+      Set.fold flush_one store.proposal_key_list_sort_by_level (nil_op, store, counter)
     in
     // prevent empty flushes to avoid gas costs when unnecessary.
     if counter.current = 0n
@@ -337,7 +336,7 @@ let flush(n, config, store : nat * config * storage): return =
 // Removes an accepted and finished proposal by key.
 let drop_proposal (proposal_key, config, store : proposal_key * config * storage): return =
   let proposal = check_if_proposal_exist (proposal_key, store) in
-  let proposal_is_expired = is_time_reached (proposal, config.proposal_expired_time) in
+  let proposal_is_expired = is_level_reached (proposal, config.proposal_expired_level) in
 
   if   (sender = proposal.proposer)
     || (sender = store.guardian && sender <> source) // Guardian cannot be equal to SOURCE
@@ -351,7 +350,7 @@ let drop_proposal (proposal_key, config, store : proposal_key * config * storage
           , config.fixed_proposal_fee_in_token
           , store
           ) in
-    let store = delete_proposal (proposal.start_date, proposal_key, store) in
+    let store = delete_proposal (proposal.start_level, proposal_key, store) in
     (nil_op, store)
   else
     (failwith("DROP_PROPOSAL_CONDITION_NOT_MET") : return)
@@ -361,7 +360,7 @@ let freeze (amt, config, store : freeze_param * config * storage) : return =
   let (operations, frozen_total_supply) = lock_governance_tokens (amt, addr, store.frozen_total_supply, store.governance_token) in
 
   // Add the `amt` to the current stage frozen token count of the freeze-history.
-  let current_stage = get_current_stage_num(store.start_time, config.period) in
+  let current_stage = get_current_stage_num(store.start_level, config.period) in
   let new_freeze_history_for_address = match Big_map.find_opt addr store.freeze_history with
     | Some fh ->
         let fh = update_fh(current_stage, fh) in
@@ -375,7 +374,7 @@ let freeze (amt, config, store : freeze_param * config * storage) : return =
 
 let unfreeze (amt, config, store : unfreeze_param * config * storage) : return =
   let addr = Tezos.sender in
-  let current_stage = get_current_stage_num(store.start_time, config.period) in
+  let current_stage = get_current_stage_num(store.start_level, config.period) in
 
   let new_freeze_history =
     match Big_map.find_opt addr store.freeze_history with

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -278,7 +278,7 @@ type initial_storage_data =
   { admin : address
   ; guardian : address
   ; governance_token : governance_token
-  ; current_level : blocks
+  ; start_level : blocks
   ; metadata_map : metadata_map
   ; freeze_history : freeze_history_list
   }
@@ -329,12 +329,10 @@ type config =
   // of new quorum threshold value at each stage.
 
   ; proposal_flush_level : blocks
-  // ^ Determine the minimum number of levels after the proposal is proposed
-  // to allow it to be `flushed`.
+  // ^ The proposal age at (and above) which the proposal is considered flushable.
   // Has to be bigger than `period * 2`
   ; proposal_expired_level : blocks
-  // ^ Determine the minimum number of levels after the proposal is proposed
-  // to be considered as expired.
+  // ^ The proposal age at (and above) which the proposal is considered expired.
   // Has to be bigger than `proposal_flush_time`
 
   ; custom_entrypoints : custom_entrypoints

--- a/src/types.mligo
+++ b/src/types.mligo
@@ -59,11 +59,9 @@ type voter_map_key = (address * vote_type)
 
 type voter_map = (voter_map_key, nat) map
 
-// Amount of `seconds` used for lengths of time
-type seconds = nat
-
-// Length of a 'stage'
-type period = { length : seconds }
+// Amount of blocks.
+type blocks = { blocks : nat }
+type period = blocks
 
 // For efficiency, we only keep a `nat` for the numerator, whereas the
 // denominator is not stored and has a fixed value of `1000000`.
@@ -88,8 +86,8 @@ type proposal =
   // ^ total amount of votes in favor
   ; downvotes : nat
   // ^ total amount of votes against
-  ; start_date : timestamp
-  // ^ time of submission, used to order proposals
+  ; start_level : blocks
+  // ^ block level of submission, used to order proposals
   ; voting_stage_num : nat
   // ^ stage number in which it is possible to vote on this proposal
   ; metadata : proposal_metadata
@@ -155,11 +153,11 @@ type storage =
   ; metadata : metadata_map
   ; extra : contract_extra
   ; proposals : (proposal_key, proposal) big_map
-  ; proposal_key_list_sort_by_date : (timestamp * proposal_key) set
+  ; proposal_key_list_sort_by_level : (blocks * proposal_key) set
   ; permits_counter : nonce
   ; freeze_history : freeze_history
   ; frozen_token_id : token_id
-  ; start_time : timestamp
+  ; start_level : blocks
   ; quorum_threshold_at_cycle : quorum_threshold_at_cycle
   ; frozen_total_supply : nat
   ; delegates : delegates
@@ -268,8 +266,8 @@ type initial_config_data =
   ; quorum_threshold : quorum_threshold
   ; max_voters : nat
   ; period : period
-  ; proposal_flush_time: seconds
-  ; proposal_expired_time: seconds
+  ; proposal_flush_level: blocks
+  ; proposal_expired_level: blocks
   ; fixed_proposal_fee_in_token: nat
   ; max_quorum_change : unsigned_quorum_fraction
   ; quorum_change : unsigned_quorum_fraction
@@ -280,7 +278,7 @@ type initial_storage_data =
   { admin : address
   ; guardian : address
   ; governance_token : governance_token
-  ; now_val : timestamp
+  ; current_level : blocks
   ; metadata_map : metadata_map
   ; freeze_history : freeze_history_list
   }
@@ -330,12 +328,12 @@ type config =
   // ^ The total supply of governance tokens used in the computation of
   // of new quorum threshold value at each stage.
 
-  ; proposal_flush_time : seconds
-  // ^ Determine the minimum amount of seconds after the proposal is proposed
+  ; proposal_flush_level : blocks
+  // ^ Determine the minimum number of levels after the proposal is proposed
   // to allow it to be `flushed`.
   // Has to be bigger than `period * 2`
-  ; proposal_expired_time : seconds
-  // ^ Determine the minimum amount of seconds after the proposal is proposed
+  ; proposal_expired_level : blocks
+  // ^ Determine the minimum number of levels after the proposal is proposed
   // to be considered as expired.
   // Has to be bigger than `proposal_flush_time`
 


### PR DESCRIPTION
Problem: We had temporarly reverted to using Timestamps for denoting
time intervals. Now we can restore the old behavior.

Solution: Revert commit 9e0c236b9759d4312904dd3af089cd709c20a8d0,
reversing changes made to a21886ed9422ba2e95a95ee23a9aeca95830a58f.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #284 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
