### PR TITLE
[#290] Check proposal really exist in existence check

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -319,11 +319,11 @@ Here is a summary of all the strings used as error messages.
 | `NOT_TOKEN_OWNER`                    | Trying to configure operators for a different wallet which sender does not own                                           |
 | `FAIL_PROPOSAL_CHECK`                | Throws paired with an additional `string` message when trying to submit a proposal that does not pass `proposal_check`.  |
 | `FROZEN_TOKEN_NOT_TRANSFERABLE`      | Transfer entrypoint is called for frozen token                                                                           |
-| `PROPOSAL_NOT_EXIST`                 | Throws when trying to vote on a proposal that does not exist                                                             |
+| `PROPOSAL_NOT_EXIST`                 | Throws when trying to vote on a proposal that does not exist or is no longer ongoing.                                    |
 | `QUORUM_NOT_MET`                     | A proposal is flushed, but there are not enough votes                                                                    |
 | `VOTING_STAGE_OVER`                  | Throws when trying to vote on a proposal that is already ended                                                           |
 | `MAX_PROPOSALS_REACHED`              | Throws when trying to propose a proposal when proposals max amount is already reached                                    |
-| `MAX_VOTERS_REACHED`                 | Throws when trying to vote on a proposal when the max voter count of that proposal is already reached                   |
+| `MAX_VOTERS_REACHED`                 | Throws when trying to vote on a proposal when the max voter count of that proposal is already reached                    |
 | `FORBIDDEN_XTZ`                      | Throws when some XTZ was received as part of the contract call                                                           |
 | `PROPOSER_NOT_EXIST_IN_LEDGER`       | Expect a proposer address to exist in Ledger but it is not found                                                         |
 | `PROPOSAL_NOT_UNIQUE`                | Trying to propose a proposal that is already existed in the Storage.                                                     |

--- a/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
+++ b/haskell/test/Test/Ligo/BaseDAO/Proposal.hs
@@ -34,6 +34,9 @@ test_BaseDAO_Proposal =
       , nettestScenarioOnEmulatorCaps "cannot propose a non-unique proposal" $
           nonUniqueProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
+      , nettestScenarioOnEmulatorCaps "cannot propose same proposal even after dropping original one" $
+          nonUniqueProposalEvenAfterDrop (originateLigoDaoWithConfigDesc dynRecUnsafe)
+
       , nettestScenarioOnEmulatorCaps "cannot propose in a non-proposal period" $
           nonProposalPeriodProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
@@ -43,6 +46,9 @@ test_BaseDAO_Proposal =
       [ nettestScenarioOnEmulatorCaps "can vote on a valid proposal" $
           voteValidProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
             checkBalanceEmulator
+
+      , nettestScenarioOnEmulatorCaps "cannot vote on a deleted proposal" $
+          voteDeletedProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)
 
       , nettestScenarioOnEmulatorCaps "cannot vote non-existing proposal" $
           voteNonExistingProposal (originateLigoDaoWithConfigDesc dynRecUnsafe)


### PR DESCRIPTION
## Description

Problem: It seems that we don't actually check the
'proposal_key_list_sort_by_date' structure for the proposal existence
check. And we should since we only remove proposals from this set during
proposal flush/delete operations.

Solution: In additon to the check in proposals bigmap, check if
'proposal_key_list_sort_by_date' also contains the proposal before
returning success. Add some tests that it works as expected.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #290 

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Commit-and-PR-policy-4cf98e1a910a415d86b5f2491d9af1af).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
